### PR TITLE
Lightflow RC6: startup hydration and interaction latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Lightflow uses a suite release version for public downloads. Individual plugins 
 
 ## [Unreleased]
 
+### RC 3 viewport and environment workflow
+
+- **Studio Render 1.5.1:** moved Scene Composer into a resizable panel attached inside **Lightflow Render** instead of occupying a generic Blockbench sidebar slot.
+- Replaced the realtime full-resolution visible-canvas Bloom capture with a reduced offscreen WebGL mask, reusable processing canvases, DPI-aware quality profiles, and a 30 FPS safety cap.
+- Realtime Bloom now preserves the Shader Architect AO-composited base frame, excludes Blockbench helpers/gizmos from its mask, and only runs in Lightflow Render mode.
+- **Lightflow Environment 1.1.0:** replaced the toolbar-only panel with an attached, resizable Lightflow Render panel and a complete advanced composer.
+- Added custom day, sunrise, night, lower-sky, sun, moon, and cloud colors plus gradient, stars, cloud appearance, motion, and contrast controls.
+- Added generated Vanilla-style cloud textures and project-texture selection for clouds, sun, and moon without bundling game assets.
+- Stopped the animated day cycle from disposing and recreating the directional shadow map on every update.
+
 ### RC 2 shader hotfixes
 
 - **Lightflow Environment 1.0.1:** fixed sky vertex/fragment assembly so array lines are joined with real newline characters instead of emitting literal `\\n` tokens into GLSL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Lightflow uses a suite release version for public downloads. Individual plugins 
 
 ## [Unreleased]
 
+### RC 4 native GPU viewport composition
+
+- **Studio Render 1.6.0:** replaced the realtime CPU readback/Canvas2D overlay with a GPU-resident emissive mask, three-level downsample Bloom pyramid, and direct framebuffer composition.
+- Fixed the 1.25× Bloom scale/offset on Windows display scaling by never passing physical render-target dimensions through Three r129's DPR-multiplying `setViewport()` path.
+- Added Adaptive quality, automatic internal-resolution hysteresis, synchronized uncapped viewport updates, and optional FPS caps from 1–144.
+- Moved Scene Composer scheduling to a coalesced microtask after AO/Atmosphere wrappers but before browser presentation, removing the extra frame of latency.
+- **Lightflow Atmosphere 1.0.1:** preserves target-local viewport/scissor state when Atmosphere is composed into Bloom or other offscreen targets.
+- **Light Manager 1.6.4:** Volume Domain selection proxies are explicitly excluded from shadow casting and receiving.
+- Volume Domain proxy meshes now carry their own no-shadow marker and continuously enforce `castShadow = false`, preventing the invisible editing cube from occluding its contents or projecting a solid box shadow.
+
 ### RC 3 viewport and environment workflow
 
 - **Studio Render 1.5.1:** moved Scene Composer into a resizable panel attached inside **Lightflow Render** instead of occupying a generic Blockbench sidebar slot.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Lightflow uses a suite release version for public downloads. Individual plugins 
 
 ## [Unreleased]
 
+### RC 5 interactive performance and transparency
+
+- **Studio Render 1.6.1:** preserves the destination alpha during additive viewport Bloom, so Blockbench's transparent checkerboard remains visible instead of becoming an opaque black background.
+- **Shader Architect 2.8.0:** removes the full light/shadow preparation accidentally triggered by uniform-only updates and no longer treats ordinary Cube transforms as lighting changes.
+- Geometry, face, and UV events now rebuild only the affected render element; light arrays, vectors, shadow-index maps, and active-preview rendering are reused or coalesced instead of recreated for every slider step.
+- **Light Manager 1.6.5:** light transforms explicitly skip scene shadow-mesh traversal and reuse update scratch objects rather than allocating world-space vectors for every light and frame.
+- **Lightflow Atmosphere 1.1.0:** separates depth and volume signatures. Light/color/intensity changes reuse the unchanged scene depth and rerun only the volumetric lighting pass; optical volume edits also retain depth, while actual geometry transforms invalidate it without rebuilding the scene partition.
+- Atmosphere selection updates no longer invalidate volumetric rendering, preview requests are frame-coalesced, and light-element lookup no longer performs a repeated linear search inside the raymarch setup.
+- **Lightflow Environment 1.2.0:** coalesces environment uniform updates and renders only the active preview, avoiding a second full render of every Blockbench preview during time animation and live panel edits.
+- These changes target high-refresh interactive editing, but the achieved frame rate still depends on GPU, viewport size, shadow resolution, volume quality, scene complexity, and Blockbench itself.
+
 ### RC 4 native GPU viewport composition
 
 - **Studio Render 1.6.0:** replaced the realtime CPU readback/Canvas2D overlay with a GPU-resident emissive mask, three-level downsample Bloom pyramid, and direct framebuffer composition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Lightflow uses a suite release version for public downloads. Individual plugins 
 
 ## [Unreleased]
 
+### Lightflow Environment 1.0.0
+
+- Added a separately loadable procedural environment module with Minecraft time (`0`–`23999`), controllable day length, realtime playback, sun azimuth, moon phases, stars, and block-shaped clouds.
+- Added independent **Vanilla** and **Vibrant Visuals** presets for sky gradients, sunset/night transitions, celestial bodies, cloud response, and ambient palettes.
+- Added directional sun and moon lighting with artist-controlled shadow area, near/far range, resolution, bias, normal bias, and pixelated-shadow settings.
+- Exposed a stable environment API and project-persisted lighting state for Shader Architect, Studio Render, and future Lightflow modules.
+
+### Shader Architect 2.7.0
+
+- Added environment ambient uniforms so sky, horizon, and ground light can tint compatible Lightflow materials in realtime.
+- Extended depth-aware SSR with a world-space procedural environment fallback—including sky gradient, sun/moon, and clouds—when a reflection ray misses visible screen geometry.
+- Added **Vibrant Visuals PBR**, a complete PBR starting preset with environment response, SSR, and pixel-shadow defaults.
+- Added a switchable pixelated-shadow path with adjustable quantization steps and pixel scale to Pixelated Lightflow and Vibrant Visuals PBR.
+- Added the Environment sun/moon as a synthetic Lightflow light source, including dynamic direction, color, strength, and shadow settings.
+
+### Studio Render 1.5.0
+
+- Added **Scene Composer** with realtime viewport Bloom, Bloom preview FPS, exposure, contrast, saturation, temperature, tint, vignette, and integrated environment controls.
+- Reused the final renderer's emissive/atmosphere Bloom masks, geometry occlusion, threshold, multiscale blur, radius, and strength in the realtime viewport preview.
+- Added one shared color-grade implementation for realtime preview and final tiled output.
+- Added a persistent Scene Composer panel plus quick viewport-Bloom and strength controls.
+
+### Light Manager 1.6.2
+
+- Fixed the Three.js r129 compatibility path so Light Manager no longer injects a second `punctualLightIntensityToIrradianceFactor` body when Blockbench already provides it.
+
+### Release-candidate validation
+
+- Extended syntax/version coverage to all five modules and added regression guards for Scene Composer parity, environment integration, Vibrant Visuals PBR, SSR environment fallback, and pixelated shadows.
+
 ### Shader Architect 2.6.0
 
 - Added lossless Cube material-slot collapsing: six equivalent face slots now render as one material batch while genuinely different textures, render modes, transparency states, and face overrides remain independent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Lightflow uses a suite release version for public downloads. Individual plugins 
 
 ## [Unreleased]
 
+### RC 2 shader hotfixes
+
+- **Lightflow Environment 1.0.1:** fixed sky vertex/fragment assembly so array lines are joined with real newline characters instead of emitting literal `\\n` tokens into GLSL.
+- **Shader Architect 2.7.1:** added punctual-light compatibility overloads locally to custom shaders that include `<lights_pars_begin>` without Three's `<bsdfs>` chunk.
+- Added the missing custom shadow-index uniforms to Pixelated Lightflow.
+- Suspended SSR capture samplers while their render target is bound, preventing framebuffer/texture feedback loops.
+- **Light Manager 1.6.3:** removed global mutation of `THREE.ShaderChunk.common`; stock Lambert/Phong shaders now retain Three r129's single native punctual helper.
+
 ### Lightflow Environment 1.0.0
 
 - Added a separately loadable procedural environment module with Minecraft time (`0`–`23999`), controllable day length, realtime playback, sun azimuth, moon phases, stars, and block-shaped clouds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Lightflow uses a suite release version for public downloads. Individual plugins 
 
 ## [Unreleased]
 
+### RC 6 startup, project hydration, and interaction latency
+
+- **Light Manager 1.7.0:** registers the plugin and its custom `light` outliner type synchronously. Material-icon generation now runs later during idle time and can no longer delay `.bbmodel` parsing.
+- Added a shared, generation-guarded Lightflow project lifecycle. If the suite becomes available after a scene is already open, it reads the current project model and restores saved lights, Volume Domains, Environment settings, material assignments, face assignments, and material instances without requiring the project to be closed and reopened.
+- Project close and tab switching now cancel stale queued scene, light-uniform, Environment, Atmosphere, and Scene Composer work. A full light-registry pass also removes lights belonging to the previous project, including when the next project contains no lights.
+- Light edits now update only the affected light. Type, color, intensity, range, shadow bias, animation, and viewport-drag paths no longer rescan every Lightflow light, every preview, and every scene mesh on each input step.
+- Viewport shadow maps now use explicit invalidation. Ordinary Cube and Group transforms update the shadow image without rewalking all caster/receiver meshes, and finishing an edit performs a lightweight light cleanup instead of a full scene traversal.
+- **Lightflow Environment 1.3.0:** keeps the directional-light topology stable while Environment or Sun is toggled, updates shadow projection and targets only when their signature changes, and limits animated sun-shadow refreshes while keeping sky and light uniforms fluid.
+- **Shader Architect 2.9.0:** isolates queued material and uniform work by project revision and hydrates saved root, element, and face material state when loaded late.
+- **Lightflow Atmosphere 1.2.0:** restores late-loaded Volume Domains and prevents a queued volume render from crossing a project transition.
+- **Studio Render 1.7.0:** coalesces Scene Composer refreshes, composites only the active viewport, discards stale work after close/switch, and removes the redundant second preview/shadow recovery render after Studio Render.
+- Added regression coverage for synchronous registration, late hydration, project isolation, partial light updates, manual shadow invalidation, stable Environment topology, and active-preview-only Scene Composer refreshes.
+
 ### RC 5 interactive performance and transparency
 
 - **Studio Render 1.6.1:** preserves the destination alpha during additive viewport Bloom, so Blockbench's transparent checkerboard remains visible instead of becoming an opaque black background.

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ The plugins work independently where possible, but they are designed to be used 
 
 | Plugin | Current version | Purpose | Dependency |
 | --- | ---: | --- | --- |
-| **Light Manager** | `1.6.2` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
-| **Lightflow Environment** | `1.0.0` | Adds procedural Vanilla and Vibrant Visuals sky presets, Minecraft time, sun/moon lighting, ambient sky influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
-| **Shader Architect** | `2.7.0` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
+| **Light Manager** | `1.6.3` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
+| **Lightflow Environment** | `1.0.1` | Adds procedural Vanilla and Vibrant Visuals sky presets, Minecraft time, sun/moon lighting, ambient sky influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
+| **Shader Architect** | `2.7.1` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
 | **Lightflow Atmosphere** | `1.0.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
 | **Studio Render** | `1.5.0` | Adds Scene Composer, final-parity realtime Bloom and color grading, plus tiled supersampling, geometry-occluded emissive Bloom, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The plugins work independently where possible, but they are designed to be used 
 
 | Plugin | Current version | Purpose | Dependency |
 | --- | ---: | --- | --- |
-| **Light Manager** | `1.6.5` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
-| **Lightflow Environment** | `1.2.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
-| **Shader Architect** | `2.8.0` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
-| **Lightflow Atmosphere** | `1.1.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
-| **Studio Render** | `1.6.1` | Adds an attached GPU Scene Composer, AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
+| **Light Manager** | `1.7.0` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
+| **Lightflow Environment** | `1.3.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
+| **Shader Architect** | `2.9.0` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
+| **Lightflow Atmosphere** | `1.2.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
+| **Studio Render** | `1.7.0` | Adds an attached GPU Scene Composer, AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
 
 ### Why Lightflow exists
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The plugins work independently where possible, but they are designed to be used 
 
 | Plugin | Current version | Purpose | Dependency |
 | --- | ---: | --- | --- |
-| **Light Manager** | `1.6.4` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
-| **Lightflow Environment** | `1.1.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
-| **Shader Architect** | `2.7.1` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
-| **Lightflow Atmosphere** | `1.0.1` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
-| **Studio Render** | `1.6.0` | Adds an attached GPU Scene Composer, AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
+| **Light Manager** | `1.6.5` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
+| **Lightflow Environment** | `1.2.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
+| **Shader Architect** | `2.8.0` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
+| **Lightflow Atmosphere** | `1.1.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
+| **Studio Render** | `1.6.1` | Adds an attached GPU Scene Composer, AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
 
 ### Why Lightflow exists
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The plugins work independently where possible, but they are designed to be used 
 
 | Plugin | Current version | Purpose | Dependency |
 | --- | ---: | --- | --- |
-| **Light Manager** | `1.6.3` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
+| **Light Manager** | `1.6.4` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
 | **Lightflow Environment** | `1.1.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
 | **Shader Architect** | `2.7.1` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
-| **Lightflow Atmosphere** | `1.0.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
-| **Studio Render** | `1.5.1` | Adds an attached Scene Composer, optimized AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
+| **Lightflow Atmosphere** | `1.0.1` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
+| **Studio Render** | `1.6.0` | Adds an attached GPU Scene Composer, AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
 
 ### Why Lightflow exists
 
@@ -168,7 +168,7 @@ With **Lightflow Atmosphere** enabled:
 With **Studio Render** enabled:
 
 1. Open **Scene Composer** to enable realtime viewport Bloom and tune Bloom, exposure, contrast, saturation, temperature, tint, and vignette.
-2. Open **Studio Render** or use **Quick Studio Render**. The final image reuses the same Bloom and color-grade pipeline shown by Scene Composer.
+2. Open **Studio Render** or use **Quick Studio Render**. The final image reuses the same Bloom parameters and emissive/occlusion semantics shown by Scene Composer.
 3. Choose **4K UHD** for a first high-quality export.
 4. Choose **Transparent** or **Solid Color** background.
 5. Use **Studio SSAA – 4x** for clean promotional output. Use lower samples while iterating.
@@ -297,11 +297,12 @@ Studio Render is the export layer. It is intended for portfolio images, social-m
 - GPU diagnostics showing the detected renderer and relevant WebGL limits.
 - Temporary Studio Render sessions that coordinate with Light Manager so final shadow settings do not permanently disturb the viewport.
 - Optional final-image Bloom with a simple strength control and advanced threshold/radius controls.
-- Realtime viewport Bloom that uses the same emissive/atmosphere semantics, occlusion, blur scales, threshold, radius, and strength as final output.
-- Low-resolution offscreen WebGL masks and reusable processing canvases for responsive editing without overwriting Shader Architect AO.
-- Helper/gizmo exclusion from the realtime Bloom source and three viewport quality profiles.
+- Realtime viewport Bloom that uses the same emissive/atmosphere semantics, depth occlusion, threshold, radius, and strength as final output.
+- A fully GPU-resident three-level downsample pyramid: the viewport path has no synchronous `readPixels`, `getImageData`, CPU pixel loop, Canvas2D blur, or DOM overlay.
+- Physical-pixel viewport tracking through `getCurrentViewport()`, with render-target viewport state kept separate from logical CSS/DPR state.
+- Helper/gizmo exclusion plus Adaptive, Performance, Balanced, and High viewport quality profiles.
 - An attached **Scene Composer** panel in Lightflow Render, with the full dialog retained for grading and advanced controls.
-- One shared Canvas2D color-grade path for the viewport preview and final render.
+- GPU framebuffer color grading in the viewport and the export-safe Canvas2D grading path for final tiled renders.
 - Emissive-only Bloom masking: emissive render-mode alpha, MER maps, dedicated emissive maps, and additive materials glow without blooming ordinary bright surfaces.
 - Atmosphere-aware Bloom masking, including per-domain Bloom contribution for bright shafts and cloud highlights.
 - Selection highlight suppression during final capture so editing state cannot leak into exported pixels.
@@ -493,9 +494,10 @@ Studio Render hides gizmos by default. Verify that **Show Gizmos** is disabled i
 ### Bloom differs between viewport and final render
 
 - Open **Scene Composer** and ensure **Realtime Viewport Bloom** is enabled.
-- Use the same Bloom threshold, strength, and radius that Studio Render will use; both paths share the same mask and compositing implementation.
-- Realtime Bloom is throttled by **Preview FPS** and an internal quality profile. Start with **Balanced**; use **Performance** for high-DPI or integrated-GPU viewports.
+- Use the same Bloom threshold, strength, and radius that Studio Render will use; both paths share mask and occlusion semantics while using output-appropriate GPU/Canvas compositors.
+- Use **Adaptive** for automatic internal-resolution control. Set **Bloom FPS Limit** to `0` to follow every viewport render, or choose a cap up to 144 FPS.
 - Realtime composition only runs in **Lightflow Render** mode. Gizmos are excluded from the Bloom mask and Shader Architect AO is preserved in the base frame.
+- On Windows display scaling, update to Studio Render `1.6.0+`; older versions could apply renderer DPR twice to offscreen targets and appear enlarged or shifted.
 - Transparent final output can composite differently over an external background; compare against the intended destination background when judging edge glow.
 
 ### The environment does not affect a material or reflection
@@ -581,7 +583,7 @@ This roadmap is directional, not a release promise.
 - Better first-run guidance and sample `.bbmodel` scenes.
 - More robust quality presets for low-, mid-, and high-end GPUs.
 - Refinement of AO, screen-space reflection history, bevel behavior, and rim consistency between viewport and final render.
-- Optional temporal stabilization and GPU post-processing for Scene Composer on capable hardware.
+- Optional temporal stabilization for Scene Composer on capable hardware.
 - A transmittance-buffer experiment for colored raster shadows, gated by GPU capabilities.
 - Evaluation of a future native/WebGPU renderer only when Blockbench and the browser graphics stack expose a stable ray-tracing path; the current WebGL backend does not advertise hardware RTX.
 - Higher-order multiple scattering, point-light volumetric shadows, artist-authored 3D density textures, and improved temporal accumulation for Atmosphere.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 Lightflow is a modular suite for artists who want more control over how Blockbench scenes look before they are shown, shared, or exported. It is designed around a simple pipeline:
 
 1. **Light Manager** creates and animates the lighting.
-2. **Shader Architect** gives the scene a material and stylized surface response.
-3. **Lightflow Atmosphere** adds local fog, God Rays, and procedural cloud volumes.
-4. **Studio Render** captures a polished, high-resolution final image.
+2. **Lightflow Environment** creates a controllable Minecraft-inspired sky, sun, moon, and ambient light.
+3. **Shader Architect** gives the scene a material and stylized surface response.
+4. **Lightflow Atmosphere** adds local fog, God Rays, and procedural cloud volumes.
+5. **Studio Render** previews the final post-process stack and captures a polished, high-resolution image.
 
 The plugins work independently where possible, but they are designed to be used together.
 
@@ -40,10 +41,11 @@ The plugins work independently where possible, but they are designed to be used 
 
 | Plugin | Current version | Purpose | Dependency |
 | --- | ---: | --- | --- |
-| **Light Manager** | `1.6.1` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
-| **Shader Architect** | `2.6.0` | Builds and assigns advanced materials to Cubes, Meshes, and Texture Meshes with PBR controls, Blockbench render modes, editable GLSL, material instances, and automatic draw-call reduction. | **Light Manager required** |
+| **Light Manager** | `1.6.2` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
+| **Lightflow Environment** | `1.0.0` | Adds procedural Vanilla and Vibrant Visuals sky presets, Minecraft time, sun/moon lighting, ambient sky influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
+| **Shader Architect** | `2.7.0` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
 | **Lightflow Atmosphere** | `1.0.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
-| **Studio Render** | `1.4.2` | Exports clean images with tiled supersampling, HDR/emissive Bloom with geometry occlusion, adjustable framing, transparency, and 4K/8K-safe output controls. | Works alone; integrates with the other Lightflow modules |
+| **Studio Render** | `1.5.0` | Adds Scene Composer, final-parity realtime Bloom and color grading, plus tiled supersampling, geometry-occluded emissive Bloom, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
 
 ### Why Lightflow exists
 
@@ -57,7 +59,7 @@ Lightflow is **not** a replacement for an offline ray tracer or a game engine. I
 
 - Blockbench **4.9.0 or newer**.
 - A WebGL-capable GPU. A dedicated GPU is strongly recommended for high-resolution Studio Render output.
-- The four plugin files from the same Lightflow release.
+- The five plugin files from the same Lightflow release.
 - Save working scenes as **`.bbmodel`** when you need Shader Architect material assignments and material instances to persist.
 
 > **Important:** Shader Architect requires Light Manager. Install and enable Light Manager first.
@@ -68,8 +70,9 @@ Lightflow is **not** a replacement for an offline ray tracer or a game engine. I
 
 ### Manual installation from a release
 
-1. Download the four JavaScript files from the latest Lightflow release:
+1. Download the five JavaScript files from the latest Lightflow release:
    - `light_manager.js`
+   - `lightflow_environment.js`
    - `shader_architect.js`
    - `lightflow_atmosphere.js`
    - `studio_render.js`
@@ -77,9 +80,10 @@ Lightflow is **not** a replacement for an offline ray tracer or a game engine. I
 3. Open the Plugin menu and load each local plugin file, or drag the JavaScript files into Blockbench.
 4. Load them in this order:
    1. **Light Manager**
-   2. **Shader Architect**
-   3. **Lightflow Atmosphere**
-   4. **Studio Render**
+   2. **Lightflow Environment**
+   3. **Shader Architect**
+   4. **Lightflow Atmosphere**
+   5. **Studio Render**
 5. Reload Blockbench or reload plugins after an update. During development, Blockbench can reload plugins with `Ctrl/Cmd + J`.
 
 ### Recommended release layout
@@ -89,6 +93,8 @@ lightflow-blockbench/
 ├─ plugins/
 │  ├─ light_manager/
 │  │  └─ light_manager.js
+│  ├─ lightflow_environment/
+│  │  └─ lightflow_environment.js
 │  ├─ shader_architect/
 │  │  └─ shader_architect.js
 │  ├─ lightflow_atmosphere/
@@ -128,17 +134,26 @@ With **Light Manager** enabled:
 3. Use the Light Properties panel to adjust color, intensity, distance, cone angle, penumbra, and shadow settings.
 4. Start with a directional key light for broad shape definition, then add a soft point or spot fill light only where it helps.
 
-### 3. Apply a material
+### 3. Set the environment (optional)
+
+With **Lightflow Environment** enabled:
+
+1. Open **Environment Composer** and choose **Vanilla** or **Vibrant Visuals**.
+2. Set Minecraft time from `0` to `23999`, or enable realtime animation.
+3. Adjust sun azimuth, shadow coverage, bias, and preview shadow resolution around the subject.
+4. Tune sky ambient strength when materials should pick up the blue sky or warm horizon colors.
+
+### 4. Apply a material
 
 With **Shader Architect** enabled:
 
 1. Open **Material Studio**.
-2. Choose a built-in material such as **Lightflow**, **Cinematic Craft**, or **Lightflow Principled PBR**.
+2. Choose a built-in material such as **Lightflow**, **Cinematic Craft**, **Lightflow Principled PBR**, or **Vibrant Visuals PBR**.
 3. Apply it globally or to selected Cubes, Meshes, and Texture Meshes. Cubes also support per-face overrides.
 4. Use exposed controls to tune lighting, ambient contribution, shadows, bevels, outlines, rim light, AO, or reflections as appropriate. Lightflow's **Shadows** toggle switches cast shadows without changing presets.
 5. Create a **Material Instance** when different parts of the same model need different values without duplicating the shader code.
 
-### 4. Add atmosphere (optional)
+### 5. Add atmosphere (optional)
 
 With **Lightflow Atmosphere** enabled:
 
@@ -148,16 +163,17 @@ With **Lightflow Atmosphere** enabled:
 4. For visible shafts, use a directional or spot light with shadows and enable **Receive Volumetric Shadows** on the domain.
 5. Keep viewport quality on **Balanced** while composing; use **High** or **Ultra** only for Studio Render.
 
-### 5. Render the image
+### 6. Compose and render the image
 
 With **Studio Render** enabled:
 
-1. Open **Studio Render** or use **Quick Studio Render**.
-2. Choose **4K UHD** for a first high-quality export.
-3. Choose **Transparent** or **Solid Color** background.
-4. Use **Studio SSAA – 4x** for clean promotional output. Use lower samples while iterating.
-5. Select a full composition or the adjustable render frame.
-6. Click **Render** and choose whether to preview, save, copy, or load the image as a texture.
+1. Open **Scene Composer** to enable realtime viewport Bloom and tune Bloom, exposure, contrast, saturation, temperature, tint, and vignette.
+2. Open **Studio Render** or use **Quick Studio Render**. The final image reuses the same Bloom and color-grade pipeline shown by Scene Composer.
+3. Choose **4K UHD** for a first high-quality export.
+4. Choose **Transparent** or **Solid Color** background.
+5. Use **Studio SSAA – 4x** for clean promotional output. Use lower samples while iterating.
+6. Select a full composition or the adjustable render frame.
+7. Click **Render** and choose whether to preview, save, copy, or load the image as a texture.
 
 ---
 
@@ -188,6 +204,21 @@ Light Manager is the foundation of the suite. It introduces real scene lights to
 - Keep shadow bounds tight around the subject. Large directional bounds reduce useful shadow-map detail.
 - Use a low-to-medium preview shadow resolution while you work, then raise only the Studio Shadow Resolution for final output.
 
+### Lightflow Environment
+
+Lightflow Environment is a procedural preview-scene module. It drives a sky dome, Minecraft-style day cycle, square sun and moon, stars, clouds, directional lighting, and the ambient colors consumed by Lightflow materials and SSR.
+
+**Main capabilities**
+
+- Minecraft time from `0` to `23999`, realtime playback, configurable day length, and sun azimuth.
+- **Vanilla** and **Vibrant Visuals** presets with tailored day, sunset, night, cloud, sun, moon, and ambient palettes.
+- Procedural square sun, moon phases, stars, and block-shaped clouds without bundled game textures.
+- Directional sun and moon lights with editable shadow area, near/far range, resolution, bias, normal bias, and pixelated shadow controls.
+- Sky, horizon, and ground ambient colors exposed to Shader Architect for material tinting and SSR miss-ray reflections.
+- Project persistence and a compact Environment panel for time and preset changes.
+
+The presets are independent procedural approximations tuned to reproduce the visual behavior of the named Minecraft render modes; they do not copy Minecraft source code or bundled textures.
+
 ### Shader Architect
 
 Shader Architect is Lightflow's material and shader workspace. It can drive an entire scene with one material or assign individual material instances to Cubes, Meshes, and Texture Meshes. Cubes additionally support individual face assignments.
@@ -201,6 +232,7 @@ Shader Architect is Lightflow's material and shader workspace. It can drive an e
 - Import and export of custom `.samat` material files.
 - Exposed uniforms for artist-facing controls and advanced technical controls for shader authors.
 - Dynamic Light Manager uniforms for light positions, directions, colors, intensities, attenuation, cones, and shadow behavior.
+- Procedural environment ambient lighting and world-space SSR fallback reflections when a screen-space ray leaves the viewport or misses visible geometry.
 - Built-in surface systems including PBR-style controls, thickness-aware real-time subsurface scattering, stylized lighting, voxel-style AO, shadows, screen-space reflections, bevels, alpha-edge treatment, outlines, and promotional rim lighting.
 - Independently switchable PBR layers for clearcoat, anisotropy, sheen, transmission, and iridescence, plus specular and clearcoat tint controls.
 - UV-derived tangent frames for proper tangent-space normal maps and genuinely directional anisotropic GGX highlights, even when Blockbench geometry has no exported tangent attribute.
@@ -210,6 +242,7 @@ Shader Architect is Lightflow's material and shader workspace. It can drive an e
 - One-click Material Override presets: **Balanced**, **Trailer Hero**, **Soft Daylight**, **Night Drama**, and **Clean Product**.
 - Automatic zero-thickness Cube handling: coincident faces render as separate front-facing surfaces, and a fully transparent side inherits the visible side without z-fighting or incorrect shared lighting.
 - Alpha-profile-aware cutouts, per-material-slot shadow textures, and stochastic semitransparent shadow density in the raster shadow pipeline.
+- A **Vibrant Visuals PBR** preset and a **Pixelated Shadows** toggle with adjustable steps and pixel scale.
 
 **Material-instance workflow**
 
@@ -262,6 +295,9 @@ Studio Render is the export layer. It is intended for portfolio images, social-m
 - GPU diagnostics showing the detected renderer and relevant WebGL limits.
 - Temporary Studio Render sessions that coordinate with Light Manager so final shadow settings do not permanently disturb the viewport.
 - Optional final-image Bloom with a simple strength control and advanced threshold/radius controls.
+- Realtime viewport Bloom that uses the same emissive/atmosphere mask, occlusion, blur scales, threshold, radius, and strength as final output.
+- **Scene Composer** controls for viewport Bloom, preview refresh rate, exposure, contrast, saturation, temperature, tint, vignette, and environment settings.
+- One shared Canvas2D color-grade path for the viewport preview and final render.
 - Emissive-only Bloom masking: emissive render-mode alpha, MER maps, dedicated emissive maps, and additive materials glow without blooming ordinary bright surfaces.
 - Atmosphere-aware Bloom masking, including per-domain Bloom contribution for bright shafts and cloud highlights.
 - Selection highlight suppression during final capture so editing state cannot leak into exported pixels.
@@ -278,8 +314,9 @@ The current built-in preset library includes:
 | --- | --- |
 | **Classic Shader** | Familiar Blockbench-like rendering with simple controls. |
 | **Lightflow Principled PBR** | Layered physically based controls for metal/roughness, SSS, clearcoat, sheen, transmission, iridescence, and reflections. |
+| **Vibrant Visuals PBR** | A Vibrant Visuals-oriented PBR starting point with environment response, SSR, restrained roughness, and pixel-shadow defaults. |
 | **Lightflow** | General-purpose stylized lighting. Use its **Shadows** toggle for shadowed or shadow-free rendering without switching materials. |
-| **Pixelated Lightflow** | A deliberately stepped or pixel-oriented shaded response. |
+| **Pixelated Lightflow** | A deliberately stepped or pixel-oriented shaded response with independently switchable pixelated shadows. |
 | **Cinematic Craft** | Minecraft-trailer-oriented hero lighting, promotional edge treatment, bevel shaping, alpha-aware silhouettes, and a polished default grade. Existing `luma_forge` assignments migrate automatically. |
 | **Minecraft Promotional Bevel** | A specialized promotional bevel treatment for blocky, illustrated presentation renders. |
 
@@ -313,9 +350,18 @@ Lightflow's SSS is a stable real-time approximation designed for Blockbench's We
 ### Sharp pixel-art render
 
 1. Start with **Pixelated Lightflow**.
-2. Keep bevel, blur-like effects, and high softness values subtle.
-3. Test native samples first; increase SSAA only when it improves the outer contour without softening the intended pixel language.
-4. Use a transparent background for later compositing.
+2. Enable **Pixelated Shadows**, then tune shadow steps and pixel scale for the model scale and camera distance.
+3. Keep bevel, blur-like effects, and high softness values subtle.
+4. Test native samples first; increase SSAA only when it improves the outer contour without softening the intended pixel language.
+5. Use a transparent background for later compositing.
+
+### Vibrant Visuals scene
+
+1. Choose the **Vibrant Visuals** Environment preset and set the Minecraft time.
+2. Apply **Vibrant Visuals PBR** to the subject.
+3. Keep environment ambient and SSR enabled so the sky and horizon influence rough materials and reflections.
+4. Enable pixelated shadows where the stylized shadow edge is desired; disable it for a continuous PCF edge without changing material.
+5. Finish Bloom and grading in Scene Composer, then use the same settings in Studio Render.
 
 ### Product-card or thumbnail render
 
@@ -347,7 +393,7 @@ Lightflow's SSS is a stable real-time approximation designed for Blockbench's We
 
 ### Save format
 
-Save active Lightflow projects as **`.bbmodel`**. Shader Architect material assignments, material instances, and Lightflow Atmosphere Volume Domains use custom project/outliner properties that may not survive every export format.
+Save active Lightflow projects as **`.bbmodel`**. Shader Architect material assignments, material instances, Lightflow Environment settings, and Lightflow Atmosphere Volume Domains use custom project/outliner properties that may not survive every export format.
 
 ### Compatibility expectations
 
@@ -440,6 +486,20 @@ Save the project as **`.bbmodel`**. Other formats may not preserve Lightflow's c
 
 Studio Render hides gizmos by default. Verify that **Show Gizmos** is disabled in Studio Render settings, then render again.
 
+### Bloom differs between viewport and final render
+
+- Open **Scene Composer** and ensure **Realtime Viewport Bloom** is enabled.
+- Use the same Bloom threshold, strength, and radius that Studio Render will use; both paths share the same mask and compositing implementation.
+- Realtime Bloom is throttled by **Preview FPS** to keep editing responsive. Raise it only when the GPU has enough headroom.
+- Transparent final output can composite differently over an external background; compare against the intended destination background when judging edge glow.
+
+### The environment does not affect a material or reflection
+
+- Confirm Lightflow Environment and Shader Architect `2.7.0+` are both enabled.
+- Use **Lightflow Principled PBR**, **Vibrant Visuals PBR**, or another environment-aware Lightflow preset.
+- Raise environment ambient strength for diffuse tinting and enable SSR for reflections.
+- SSR reflects visible screen geometry first and uses the procedural environment only for miss rays; fully off-screen objects are not reconstructed.
+
 ### Volumetric shafts are missing
 
 - Confirm the Volume Domain is enabled and surrounds the visible ray path.
@@ -468,6 +528,7 @@ A release-candidate checkout keeps each independently loadable plugin at the rep
 ```text
 lightflow-blockbench/
 ├─ light_manager.js
+├─ lightflow_environment.js
 ├─ shader_architect.js
 ├─ lightflow_atmosphere.js
 ├─ studio_render.js
@@ -483,6 +544,7 @@ lightflow-blockbench/
 Keep plugin IDs, JavaScript file names, and release package names consistent:
 
 - `light_manager`
+- `lightflow_environment`
 - `shader_architect`
 - `lightflow_atmosphere`
 - `studio_render`
@@ -513,7 +575,8 @@ This roadmap is directional, not a release promise.
 - More artist-friendly preset packs and reusable lighting rigs.
 - Better first-run guidance and sample `.bbmodel` scenes.
 - More robust quality presets for low-, mid-, and high-end GPUs.
-- Refinement of AO, shadows, screen-space effects, bevel behavior, and rim consistency between viewport and final render.
+- Refinement of AO, screen-space reflection history, bevel behavior, and rim consistency between viewport and final render.
+- Optional temporal stabilization and GPU post-processing for Scene Composer on capable hardware.
 - A transmittance-buffer experiment for colored raster shadows, gated by GPU capabilities.
 - Evaluation of a future native/WebGPU renderer only when Blockbench and the browser graphics stack expose a stable ray-tracing path; the current WebGL backend does not advertise hardware RTX.
 - Higher-order multiple scattering, point-light volumetric shadows, artist-authored 3D density textures, and improved temporal accumulation for Atmosphere.

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ The plugins work independently where possible, but they are designed to be used 
 | Plugin | Current version | Purpose | Dependency |
 | --- | ---: | --- | --- |
 | **Light Manager** | `1.6.3` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
-| **Lightflow Environment** | `1.0.1` | Adds procedural Vanilla and Vibrant Visuals sky presets, Minecraft time, sun/moon lighting, ambient sky influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
+| **Lightflow Environment** | `1.1.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
 | **Shader Architect** | `2.7.1` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
 | **Lightflow Atmosphere** | `1.0.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
-| **Studio Render** | `1.5.0` | Adds Scene Composer, final-parity realtime Bloom and color grading, plus tiled supersampling, geometry-occluded emissive Bloom, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
+| **Studio Render** | `1.5.1` | Adds an attached Scene Composer, optimized AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
 
 ### Why Lightflow exists
 
@@ -212,10 +212,12 @@ Lightflow Environment is a procedural preview-scene module. It drives a sky dome
 
 - Minecraft time from `0` to `23999`, realtime playback, configurable day length, and sun azimuth.
 - **Vanilla** and **Vibrant Visuals** presets with tailored day, sunset, night, cloud, sun, moon, and ambient palettes.
-- Procedural square sun, moon phases, stars, and block-shaped clouds without bundled game textures.
+- Procedural or generated Vanilla-style block clouds, with project-texture overrides for clouds, sun, and moon.
+- Complete custom sky palette controls for day/night zenith, horizon, sunrise, lower sky, sun, moon, and clouds.
+- Adjustable gradient shape, star density, cloud scale, direction, contrast, brightness, opacity, coverage, and speed.
 - Directional sun and moon lights with editable shadow area, near/far range, resolution, bias, normal bias, and pixelated shadow controls.
 - Sky, horizon, and ground ambient colors exposed to Shader Architect for material tinting and SSR miss-ray reflections.
-- Project persistence and a compact Environment panel for time and preset changes.
+- Project persistence and a resizable Environment panel attached below the Outliner in **Lightflow Render** mode.
 
 The presets are independent procedural approximations tuned to reproduce the visual behavior of the named Minecraft render modes; they do not copy Minecraft source code or bundled textures.
 
@@ -295,8 +297,10 @@ Studio Render is the export layer. It is intended for portfolio images, social-m
 - GPU diagnostics showing the detected renderer and relevant WebGL limits.
 - Temporary Studio Render sessions that coordinate with Light Manager so final shadow settings do not permanently disturb the viewport.
 - Optional final-image Bloom with a simple strength control and advanced threshold/radius controls.
-- Realtime viewport Bloom that uses the same emissive/atmosphere mask, occlusion, blur scales, threshold, radius, and strength as final output.
-- **Scene Composer** controls for viewport Bloom, preview refresh rate, exposure, contrast, saturation, temperature, tint, vignette, and environment settings.
+- Realtime viewport Bloom that uses the same emissive/atmosphere semantics, occlusion, blur scales, threshold, radius, and strength as final output.
+- Low-resolution offscreen WebGL masks and reusable processing canvases for responsive editing without overwriting Shader Architect AO.
+- Helper/gizmo exclusion from the realtime Bloom source and three viewport quality profiles.
+- An attached **Scene Composer** panel in Lightflow Render, with the full dialog retained for grading and advanced controls.
 - One shared Canvas2D color-grade path for the viewport preview and final render.
 - Emissive-only Bloom masking: emissive render-mode alpha, MER maps, dedicated emissive maps, and additive materials glow without blooming ordinary bright surfaces.
 - Atmosphere-aware Bloom masking, including per-domain Bloom contribution for bright shafts and cloud highlights.
@@ -490,7 +494,8 @@ Studio Render hides gizmos by default. Verify that **Show Gizmos** is disabled i
 
 - Open **Scene Composer** and ensure **Realtime Viewport Bloom** is enabled.
 - Use the same Bloom threshold, strength, and radius that Studio Render will use; both paths share the same mask and compositing implementation.
-- Realtime Bloom is throttled by **Preview FPS** to keep editing responsive. Raise it only when the GPU has enough headroom.
+- Realtime Bloom is throttled by **Preview FPS** and an internal quality profile. Start with **Balanced**; use **Performance** for high-DPI or integrated-GPU viewports.
+- Realtime composition only runs in **Lightflow Render** mode. Gizmos are excluded from the Bloom mask and Shader Architect AO is preserved in the base frame.
 - Transparent final output can composite differently over an external background; compare against the intended destination background when judging edge glow.
 
 ### The environment does not affect a material or reflection

--- a/light_manager.js
+++ b/light_manager.js
@@ -3314,7 +3314,19 @@ window.LightManagerFitTool = {
     }
 };
 
-if (!THREE.ShaderChunk.common.includes('PUNCTUAL_LIGHT_PATCH')) {
+/*
+ * Older Three.js builds did not expose the distance helper used by the light
+ * chunks. Blockbench 5 / Three r129 already defines it in
+ * lights_pars_begin. Injecting a second body into <common> makes every stock
+ * Lambert/Phong material fail to compile in WebGL2, so only install the
+ * compatibility helper when the active light chunk genuinely lacks it.
+ */
+const lightManagerHasNativePunctualHelper = !!(
+    THREE.ShaderChunk.lights_pars_begin &&
+    THREE.ShaderChunk.lights_pars_begin.includes('punctualLightIntensityToIrradianceFactor')
+);
+
+if (!lightManagerHasNativePunctualHelper && !THREE.ShaderChunk.common.includes('PUNCTUAL_LIGHT_PATCH')) {
     THREE.ShaderChunk.common += `\n
     #ifndef PUNCTUAL_LIGHT_PATCH
     #define PUNCTUAL_LIGHT_PATCH
@@ -3922,7 +3934,7 @@ function initialize_light_plugin() {
         author: 'MidFord327',
         description: 'Add production-ready point, spot, and directional lights to Blockbench with viewport gizmos, animation support, shadows, and Studio Render controls. Provides the Lightflow lighting foundation for Shader Architect and Studio Render.',
         tags: ['Lightflow', 'Lighting', 'Shadows', 'Animation', 'Rendering', 'Studio'],
-        version: '1.6.1',
+        version: '1.6.2',
         min_version: '4.9.0',
         variant: 'both',
 

--- a/light_manager.js
+++ b/light_manager.js
@@ -3315,36 +3315,12 @@ window.LightManagerFitTool = {
 };
 
 /*
- * Older Three.js builds did not expose the distance helper used by the light
- * chunks. Blockbench 5 / Three r129 already defines it in
- * lights_pars_begin. Injecting a second body into <common> makes every stock
- * Lambert/Phong material fail to compile in WebGL2, so only install the
- * compatibility helper when the active light chunk genuinely lacks it.
+ * Do not patch THREE.ShaderChunk.common here. Three r129 owns the punctual
+ * attenuation helper in <bsdfs>; a global copy collides with stock
+ * Lambert/Phong materials. Shader Architect provides its compatibility
+ * overload only inside custom shaders that consume <lights_pars_begin>
+ * without also consuming <bsdfs>.
  */
-const lightManagerHasNativePunctualHelper = !!(
-    THREE.ShaderChunk.lights_pars_begin &&
-    THREE.ShaderChunk.lights_pars_begin.includes('punctualLightIntensityToIrradianceFactor')
-);
-
-if (!lightManagerHasNativePunctualHelper && !THREE.ShaderChunk.common.includes('PUNCTUAL_LIGHT_PATCH')) {
-    THREE.ShaderChunk.common += `\n
-    #ifndef PUNCTUAL_LIGHT_PATCH
-    #define PUNCTUAL_LIGHT_PATCH
-    float punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {
-        if( cutoffDistance > 0.0 && decayExponent > 0.0 ) {
-            return pow( clamp( -lightDistance / cutoffDistance + 1.0, 0.0, 1.0 ), decayExponent );
-        }
-        return 1.0;
-    }
-    float punctualLightIntensityToIrradianceFactor( const in float lightDistance, const in float cutoffDistance ) {
-        if( cutoffDistance > 0.0 ) {
-            return clamp( 1.0 - lightDistance / cutoffDistance, 0.0, 1.0 );
-        }
-        return 1.0;
-    }
-    #endif
-    `;
-}
 
 if (typeof window.on_light_element_updated !== 'function') {
     window.on_light_element_updated = () => { };
@@ -3934,7 +3910,7 @@ function initialize_light_plugin() {
         author: 'MidFord327',
         description: 'Add production-ready point, spot, and directional lights to Blockbench with viewport gizmos, animation support, shadows, and Studio Render controls. Provides the Lightflow lighting foundation for Shader Architect and Studio Render.',
         tags: ['Lightflow', 'Lighting', 'Shadows', 'Animation', 'Rendering', 'Studio'],
-        version: '1.6.2',
+        version: '1.6.3',
         min_version: '4.9.0',
         variant: 'both',
 

--- a/light_manager.js
+++ b/light_manager.js
@@ -86,7 +86,7 @@ const DEFAULT_SHADOW_BIAS = -0.0005;
 const DEFAULT_SHADOW_NORMAL_BIAS = 0.01;
 const DEFAULT_SHADOW_SOFTNESS = 1.75;
 
-const LIGHT_MANAGER_BAR_ITEM_IDS = [
+const LIGHT_MANAGER_ACTION_IDS = [
     'add_light',
     'add_spot_light',
     'add_directional_light',
@@ -94,7 +94,12 @@ const LIGHT_MANAGER_BAR_ITEM_IDS = [
     'fit_light_bounds_to_selection',
     'light_manager_edit_tool',
     'light_manager_free_move',
-    'toggle_light_area_gizmos',
+    'toggle_light_area_gizmos'
+];
+
+// These IDs belonged to the pre-form Light Properties toolbars. Keep them only
+// as cleanup targets so plugin reloads cannot leave obsolete BarItems behind.
+const LIGHT_MANAGER_LEGACY_BAR_ITEM_IDS = [
     'light_type_select',
     'light_color_picker',
     'light_temperature_slider',
@@ -113,7 +118,7 @@ const LIGHT_MANAGER_BAR_ITEM_IDS = [
     'light_shadow_normal_bias_sliderbox'
 ];
 
-const LIGHT_MANAGER_TOOLBAR_IDS = [
+const LIGHT_MANAGER_LEGACY_TOOLBAR_IDS = [
     'light_gizmo_tools',
     'light_quickbuttons',
     'light_shadow_quality',
@@ -122,16 +127,6 @@ const LIGHT_MANAGER_TOOLBAR_IDS = [
     'light_shadow_bounds_settings',
     'light_shadow_bias_settings'
 ];
-
-const LIGHT_MANAGER_TOOLBAR_DEFAULT_CHILDREN = {
-    light_gizmo_tools: ['light_manager_edit_tool', 'light_manager_free_move'],
-    light_quickbuttons: ['light_type_select', 'light_color_picker', '#', 'light_temperature_slider'],
-    light_shadow_quality: ['cast_shadows', '#', 'light_shadow_resolution_select', 'light_studio_shadow_resolution_select'],
-    light_settings: ['light_intensity_slider', '#', 'light_distance_slider', '#', 'light_cone_angle_slider', '#', 'light_cone_penumbra_slider'],
-    light_shadow_clip_settings: ['light_shadow_near_sliderbox', 'light_shadow_far_sliderbox'],
-    light_shadow_bounds_settings: ['light_shadow_bounds_slider'],
-    light_shadow_bias_settings: ['light_shadow_softness_sliderbox', '#', 'light_shadow_bias_sliderbox', '#', 'light_shadow_normal_bias_sliderbox']
-};
 
 function deleteLightManagerRegistryItem(registry, id) {
     if (!registry || !id) return;
@@ -154,42 +149,30 @@ function cleanupLightManagerRegistries() {
     const barItems = typeof BarItems !== 'undefined' ? BarItems : window.BarItems;
     const toolbars = typeof Toolbars !== 'undefined' ? Toolbars : window.Toolbars;
 
-    LIGHT_MANAGER_BAR_ITEM_IDS.forEach(id => deleteLightManagerRegistryItem(barItems, id));
-    LIGHT_MANAGER_TOOLBAR_IDS.forEach(id => deleteLightManagerRegistryItem(toolbars, id));
+    LIGHT_MANAGER_ACTION_IDS.forEach(id => deleteLightManagerRegistryItem(barItems, id));
+    LIGHT_MANAGER_LEGACY_BAR_ITEM_IDS.forEach(id => deleteLightManagerRegistryItem(barItems, id));
+    LIGHT_MANAGER_LEGACY_TOOLBAR_IDS.forEach(id => deleteLightManagerRegistryItem(toolbars, id));
 }
 
-function lightManagerStoredToolbarMissingDefault(storedChildren, defaultChildren) {
-    if (!Array.isArray(storedChildren) || !Array.isArray(defaultChildren)) return false;
-
-    return defaultChildren.some(child => {
-        if (typeof child !== 'string' || child.match(/^[_+#]/)) return false;
-        return !storedChildren.includes(child);
-    });
-}
-
-function resetLightManagerStoredToolbarLayouts() {
+function removeLightManagerLegacyStoredToolbarLayouts() {
     const bars = typeof BARS !== 'undefined' ? BARS : window.BARS;
-    let changed = false;
 
     if (bars && bars.stored) {
-        LIGHT_MANAGER_TOOLBAR_IDS.forEach(id => {
-            if (!lightManagerStoredToolbarMissingDefault(bars.stored[id], LIGHT_MANAGER_TOOLBAR_DEFAULT_CHILDREN[id])) return;
-            delete bars.stored[id];
-            changed = true;
-        });
+        LIGHT_MANAGER_LEGACY_TOOLBAR_IDS.forEach(id => delete bars.stored[id]);
     }
 
     if (typeof localStorage !== 'undefined') {
         try {
             const storedToolbars = JSON.parse(localStorage.getItem('toolbars') || '{}');
-            LIGHT_MANAGER_TOOLBAR_IDS.forEach(id => {
-                if (!lightManagerStoredToolbarMissingDefault(storedToolbars[id], LIGHT_MANAGER_TOOLBAR_DEFAULT_CHILDREN[id])) return;
+            let changed = false;
+            LIGHT_MANAGER_LEGACY_TOOLBAR_IDS.forEach(id => {
+                if (!Object.prototype.hasOwnProperty.call(storedToolbars, id)) return;
                 delete storedToolbars[id];
                 changed = true;
             });
             if (changed) localStorage.setItem('toolbars', JSON.stringify(storedToolbars));
         } catch (error) {
-            // Ignore invalid toolbar storage; Blockbench will rebuild from defaults.
+            // Ignore invalid toolbar storage; the live registries are still cleaned.
         }
     }
 }
@@ -265,14 +248,42 @@ function markLightManagerShadowsDirty(options = {}) {
 }
 
 function lightManagerHasActiveShadowLights() {
-    if (window.LightElement && Array.isArray(LightElement.all)) {
-        return LightElement.all.some(element => {
+    const hasElementRegistry = !!(window.LightElement && Array.isArray(LightElement.all));
+    const hasElementShadowLight = hasElementRegistry
+        ? LightElement.all.some(element => {
             return element && element.visibility !== false && element.has_shadow !== false;
-        });
+        })
+        : false;
+
+    if (hasElementShadowLight) return true;
+
+    /*
+     * Environment lights are deliberately virtual: they live in the THREE
+     * scene/three_lights registry but not in LightElement.all. Looking only at
+     * outliner lights disabled the renderer shadow map and caster/receiver
+     * preparation until an unrelated LightElement also enabled shadows.
+     */
+    const environmentLight =
+        window.LightflowEnvironment?.getDirectionalLight?.() ||
+        window.LightflowEnvironmentSunLight ||
+        null;
+    if (
+        environmentLight &&
+        environmentLight.visible !== false &&
+        environmentLight.castShadow === true &&
+        environmentLight.shadow
+    ) {
+        return true;
     }
 
     return Object.values(window.three_lights || {}).some(light => {
-        return light && light.visible !== false && light.castShadow !== false;
+        return !!(
+            light &&
+            light.visible !== false &&
+            light.castShadow === true &&
+            light.shadow &&
+            (!hasElementRegistry || light.userData?.lightflowEnvironmentVirtual)
+        );
     });
 }
 
@@ -375,7 +386,7 @@ const LIGHT_MANAGER_PROFILES = {
     point_fill: {
         light_type: 'point',
         intensity: 1.4,
-        distance: 18,
+        distance: 0,
         angle: 45,
         penumbra: 0,
         has_shadow: true,
@@ -390,7 +401,7 @@ const LIGHT_MANAGER_PROFILES = {
     spot_key: {
         light_type: 'spot',
         intensity: 2.5,
-        distance: 28,
+        distance: 0,
         angle: 32,
         penumbra: 0.35,
         has_shadow: true,
@@ -3584,6 +3595,1031 @@ function kelvinToTinyColor(kelvin) {
     });
 }
 
+/**
+ * Returns a stylized hexadecimal foreground color with sufficient contrast
+ * against the given background.
+ *
+ * Unlike a basic contrast correction that only darkens or lightens a color,
+ * this function works in the perceptual OKLCH color space:
+ *
+ * - Preserves the original hue and visual identity.
+ * - Deepens and enriches pastel colors on light backgrounds.
+ * - Slightly reduces chroma when lightening colors on dark backgrounds,
+ *   preventing overly bright or neon-looking results.
+ * - Leaves the original color unchanged when it already has enough contrast.
+ * - Automatically maps out-of-gamut colors back into displayable sRGB.
+ *
+ * Supported CSS color formats include:
+ *
+ * - CSS variables: "var(--color-accent)"
+ * - Hexadecimal: "#9ecbff", "#fff"
+ * - Named colors: "white", "red", "royalblue"
+ * - RGB: "rgb(120 180 255)"
+ * - HSL: "hsl(210 100% 75%)"
+ * - OKLCH and other browser-supported CSS color formats
+ *
+ * This function requires a browser environment because CSS variables and
+ * browser-supported color syntaxes are resolved through the DOM.
+ *
+ * @param {string} color
+ * The foreground CSS color.
+ *
+ * @param {string} background
+ * The CSS background color.
+ *
+ * @param {object} [options]
+ * Optional contrast and styling settings.
+ *
+ * @param {number} [options.minContrast=4.5]
+ * Minimum WCAG contrast ratio.
+ *
+ * Common values:
+ * - 3.0 for large text, icons, borders, and large UI elements.
+ * - 4.5 for normal text and general interface content.
+ * - 7.0 for enhanced accessibility.
+ *
+ * @param {number} [options.styleStrength=0.85]
+ * Controls how strongly the function stylizes insufficient-contrast colors.
+ *
+ * Range:
+ * - 0: Mostly preserves the original chroma.
+ * - 0.5: Moderate chroma adjustment.
+ * - 1: Stronger pastel-to-rich-color transformation.
+ *
+ * @param {Element} [options.contextElement=document.documentElement]
+ * Element used to resolve CSS custom properties.
+ *
+ * @returns {string}
+ * An opaque hexadecimal color in "#RRGGBB" format.
+ *
+ * @throws {TypeError}
+ * If the provided colors or context element are invalid.
+ *
+ * @throws {RangeError}
+ * If minContrast or styleStrength are outside their supported ranges.
+ *
+ * @example
+ * const foreground = getStylizedContrastingColor(
+ *     "var(--color-accent)",
+ *     "var(--color-bg)"
+ * );
+ *
+ * @example
+ * const accessiblePastel = getStylizedContrastingColor(
+ *     "#B9DEFF",
+ *     "white",
+ *     {
+ *         minContrast: 4.5,
+ *         styleStrength: 0.9,
+ *     }
+ * );
+ */
+function getStylizedContrastingColor(
+    color,
+    background,
+    {
+        minContrast = 4.5,
+        styleStrength = 0.85,
+        contextElement = document.documentElement,
+    } = {}
+) {
+    if (
+        !Number.isFinite(minContrast) ||
+        minContrast < 1 ||
+        minContrast > 21
+    ) {
+        throw new RangeError("minContrast must be between 1 and 21.");
+    }
+
+    if (
+        !Number.isFinite(styleStrength) ||
+        styleStrength < 0 ||
+        styleStrength > 1
+    ) {
+        throw new RangeError("styleStrength must be between 0 and 1.");
+    }
+
+    const backgroundRgba = resolveCssColor(
+        background,
+        contextElement
+    );
+
+    const opaqueBackground = compositeOverWhite(backgroundRgba);
+
+    const foregroundRgba = resolveCssColor(
+        color,
+        contextElement
+    );
+
+    const opaqueForeground = compositeColors(
+        foregroundRgba,
+        opaqueBackground
+    );
+
+    const originalContrast = contrastRatio(
+        opaqueForeground,
+        opaqueBackground
+    );
+
+    if (originalContrast >= minContrast) {
+        return rgbToHex(opaqueForeground);
+    }
+
+    const originalOklch = rgbToOklch(opaqueForeground);
+    const backgroundLuminance = relativeLuminance(opaqueBackground);
+
+    /*
+     * Light backgrounds normally need a deeper foreground.
+     * Dark backgrounds normally need a lighter foreground.
+     */
+    const preferredDirection =
+        backgroundLuminance >= 0.42
+            ? "darker"
+            : "lighter";
+
+    const idealChroma = getIdealStyledChroma(
+        originalOklch.c,
+        preferredDirection,
+        styleStrength
+    );
+
+    const chromaTargets = createChromaTargets(
+        originalOklch.c,
+        idealChroma,
+        preferredDirection,
+        styleStrength
+    );
+
+    const candidates = chromaTargets
+        .map((targetChroma) =>
+            findAccessibleCandidate({
+                originalOklch,
+                targetChroma,
+                background: opaqueBackground,
+                minContrast,
+                direction: preferredDirection,
+            })
+        )
+        .filter(Boolean);
+
+    /*
+     * Extremely high requested contrast ratios may not be achievable in the
+     * preferred direction. In that case, test the opposite direction too.
+     */
+    if (candidates.length === 0) {
+        const oppositeDirection =
+            preferredDirection === "darker"
+                ? "lighter"
+                : "darker";
+
+        const oppositeIdealChroma = getIdealStyledChroma(
+            originalOklch.c,
+            oppositeDirection,
+            styleStrength * 0.5
+        );
+
+        const oppositeTargets = createChromaTargets(
+            originalOklch.c,
+            oppositeIdealChroma,
+            oppositeDirection,
+            styleStrength * 0.5
+        );
+
+        for (const targetChroma of oppositeTargets) {
+            const candidate = findAccessibleCandidate({
+                originalOklch,
+                targetChroma,
+                background: opaqueBackground,
+                minContrast,
+                direction: oppositeDirection,
+            });
+
+            if (candidate) {
+                candidate.directionPenalty = 0.075;
+                candidates.push(candidate);
+            }
+        }
+    }
+
+    if (candidates.length === 0) {
+        return getMaximumContrastColor(opaqueBackground);
+    }
+
+    for (const candidate of candidates) {
+        candidate.score = scoreCandidate({
+            candidate,
+            originalOklch,
+            idealChroma,
+            minContrast,
+            styleStrength,
+        });
+    }
+
+    candidates.sort((a, b) => a.score - b.score);
+
+    return rgbToHex(candidates[0].rgb);
+}
+
+/**
+ * Calculates the desirable chroma for the styled result.
+ *
+ * On light backgrounds, pastel colors are enriched before being darkened.
+ * On dark backgrounds, chroma is reduced slightly when the color must be
+ * lightened, which prevents neon-like results.
+ *
+ * @param {number} originalChroma
+ * @param {"darker" | "lighter"} direction
+ * @param {number} styleStrength
+ * @returns {number}
+ */
+function getIdealStyledChroma(
+    originalChroma,
+    direction,
+    styleStrength
+) {
+    /*
+     * Keep neutral colors neutral. A gray should not suddenly receive hue.
+     */
+    if (originalChroma < 0.012) {
+        return originalChroma;
+    }
+
+    if (direction === "darker") {
+        /*
+         * Pastel colors usually have low or medium chroma combined with high
+         * lightness. Increasing chroma while reducing lightness creates a
+         * richer representative shade instead of a dull darkened pastel.
+         */
+        const pastelFactor = clamp(
+            1 - originalChroma / 0.2,
+            0,
+            1
+        );
+
+        const chromaIncrease =
+            (0.025 + pastelFactor * 0.065) *
+            styleStrength;
+
+        return clamp(
+            originalChroma + chromaIncrease,
+            0,
+            0.24
+        );
+    }
+
+    /*
+     * When lightening a color, excessive chroma may create a glowing or neon
+     * appearance. A small chroma reduction usually looks more comfortable.
+     */
+    return clamp(
+        originalChroma * (1 - 0.16 * styleStrength),
+        0,
+        0.24
+    );
+}
+
+/**
+ * Creates multiple chroma possibilities so the algorithm can select the
+ * result that best balances identity, contrast, and visual styling.
+ *
+ * @param {number} originalChroma
+ * @param {number} idealChroma
+ * @param {"darker" | "lighter"} direction
+ * @param {number} styleStrength
+ * @returns {number[]}
+ */
+function createChromaTargets(
+    originalChroma,
+    idealChroma,
+    direction,
+    styleStrength
+) {
+    if (originalChroma < 0.012) {
+        return [originalChroma];
+    }
+
+    const targets =
+        direction === "darker"
+            ? [
+                  originalChroma,
+                  lerp(
+                      originalChroma,
+                      idealChroma,
+                      0.35
+                  ),
+                  lerp(
+                      originalChroma,
+                      idealChroma,
+                      0.7
+                  ),
+                  idealChroma,
+                  idealChroma *
+                      (1 + 0.08 * styleStrength),
+                  originalChroma * 0.9,
+              ]
+            : [
+                  originalChroma,
+                  lerp(
+                      originalChroma,
+                      idealChroma,
+                      0.5
+                  ),
+                  idealChroma,
+                  idealChroma * 0.88,
+              ];
+
+    return [...new Set(
+        targets.map((value) =>
+            Number(clamp(value, 0, 0.25).toFixed(6))
+        )
+    )];
+}
+
+/**
+ * Finds the smallest lightness adjustment that reaches the requested
+ * contrast ratio for a specific chroma.
+ *
+ * @param {object} parameters
+ * @param {{l: number, c: number, h: number}} parameters.originalOklch
+ * @param {number} parameters.targetChroma
+ * @param {{r: number, g: number, b: number}} parameters.background
+ * @param {number} parameters.minContrast
+ * @param {"darker" | "lighter"} parameters.direction
+ * @returns {{
+ *     rgb: {r: number, g: number, b: number, a: number},
+ *     oklch: {l: number, c: number, h: number},
+ *     contrast: number,
+ *     directionPenalty: number
+ * } | null}
+ */
+function findAccessibleCandidate({
+    originalOklch,
+    targetChroma,
+    background,
+    minContrast,
+    direction,
+}) {
+    const extremeLightness =
+        direction === "darker" ? 0 : 1;
+
+    const extremeCandidate = oklchToDisplayRgb({
+        l: extremeLightness,
+        c: targetChroma,
+        h: originalOklch.h,
+    });
+
+    const extremeContrast = contrastRatio(
+        extremeCandidate.rgb,
+        background
+    );
+
+    if (extremeContrast < minContrast) {
+        return null;
+    }
+
+    let inaccessibleLightness = originalOklch.l;
+    let accessibleLightness = extremeLightness;
+    let bestCandidate = extremeCandidate;
+
+    for (let iteration = 0; iteration < 32; iteration += 1) {
+        const currentLightness =
+            (inaccessibleLightness + accessibleLightness) / 2;
+
+        const candidate = oklchToDisplayRgb({
+            l: currentLightness,
+            c: targetChroma,
+            h: originalOklch.h,
+        });
+
+        const candidateContrast = contrastRatio(
+            candidate.rgb,
+            background
+        );
+
+        if (candidateContrast >= minContrast) {
+            accessibleLightness = currentLightness;
+            bestCandidate = candidate;
+        } else {
+            inaccessibleLightness = currentLightness;
+        }
+    }
+
+    const finalContrast = contrastRatio(
+        bestCandidate.rgb,
+        background
+    );
+
+    return {
+        rgb: bestCandidate.rgb,
+        oklch: {
+            l: accessibleLightness,
+            c: bestCandidate.chroma,
+            h: originalOklch.h,
+        },
+        contrast: finalContrast,
+        directionPenalty: 0,
+    };
+}
+
+/**
+ * Scores a candidate according to perceptual identity, desired styling,
+ * contrast overshoot, and direction preference.
+ *
+ * Lower scores are better.
+ *
+ * @param {object} parameters
+ * @param {{
+ *     oklch: {l: number, c: number, h: number},
+ *     contrast: number,
+ *     directionPenalty: number
+ * }} parameters.candidate
+ * @param {{l: number, c: number, h: number}} parameters.originalOklch
+ * @param {number} parameters.idealChroma
+ * @param {number} parameters.minContrast
+ * @param {number} parameters.styleStrength
+ * @returns {number}
+ */
+function scoreCandidate({
+    candidate,
+    originalOklch,
+    idealChroma,
+    minContrast,
+    styleStrength,
+}) {
+    const identityDistance = perceptualOklchDistance(
+        candidate.oklch,
+        originalOklch
+    );
+
+    const styledChromaDifference = Math.abs(
+        candidate.oklch.c - idealChroma
+    );
+
+    /*
+     * A tiny overshoot penalty favors colors close to the requested contrast
+     * instead of unnecessarily approaching pure black or white.
+     */
+    const contrastOvershoot = Math.max(
+        0,
+        candidate.contrast - minContrast
+    );
+
+    return (
+        identityDistance +
+        styledChromaDifference *
+            (0.75 + styleStrength * 0.85) +
+        contrastOvershoot * 0.0025 +
+        candidate.directionPenalty
+    );
+}
+
+/**
+ * Calculates an approximate perceptual distance between two OKLCH colors.
+ *
+ * Hue is compared through OKLab Cartesian coordinates to avoid problems
+ * around the 0° and 360° hue boundary.
+ *
+ * @param {{l: number, c: number, h: number}} colorA
+ * @param {{l: number, c: number, h: number}} colorB
+ * @returns {number}
+ */
+function perceptualOklchDistance(colorA, colorB) {
+    const labA = oklchToOklab(colorA);
+    const labB = oklchToOklab(colorB);
+
+    const deltaL = labA.l - labB.l;
+    const deltaA = labA.a - labB.a;
+    const deltaB = labA.b - labB.b;
+
+    return Math.sqrt(
+        deltaL * deltaL * 1.2 +
+        deltaA * deltaA * 0.72 +
+        deltaB * deltaB * 0.72
+    );
+}
+
+/**
+ * Converts OKLCH coordinates into OKLab coordinates.
+ *
+ * @param {{l: number, c: number, h: number}} oklch
+ * @returns {{l: number, a: number, b: number}}
+ */
+function oklchToOklab({ l, c, h }) {
+    const hueRadians = (h * Math.PI) / 180;
+
+    return {
+        l,
+        a: c * Math.cos(hueRadians),
+        b: c * Math.sin(hueRadians),
+    };
+}
+
+/**
+ * Converts an OKLCH color into displayable sRGB.
+ *
+ * If the color is outside the sRGB gamut, chroma is reduced while preserving
+ * the requested lightness and hue.
+ *
+ * @param {{l: number, c: number, h: number}} oklch
+ * @returns {{
+ *     rgb: {r: number, g: number, b: number, a: number},
+ *     chroma: number
+ * }}
+ */
+function oklchToDisplayRgb(oklch) {
+    const initialRgb = oklchToRgb(oklch);
+
+    if (isRgbInGamut(initialRgb)) {
+        return {
+            rgb: normalizeRgb(initialRgb),
+            chroma: oklch.c,
+        };
+    }
+
+    let minimumChroma = 0;
+    let maximumChroma = oklch.c;
+    let bestChroma = 0;
+
+    let bestRgb = oklchToRgb({
+        ...oklch,
+        c: 0,
+    });
+
+    for (let iteration = 0; iteration < 26; iteration += 1) {
+        const currentChroma =
+            (minimumChroma + maximumChroma) / 2;
+
+        const candidateRgb = oklchToRgb({
+            ...oklch,
+            c: currentChroma,
+        });
+
+        if (isRgbInGamut(candidateRgb)) {
+            minimumChroma = currentChroma;
+            bestChroma = currentChroma;
+            bestRgb = candidateRgb;
+        } else {
+            maximumChroma = currentChroma;
+        }
+    }
+
+    return {
+        rgb: normalizeRgb(bestRgb),
+        chroma: bestChroma,
+    };
+}
+
+/**
+ * Resolves any browser-supported CSS color into RGBA values.
+ *
+ * CSS custom properties are resolved relative to contextElement. The browser
+ * itself parses the resulting color through a one-pixel canvas, allowing the
+ * function to support modern formats such as HSL, OKLCH, and color().
+ *
+ * @param {string} cssColor
+ * @param {Element} contextElement
+ * @returns {{r: number, g: number, b: number, a: number}}
+ */
+function resolveCssColor(cssColor, contextElement) {
+    if (
+        typeof cssColor !== "string" ||
+        cssColor.trim() === ""
+    ) {
+        throw new TypeError(
+            "CSS colors must be non-empty strings."
+        );
+    }
+
+    if (
+        !contextElement ||
+        typeof contextElement.appendChild !== "function" ||
+        !contextElement.ownerDocument
+    ) {
+        throw new TypeError(
+            "contextElement must be a valid DOM Element."
+        );
+    }
+
+    const documentReference =
+        contextElement.ownerDocument;
+
+    const probe =
+        documentReference.createElement("span");
+
+    probe.style.cssText = [
+        "all: initial",
+        "position: fixed",
+        "left: -99999px",
+        "top: -99999px",
+        "display: block",
+        "visibility: hidden",
+        "pointer-events: none",
+    ].join(";");
+
+    probe.style.color = cssColor;
+
+    if (
+        !probe.style.color &&
+        !cssColor.includes("var(")
+    ) {
+        throw new Error(
+            `Invalid CSS color: "${cssColor}".`
+        );
+    }
+
+    contextElement.appendChild(probe);
+
+    let computedColor;
+
+    try {
+        computedColor =
+            documentReference.defaultView
+                ?.getComputedStyle(probe)
+                .color ?? "";
+    } finally {
+        probe.remove();
+    }
+
+    if (!computedColor) {
+        throw new Error(
+            `Could not resolve CSS color: "${cssColor}".`
+        );
+    }
+
+    const canvas =
+        documentReference.createElement("canvas");
+
+    canvas.width = 1;
+    canvas.height = 1;
+
+    const context = canvas.getContext("2d", {
+        willReadFrequently: true,
+    });
+
+    if (!context) {
+        throw new Error(
+            "Could not create a canvas rendering context."
+        );
+    }
+
+    context.clearRect(0, 0, 1, 1);
+    context.fillStyle = "rgba(0, 0, 0, 0)";
+    context.fillStyle = computedColor;
+    context.fillRect(0, 0, 1, 1);
+
+    const [r, g, b, alpha] =
+        context.getImageData(0, 0, 1, 1).data;
+
+    return {
+        r,
+        g,
+        b,
+        a: alpha / 255,
+    };
+}
+
+/**
+ * Calculates the WCAG contrast ratio between two opaque RGB colors.
+ *
+ * @param {{r: number, g: number, b: number}} colorA
+ * @param {{r: number, g: number, b: number}} colorB
+ * @returns {number}
+ */
+function contrastRatio(colorA, colorB) {
+    const luminanceA = relativeLuminance(colorA);
+    const luminanceB = relativeLuminance(colorB);
+
+    const lighter = Math.max(
+        luminanceA,
+        luminanceB
+    );
+
+    const darker = Math.min(
+        luminanceA,
+        luminanceB
+    );
+
+    return (lighter + 0.05) / (darker + 0.05);
+}
+
+/**
+ * Calculates the WCAG relative luminance of an sRGB color.
+ *
+ * @param {{r: number, g: number, b: number}} rgb
+ * @returns {number}
+ */
+function relativeLuminance({ r, g, b }) {
+    const [linearR, linearG, linearB] = [
+        r,
+        g,
+        b,
+    ].map((component) => {
+        const srgb = clamp(
+            component / 255,
+            0,
+            1
+        );
+
+        return srgb <= 0.04045
+            ? srgb / 12.92
+            : ((srgb + 0.055) / 1.055) ** 2.4;
+    });
+
+    return (
+        0.2126 * linearR +
+        0.7152 * linearG +
+        0.0722 * linearB
+    );
+}
+
+/**
+ * Converts an sRGB color into OKLCH.
+ *
+ * @param {{r: number, g: number, b: number}} rgb
+ * @returns {{l: number, c: number, h: number}}
+ */
+function rgbToOklch({ r, g, b }) {
+    const linearR = srgbToLinear(r / 255);
+    const linearG = srgbToLinear(g / 255);
+    const linearB = srgbToLinear(b / 255);
+
+    const l =
+        0.4122214708 * linearR +
+        0.5363325363 * linearG +
+        0.0514459929 * linearB;
+
+    const m =
+        0.2119034982 * linearR +
+        0.6806995451 * linearG +
+        0.1073969566 * linearB;
+
+    const s =
+        0.0883024619 * linearR +
+        0.2817188376 * linearG +
+        0.6299787005 * linearB;
+
+    const lRoot = Math.cbrt(l);
+    const mRoot = Math.cbrt(m);
+    const sRoot = Math.cbrt(s);
+
+    const lightness =
+        0.2104542553 * lRoot +
+        0.793617785 * mRoot -
+        0.0040720468 * sRoot;
+
+    const a =
+        1.9779984951 * lRoot -
+        2.428592205 * mRoot +
+        0.4505937099 * sRoot;
+
+    const bValue =
+        0.0259040371 * lRoot +
+        0.7827717662 * mRoot -
+        0.808675766 * sRoot;
+
+    const chroma = Math.sqrt(
+        a * a + bValue * bValue
+    );
+
+    const hue =
+        chroma < 1e-7
+            ? 0
+            : (
+                  Math.atan2(bValue, a) *
+                  180
+              ) / Math.PI;
+
+    return {
+        l: clamp(lightness, 0, 1),
+        c: Math.max(0, chroma),
+        h: hue < 0 ? hue + 360 : hue,
+    };
+}
+
+/**
+ * Converts OKLCH into potentially out-of-gamut sRGB values.
+ *
+ * @param {{l: number, c: number, h: number}} oklch
+ * @returns {{r: number, g: number, b: number, a: number}}
+ */
+function oklchToRgb({ l, c, h }) {
+    const hueRadians = (h * Math.PI) / 180;
+
+    const a = c * Math.cos(hueRadians);
+    const b = c * Math.sin(hueRadians);
+
+    const lRoot =
+        l +
+        0.3963377774 * a +
+        0.2158037573 * b;
+
+    const mRoot =
+        l -
+        0.1055613458 * a -
+        0.0638541728 * b;
+
+    const sRoot =
+        l -
+        0.0894841775 * a -
+        1.291485548 * b;
+
+    const lLinear = lRoot ** 3;
+    const mLinear = mRoot ** 3;
+    const sLinear = sRoot ** 3;
+
+    const linearR =
+        4.0767416621 * lLinear -
+        3.3077115913 * mLinear +
+        0.2309699292 * sLinear;
+
+    const linearG =
+        -1.2684380046 * lLinear +
+        2.6097574011 * mLinear -
+        0.3413193965 * sLinear;
+
+    const linearB =
+        -0.0041960863 * lLinear -
+        0.7034186147 * mLinear +
+        1.707614701 * sLinear;
+
+    return {
+        r: linearToSrgb(linearR) * 255,
+        g: linearToSrgb(linearG) * 255,
+        b: linearToSrgb(linearB) * 255,
+        a: 1,
+    };
+}
+
+/**
+ * Composites an RGBA foreground over an opaque background.
+ *
+ * @param {{r: number, g: number, b: number, a: number}} foreground
+ * @param {{r: number, g: number, b: number, a: number}} background
+ * @returns {{r: number, g: number, b: number, a: number}}
+ */
+function compositeColors(foreground, background) {
+    const alpha = clamp(foreground.a, 0, 1);
+
+    return {
+        r:
+            foreground.r * alpha +
+            background.r * (1 - alpha),
+
+        g:
+            foreground.g * alpha +
+            background.g * (1 - alpha),
+
+        b:
+            foreground.b * alpha +
+            background.b * (1 - alpha),
+
+        a: 1,
+    };
+}
+
+/**
+ * Composites a potentially transparent background over white.
+ *
+ * @param {{r: number, g: number, b: number, a: number}} color
+ * @returns {{r: number, g: number, b: number, a: number}}
+ */
+function compositeOverWhite(color) {
+    return compositeColors(color, {
+        r: 255,
+        g: 255,
+        b: 255,
+        a: 1,
+    });
+}
+
+/**
+ * Returns either black or white, depending on which produces more contrast.
+ *
+ * @param {{r: number, g: number, b: number}} background
+ * @returns {"#000000" | "#FFFFFF"}
+ */
+function getMaximumContrastColor(background) {
+    const black = {
+        r: 0,
+        g: 0,
+        b: 0,
+    };
+
+    const white = {
+        r: 255,
+        g: 255,
+        b: 255,
+    };
+
+    return contrastRatio(black, background) >=
+        contrastRatio(white, background)
+        ? "#000000"
+        : "#FFFFFF";
+}
+
+/**
+ * Converts an RGB color into an uppercase hexadecimal string.
+ *
+ * @param {{r: number, g: number, b: number}} rgb
+ * @returns {string}
+ */
+function rgbToHex({ r, g, b }) {
+    const toHex = (component) =>
+        Math.round(clamp(component, 0, 255))
+            .toString(16)
+            .padStart(2, "0")
+            .toUpperCase();
+
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Converts an sRGB channel into linear-light RGB.
+ *
+ * @param {number} value
+ * @returns {number}
+ */
+function srgbToLinear(value) {
+    return value <= 0.04045
+        ? value / 12.92
+        : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+/**
+ * Converts a linear-light RGB channel into sRGB.
+ *
+ * @param {number} value
+ * @returns {number}
+ */
+function linearToSrgb(value) {
+    return value <= 0.0031308
+        ? 12.92 * value
+        : 1.055 *
+              Math.pow(value, 1 / 2.4) -
+              0.055;
+}
+
+/**
+ * Determines whether all RGB channels are inside the sRGB gamut.
+ *
+ * @param {{r: number, g: number, b: number}} rgb
+ * @returns {boolean}
+ */
+function isRgbInGamut({ r, g, b }) {
+    const epsilon = 1e-5;
+
+    return (
+        r >= -epsilon &&
+        r <= 255 + epsilon &&
+        g >= -epsilon &&
+        g <= 255 + epsilon &&
+        b >= -epsilon &&
+        b <= 255 + epsilon
+    );
+}
+
+/**
+ * Clamps RGB channels and returns an opaque color.
+ *
+ * @param {{r: number, g: number, b: number}} rgb
+ * @returns {{r: number, g: number, b: number, a: number}}
+ */
+function normalizeRgb({ r, g, b }) {
+    return {
+        r: clamp(r, 0, 255),
+        g: clamp(g, 0, 255),
+        b: clamp(b, 0, 255),
+        a: 1,
+    };
+}
+
+/**
+ * Linearly interpolates between two values.
+ *
+ * @param {number} start
+ * @param {number} end
+ * @param {number} amount
+ * @returns {number}
+ */
+function lerp(start, end, amount) {
+    return start + (end - start) * amount;
+}
+
+/**
+ * Restricts a number to the provided range.
+ *
+ * @param {number} value
+ * @param {number} minimum
+ * @param {number} maximum
+ * @returns {number}
+ */
+function clamp(value, minimum, maximum) {
+    return Math.min(
+        maximum,
+        Math.max(minimum, value)
+    );
+}
+
 // Dictionary to store Base64 textures for each light type
 let light_icons_b64 = {};
 
@@ -3598,6 +4634,7 @@ function initialize_light_plugin() {
         'dialog.preview_options.show_light_area_gizmos': 'Show Light Area Gizmos',
         'panel.light_properties': 'LIGHT',
         'property.light_settings': 'Light Settings',
+        'property.shadow_settings': 'Shadow Settings',
         'property.light_color': 'Light Color',
         'property.light_intensity': 'Intensity',
         'property.light_intensity.desc': 'The brightness of the light. Higher values produce brighter illumination.',
@@ -3606,9 +4643,12 @@ function initialize_light_plugin() {
         'property.light_type': 'Light Type',
         'property.light_type.point': 'Point',
         'property.light_type.directional': 'Directional',
+        'property.light_directional_settings.disabled.desc': 'Only for directional lights.',
         'property.light_type.spot': 'Spot',
+        'property.light_spot_settings.disabled.desc': 'Only for spot lights.',
         'property.distance': 'Distance',
         'property.distance.desc': 'Maximum range of the light. 0 means no limit.',
+        'property.light_cone_settings': 'Spot Cone Settings',
         'property.angle': 'Cone Angle',
         'property.angle.desc': 'Angle of the spot light cone in degrees.',
         'property.penumbra': 'Penumbra',
@@ -3617,16 +4657,17 @@ function initialize_light_plugin() {
         'property.cone_angle.desc': 'Angle of the spot light cone in degrees.',
         'property.cone_penumbra': 'Penumbra',
         'property.cone_penumbra.desc': 'Softness of the spot light cone edge (0 to 1).',
-        'property.light.viewport_tools': 'Viewport Tools',
-        'property.light.quickbuttons': 'Light',
-        'property.light.shadows': 'Shadows',
         'property.cast_shadows': 'Cast Shadows',
-        'property.shadow_near': 'Near',
-        'property.shadow_far': 'Far',
-        'property.shadow_bounds': 'Bounds',
-        'property.shadow_clip': 'Clip',
-        'property.shadow_area': 'Shadow Area',
+        'property.cast_shadows.desc': 'Whether the light casts shadows. Disabling can improve performance.',
+        'property.cast_shadows_off.desc': 'Cast Shadows is off.',
+        'property.shadow_near': 'Shadow Near',
+        'property.shadow_far': 'Shadow Far',
+        'property.shadow_bounds': 'Shadow Bounds',
+        'property.shadow_bounds.desc': 'Size of the shadow area for directional lights. Adjust to reduce shadow artifacts.',
+        'property.shadow_clip': 'Shadow Clip',
+        'property.shadow_clip.desc': 'Distance from the light where shadows start to be rendered. Adjust to reduce shadow artifacts.',
         'property.shadow_biases': 'Shadow Tuning',
+        'property.shadow_biases.desc': 'Adjust shadow depth to reduce artifacts.',
         'property.shadow_resolution': 'Resolution',
         'property.studio_shadow_resolution': 'Studio Shadow',
         'property.studio_shadow_resolution.desc': 'Shadow size used only while Studio Render captures. Same keeps the viewport resolution.',
@@ -3740,6 +4781,7 @@ function initialize_light_plugin() {
         'dialog.preview_options.show_light_area_gizmos': 'Mostrar gizmos de area de luz',
         'panel.light_properties': 'LUZ',
         'property.light_settings': 'Ajustes de luz',
+        'property.shadow_settings': 'Ajustes de sombras',
         'property.light_color': 'Color de luz',
         'property.light_intensity': 'Intensidad',
         'property.light_intensity.desc': 'Brillo de la luz. Valores mas altos producen mas iluminacion.',
@@ -3748,9 +4790,12 @@ function initialize_light_plugin() {
         'property.light_type': 'Tipo de luz',
         'property.light_type.point': 'Punto',
         'property.light_type.directional': 'Direccional',
+        'property.light_directional_settings.disabled.desc': 'Solo disponible para luces direccionales.',
         'property.light_type.spot': 'Spot',
+        'property.light_spot_settings.disabled.desc': 'Solo disponible para luces spot.',
         'property.distance': 'Distancia',
         'property.distance.desc': 'Rango maximo de la luz. 0 significa sin limite.',
+        'property.light_cone_settings': 'Ajustes del cono de luz',
         'property.angle': 'Angulo del cono',
         'property.angle.desc': 'Angulo del cono de la luz spot en grados.',
         'property.penumbra': 'Penumbra',
@@ -3759,16 +4804,17 @@ function initialize_light_plugin() {
         'property.cone_angle.desc': 'Angulo del cono de la luz spot en grados.',
         'property.cone_penumbra': 'Penumbra',
         'property.cone_penumbra.desc': 'Suavidad del borde del cono spot (0 a 1).',
-        'property.light.viewport_tools': 'Herramientas de viewport',
-        'property.light.quickbuttons': 'Luz',
-        'property.light.shadows': 'Sombras',
         'property.cast_shadows': 'Proyecta sombras',
-        'property.shadow_near': 'Cerca',
-        'property.shadow_far': 'Lejos',
-        'property.shadow_bounds': 'Area',
-        'property.shadow_clip': 'Recorte',
-        'property.shadow_area': 'Area de sombra',
-        'property.shadow_biases': 'Ajuste de sombra',
+        'property.cast_shadows.desc': 'Si la luz proyecta sombras. Desactivar puede mejorar el rendimiento.',
+        'property.cast_shadows_off.desc': 'La proyeccion de sombras esta desactivada.',
+        'property.shadow_near': 'Recorte Cercano',
+        'property.shadow_far': 'Recorte Lejano',
+        'property.shadow_bounds': 'Area de sombra',
+        'property.shadow_bounds.desc': 'Tamano del area de sombras para luces direccionales. Ajustalo para reducir artefactos.',
+        'property.shadow_clip': 'Recorte de sombra',
+        'property.shadow_clip.desc': 'Distancia desde la luz donde comienzan a renderizarse las sombras. Ajusta para reducir artefactos de sombra.',
+        'property.shadow_biases': 'Ajustes de sombra',
+        'property.shadow_biases.desc': 'Ajusta la profundidad de sombra para reducir artefactos.',
         'property.shadow_resolution': 'Resolucion',
         'property.studio_shadow_resolution': 'Sombra Studio',
         'property.studio_shadow_resolution.desc': 'Tamano de sombra usado solo durante capturas de Studio Render. Igual conserva la resolucion del preview.',
@@ -3880,6 +4926,7 @@ function initialize_light_plugin() {
 
 
     let deletables = [];
+    let lightManagerUIApi = null;
     let lightTextures = {}; // THREE.Texture instances will be loaded here
     let originalAnimatorPreview = null;
 
@@ -3925,6 +4972,182 @@ function initialize_light_plugin() {
         if (typeof light.dispose === 'function') light.dispose();
     }
 
+    /**
+     * Groups Blockbench form elements into horizontal rows.
+     * Intercepts `buildForm` to ensure the grouping survives any DOM updates/rebuilds.
+     * Supports Blockbench toolbar-style separators:
+     * '_' (vertical border), '-' (horizontal divider), '+' (spacer), and '#' (linebreak).
+     *
+     * @param {InputForm} form - The form instance (e.g., panel.form)
+     * @param {Array<Object>} groups - List of group configurations
+     * @param {Array<string>} groups[].elements - The IDs of the form elements and separators
+     * @param {string} [groups[].gap='8px'] - Flexbox gap between elements
+     * @param {Object} [groups[].flex={}] - Flexbox grow/shrink/basis rules per element ID
+     * @param {string} [groups[].divider_color='var(--color-elevated)'] - Color for '_' and '-' dividers
+     */
+    function applyIndestructibleFormGroups(form, groups) {
+        if (!form) return;
+        const separatorTokens = new Set(['_', '+', '#', '-']);
+        const isSeparator = id => typeof id === 'string' && separatorTokens.has(id);
+
+        const getFormBar = (formNode, id) => {
+            const directBar = form.form_data?.[id]?.bar;
+            if (directBar && directBar.nodeType === 1 && formNode.contains(directBar)) return directBar;
+            const className = `form_bar_${id}`;
+            return [...formNode.querySelectorAll('.dialog_bar, .full_width_dialog_bar')]
+                .find(node => node.classList.contains(className)) || null;
+        };
+
+        // Internal function that handles the visual restructuring
+        const groupElements = () => {
+            if (!form.node) return;
+            let formNode = form.node;
+
+            groups.forEach(config => {
+                let {
+                    elements,
+                    gap = '8px',
+                    flex = {},
+                    divider_color = 'var(--color-elevated)'
+                } = config;
+
+                if (!elements || elements.length === 0) return;
+
+                // Find the first actual form element to use as an insertion anchor (ignoring separators)
+                let firstRealId = elements.find(id => typeof id === 'string' && !isSeparator(id));
+                if (!firstRealId) return;
+
+                let firstBar = getFormBar(formNode, firstRealId);
+                if (!firstBar) return;
+
+                // Reuse an existing row after dynamic form rebuilds. Blockbench can preserve
+                // the first bar while replacing later bars, so returning early here would leave
+                // the replacement controls stacked vertically.
+                let row = firstBar.parentElement.classList.contains('form_row_group')
+                    ? firstBar.parentElement
+                    : null;
+                if (!row) {
+                    row = document.createElement('div');
+                    row.className = 'form_row_group full_width_dialog_bar';
+                    firstBar.parentNode.insertBefore(row, firstBar);
+                }
+                row.querySelectorAll(':scope > .light_manager_form_separator').forEach(separator => separator.remove());
+                row.style.display = 'flex';
+                row.style.alignItems = 'center';
+                row.style.gap = gap;
+                row.style.width = '100%';
+                row.style.background = 'transparent';
+                row.style.padding = '0';
+                row.style.boxSizing = 'border-box';
+
+                // Move elements and separators into the row
+                elements.forEach(id => {
+                    // Check if the item is a separator/spacer
+                    if (isSeparator(id)) {
+                        let char = id.substring(0, 1);
+                        let sep = document.createElement('div');
+
+                        let typeClass = '';
+                        if (char === '_') typeClass = 'border';
+                        else if (char === '+') typeClass = 'spacer';
+                        else if (char === '#') typeClass = 'linebreak';
+                        else if (char === '-') typeClass = 'horizontal_divider';
+
+                        sep.className = `toolbar_separator light_manager_form_separator ${typeClass}`;
+
+                        if (char === '+') {
+                            // Spacer: flexes to push elements apart
+                            sep.style.flex = '1 1 auto';
+                            sep.style.minWidth = '0px';
+                        } else if (char === '_') {
+                            // Border: renders a vertical line
+                            sep.style.flex = '0 0 auto';
+                            sep.style.height = '24px';
+                            sep.style.width = '2px';
+                            sep.style.backgroundColor = divider_color;
+                            sep.style.margin = '0 4px';
+                        } else if (char === '-') {
+                            // Horizontal divider: renders a full-width horizontal line and forces a line break
+                            sep.style.flex = '1 1 100%';
+                            sep.style.height = '2px';
+                            sep.style.backgroundColor = divider_color;
+                            sep.style.margin = '4px 0';
+                            row.style.flexWrap = 'wrap'; // Ensure the row allows wrapping
+                        } else if (char === '#') {
+                            // Linebreak: forces next items to a new line inside the flex container
+                            sep.style.flex = '1 1 100%';
+                            sep.style.height = '0';
+                            row.style.flexWrap = 'wrap';
+                        }
+
+                        row.appendChild(sep);
+                        return;
+                    }
+
+                    // Handle normal form elements
+                    let bar = getFormBar(formNode, id);
+                    if (bar) {
+                        bar.style.padding = '0';
+                        bar.style.margin = '0';
+                        bar.style.border = 'none';
+                        bar.style.minHeight = '0';
+                        bar.style.flex = flex[id] !== undefined ? flex[id] : '1 1 auto';
+                        row.appendChild(bar);
+                    }
+                });
+            });
+        };
+
+        // 1. Apply immediately (for initial creation)
+        groupElements();
+
+        // 2. MAGIC: Intercept the original buildForm method
+        let originalBuildForm = form.buildForm;
+        form.buildForm = function (...args) {
+            // Let Blockbench build the entire form natively first
+            const response = originalBuildForm.apply(this, args);
+
+            // Re-apply our groups immediately after
+            groupElements();
+            return response;
+        };
+    }
+
+    function getLightManagerMarkerColor(index, tone = 'pastel', fallback = 'var(--color-accent)') {
+        const palette = globalThis.markerColors;
+        const entry = Array.isArray(palette) ? palette[index] : null;
+        return entry?.[tone] || entry?.pastel || entry?.standard || fallback;
+    }
+
+    function addLightManagerCompactPanelStyles(panelId) {
+        const safeId = String(panelId || '').replace(/[^a-z0-9_-]/gi, '');
+        if (!safeId || typeof Blockbench?.addCSS !== 'function') return null;
+        const selector = `#panel_${safeId}`;
+        return Blockbench.addCSS(`
+            ${selector} {
+                overflow-y: auto !important;
+                overflow-x: hidden;
+                background: var(--color-ui);
+            }
+            ${selector} .dialog_bar,
+            ${selector} .full_width_dialog_bar {
+                margin-top: 0;
+                margin-bottom: 0;
+            }
+            ${selector} .form_row_group {
+                min-width: 0;
+                min-height: 30px;
+            }
+            ${selector}::-webkit-scrollbar {
+                width: 6px;
+            }
+            ${selector}::-webkit-scrollbar-thumb {
+                background-color: var(--color-button);
+                border-radius: 3px;
+            }
+        `);
+    }
+
     Plugin.register('light_manager', {
         title: 'Light Manager',
         icon: 'light_mode',
@@ -3938,12 +5161,202 @@ function initialize_light_plugin() {
         onload() {
             disposeLightManagerResources();
             cleanupLightManagerRegistries();
-            resetLightManagerStoredToolbarLayouts();
+            removeLightManagerLegacyStoredToolbarLayouts();
             restoreLightManagerRendererShadowSettings();
             restoreLightManagerAnimatorPreview();
             resetLightManagerShadowState();
             window.LightManagerMarkShadowsDirty = markLightManagerShadowsDirty;
             patchLightManagerAnimatorPreview();
+
+            // Shared condition/disabled-state support for Light Manager custom FormElements.
+            // `show_condition` is normalized to Blockbench's native form condition path. The
+            // custom disabled path joins the same form.update pass instead of adding event listeners.
+            const ensureLightManagerFormStateBridge = (form) => {
+                if (form._lightManagerFormStateBridge) return form._lightManagerFormStateBridge;
+
+                const updaters = new Map();
+                const originalUpdate = form.update;
+                const originalBuildForm = form.buildForm;
+
+                form.update = function (formResult) {
+                    const result = formResult === undefined ? this.getResult() : formResult;
+                    const response = originalUpdate.call(this, result);
+                    for (const updateElementState of updaters.values()) {
+                        updateElementState({ result, cause: 'form_update' });
+                    }
+                    return response;
+                };
+                form.buildForm = function (...args) {
+                    updaters.clear();
+                    const response = originalBuildForm.apply(this, args);
+                    this.update();
+                    return response;
+                };
+
+                form._lightManagerFormStateBridge = { updaters };
+                return form._lightManagerFormStateBridge;
+            };
+            const setupLightManagerFormElementState = (element) => {
+                const data = element.options || {};
+                const bridge = ensureLightManagerFormStateBridge(element.form);
+
+                if (data.show_condition !== undefined) {
+                    data.condition = data.show_condition;
+                    element.condition = data.show_condition;
+                }
+
+                const hasDynamicDisable = data.disable_condition !== undefined && typeof data.disable_condition !== 'boolean';
+                const hasStaticDisable = !!data.disable || data.disable_condition === true;
+                element.is_disabled = false;
+                if (!hasDynamicDisable && !hasStaticDisable) return;
+
+                const roots = [...new Set([
+                    element.node,
+                    element.slider_node,
+                    element.inputs_container,
+                    element.toggle_btn,
+                    element.colorpicker && element.colorpicker.node,
+                    element.popup_panel
+                ].filter(node => node && node.nodeType === 1))];
+                const controls = [...new Set(roots.flatMap(root => {
+                    const found = [...root.querySelectorAll('input, button, select, textarea, [contenteditable], .nslide')];
+                    if (/^(INPUT|BUTTON|SELECT|TEXTAREA)$/.test(root.tagName) || root.hasAttribute('contenteditable') || root.classList.contains('nslide')) {
+                        found.unshift(root);
+                    }
+                    return found;
+                }))];
+                const disabledIconColor = data.disable_icon_color || data.disabled_icon_color || data.disable_color;
+                const icons = disabledIconColor ? [...new Set(roots.flatMap(root => {
+                    const found = [...root.querySelectorAll('.material-icons, .fa, .fas, .far, .fab')];
+                    if (root.classList.contains('material-icons') || root.classList.contains('fa')) found.unshift(root);
+                    return found;
+                }))] : [];
+                const defaultFilter = ['combo_slider', 'compact_select', 'horizontal_select', 'compact_text', 'custom_checkbox', 'action_toggle', 'action_button', 'custom_vector'].includes(data.type)
+                    ? 'grayscale(100%)'
+                    : 'none';
+                const rootStyles = new Map(roots.map(root => [root, {
+                    opacity: root.style.opacity,
+                    filter: root.style.filter,
+                    cursor: root.style.cursor,
+                    pointerEvents: root.style.pointerEvents
+                }]));
+                const controlStates = new Map(controls.map(control => [control, {
+                    disabled: 'disabled' in control ? control.disabled : false,
+                    contenteditable: control.getAttribute('contenteditable')
+                }]));
+                const rootTitles = new Map();
+                const iconColors = new Map();
+                let lastTooltip;
+
+                const translateText = (text, result) => {
+                    if (typeof text === 'function') text = text(result, element);
+                    if (text === undefined || text === null) return '';
+                    return typeof tl === 'function' ? tl(text) : String(text);
+                };
+                const evaluate = (condition, result, fallback) => {
+                    try {
+                        return !!Condition(condition, result);
+                    } catch (error) {
+                        return fallback;
+                    }
+                };
+                const updateTooltip = (disabled, result) => {
+                    const disableDesc = disabled ? translateText(data.disable_desc, result) : '';
+                    const tooltip = disableDesc || translateText(data.description, result);
+                    if (tooltip === lastTooltip) return;
+                    element.bar.title = tooltip;
+                    if (disabled && disableDesc) {
+                        for (const root of roots) root.title = disableDesc;
+                    }
+                    lastTooltip = tooltip;
+                };
+                const applyDisabledState = (disabled, result) => {
+                    disabled = !!disabled;
+                    const previousDisabled = element.is_disabled;
+                    if (disabled === previousDisabled) {
+                        updateTooltip(disabled, result);
+                        return;
+                    }
+
+                    const effectEnabled = data.disable_effect !== false;
+                    const disabledOpacity = effectEnabled
+                        ? (data.disable_opacity !== undefined ? String(data.disable_opacity) : '0.5')
+                        : '1';
+                    const disabledFilter = effectEnabled
+                        ? (data.disable_filter !== undefined ? String(data.disable_filter) : defaultFilter)
+                        : 'none';
+
+                    if (disabled && element.closePopup && element._isOpen) {
+                        element.closePopup({ type: 'mousedown', target: document.body });
+                    }
+
+                    for (const root of roots) {
+                        const original = rootStyles.get(root);
+                        root.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+                        root.classList.toggle('form_element_disabled', disabled);
+                        if (disabled) {
+                            rootTitles.set(root, root.title);
+                            root.style.opacity = disabledOpacity;
+                            root.style.filter = disabledFilter;
+                            root.style.cursor = 'not-allowed';
+                            root.style.pointerEvents = data.disable_pointer_events === false ? original.pointerEvents : 'none';
+                        } else {
+                            root.style.opacity = original.opacity;
+                            root.style.filter = original.filter;
+                            root.style.cursor = original.cursor;
+                            root.style.pointerEvents = original.pointerEvents;
+                            if (rootTitles.has(root)) root.title = rootTitles.get(root);
+                        }
+                    }
+
+                    for (const control of controls) {
+                        const original = controlStates.get(control);
+                        if ('disabled' in control) control.disabled = disabled || original.disabled;
+                        if (control.hasAttribute('contenteditable')) {
+                            control.setAttribute('contenteditable', disabled ? 'false' : (original.contenteditable || 'false'));
+                        }
+                        control.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+                    }
+
+                    for (const icon of icons) {
+                        if (disabled) {
+                            iconColors.set(icon, icon.style.color || '');
+                            icon.style.color = disabledIconColor;
+                        } else if (iconColors.has(icon)) {
+                            icon.style.color = iconColors.get(icon);
+                        }
+                    }
+
+                    if (element.colorpicker && element.colorpicker.jq && typeof element.colorpicker.jq.spectrum === 'function') {
+                        try {
+                            element.colorpicker.jq.spectrum(disabled ? 'disable' : 'enable');
+                        } catch (error) {
+                            // Pointer events and native input state remain as the safe fallback.
+                        }
+                    }
+
+                    element.is_disabled = disabled;
+                    if (!disabled && previousDisabled && typeof element.updateVisuals === 'function') {
+                        element.updateVisuals(false);
+                    }
+                    updateTooltip(disabled, result);
+                };
+                const updateState = (event) => {
+                    const result = event && event.result !== undefined ? event.result : element.form.getResult();
+                    const conditionalDisable = hasDynamicDisable
+                        ? evaluate(data.disable_condition, result, true)
+                        : false;
+                    applyDisabledState(hasStaticDisable || conditionalDisable, result);
+                };
+
+                element.applyDisabledState = (disabled) => applyDisabledState(disabled, element.form.getResult());
+                element._lightManagerFormStateUpdate = updateState;
+                if (hasDynamicDisable) {
+                    bridge.updaters.set(element.id, updateState);
+                } else {
+                    updateState();
+                }
+            };
 
             class ComboSlider extends Widget {
                 constructor(id, data) {
@@ -3995,6 +5408,8 @@ function initialize_light_plugin() {
                     if (!this.settings.allow_higher) numberInputOptions.max = this.settings.max;
 
                     let numberInput = Interface.createElement('input', numberInputOptions);
+                    this.rangeInput = rangeInput;
+                    this.numberInput = numberInput;
 
                     let numberContainer = Interface.createElement('div', {
                         class: 'numeric_input tool disp_text',
@@ -4003,7 +5418,7 @@ function initialize_light_plugin() {
 
                     let comboWrapper = Interface.createElement('div', {
                         class: 'bar slider_input_combo',
-                        title: data.title ? tl(data.title) : '',
+                        title: data.description ? (typeof tl !== 'undefined' ? tl(data.description) : data.description) : (data.title ? (typeof tl !== 'undefined' ? tl(data.title) : data.title) : ''),
                         style: `display: flex;align-items: center;height: 100%;margin: 0 5px;flex: 1 1 auto;min-width: 0;width: auto; `
                     }, [rangeInput, numberContainer]);
 
@@ -4024,8 +5439,19 @@ function initialize_light_plugin() {
                     if (data.label) {
                         let labelElement = Interface.createElement('span', {
                             style: 'margin-right: 5px; font-size: 13px; color: var(--color-subtle_text); white-space: nowrap; display: flex; align-items: center;'
-                        }, tl(data.label));
+                        }, typeof tl !== 'undefined' ? tl(data.label) : data.label);
                         containerChildren.push(labelElement);
+
+                        // Añadir icono de ayuda con la descripción
+                        if (data.description) {
+                            let infoIcon = Interface.createElement('i', {
+                                class: 'fa fa-question dialog_form_description',
+                                title: typeof tl !== 'undefined' ? tl(data.description) : data.description,
+                                style: 'font-size: 14px; cursor: help; margin-right: 5px; color: var(--color-subtle_text); display: flex; align-items: center;'
+                            });
+                            containerChildren.push(infoIcon);
+                            comboWrapper.title = '';
+                        }
                     }
 
                     containerChildren.push(comboWrapper);
@@ -4072,6 +5498,9 @@ function initialize_light_plugin() {
                     if (typeof data.onAfter === 'function') {
                         this.onAfter = data.onAfter;
                     }
+                    this.onDrag = typeof data.onDrag === 'function'
+                        ? data.onDrag
+                        : (typeof data.onMove === 'function' ? data.onMove : null);
 
                     // Keep both inputs synchronized.
                     let $inputs = $(this.node).find('input');
@@ -4083,6 +5512,9 @@ function initialize_light_plugin() {
                         if (isNaN(val)) return;
                         let is_number_input = event.target === $number[0];
                         scope.change(val, event.originalEvent, is_number_input);
+                        if (scope.onDrag && (scope.isDragging || event.target === $range[0])) {
+                            scope.onDrag(val, event.originalEvent, is_number_input);
+                        }
                     });
 
                     $number.on('blur', function (event) {
@@ -4157,6 +5589,27 @@ function initialize_light_plugin() {
                     }
                 }
 
+                setResetValue(value, refreshButton = true) {
+                    this.settings.reset_value = value;
+                    if (refreshButton) {
+                        this.updateResetButton();
+                    }
+                    return this;
+                }
+
+                setColor(color) {
+                    const normalizedColor = color || '';
+                    if (this.rangeInput) {
+                        this.rangeInput.style.setProperty('--color-thumb', normalizedColor);
+                        this.rangeInput.style.accentColor = normalizedColor;
+                        this.rangeInput.style.color = normalizedColor;
+                    }
+                    if (this.resetBtn) {
+                        this.resetBtn.style.color = normalizedColor || 'var(--color-subtle_text)';
+                    }
+                    return this;
+                }
+
                 change(value, event, skip_number_input_update = false) {
                     if (!this.settings.allow_lower && value < this.settings.min) {
                         value = this.settings.min;
@@ -4219,6 +5672,7 @@ function initialize_light_plugin() {
                     this.values = [];
                     this.options = data.options || {};
                     this.onChange = data.onChange;
+                    this.description = data.description || data.title || '';
 
                     // Collect available option keys.
                     for (let key in this.options) {
@@ -4309,8 +5763,11 @@ function initialize_light_plugin() {
                     this.value = key;
                     let opt = this.options[key];
 
-                    // Tooltip includes the widget name and current option.
-                    this.node.title = `${this.name ? this.name + ': ' : ''}${opt.name || key}`;
+                    // Tooltip includes the widget name, current option y la descripción si existe.
+                    let baseName = this.name ? this.name + ': ' : '';
+                    let optName = opt.name || key;
+                    let desc = this.description ? '\n' + (typeof tl !== 'undefined' ? tl(this.description) : this.description) : '';
+                    this.node.title = `${baseName}${optName}${desc}`;
 
                     // Replace the visible icon in every widget instance.
                     this.nodes.forEach(n => {
@@ -4385,6 +5842,7 @@ function initialize_light_plugin() {
                     this.expand = !!data.expand;
                     this.text_alignment = data.text_alignment || 'left';
                     this.onUpdate = data.onUpdate;
+                    this.description = data.description || data.title || '';
 
                     // DOM node.
                     this.node = document.createElement('div');
@@ -4474,6 +5932,15 @@ function initialize_light_plugin() {
                 }
 
                 /**
+                 * Updates the description tooltip.
+                 */
+                setDescription(desc) {
+                    this.description = desc;
+                    this.buildDOM();
+                    return this;
+                }
+
+                /**
                  * Updates the icon dynamically.
                  */
                 setIcon(icon) {
@@ -4532,6 +5999,7 @@ function initialize_light_plugin() {
                     this.icon_name = data.icon || '';
                     this.expand = data.expand || false;
                     this.width = typeof data.width === 'number' ? data.width + 'px' : (data.width || '120px');
+                    this.description = data.description || data.title || '';
 
                     // Callbacks
                     this.onEdit = data.onEdit;
@@ -4541,6 +6009,10 @@ function initialize_light_plugin() {
                     this.node = document.createElement('div');
                     this.node.className = 'tool wide widget text_input_widget';
                     this.node.setAttribute('toolbar_item', this.id);
+
+                    if (this.description) {
+                        this.node.title = typeof tl !== 'undefined' ? tl(this.description) : this.description;
+                    }
 
                     // Styling the container to blend with Blockbench toolbars
                     this.node.style.display = 'flex';
@@ -4657,7 +6129,7 @@ function initialize_light_plugin() {
 
                 /**
                  * Set the text value programmatically
-                 * @param {string} text 
+                 * @param {string} text
                  */
                 set(text) {
                     this.value = text;
@@ -4669,7 +6141,7 @@ function initialize_light_plugin() {
 
                 /**
                  * Change the placeholder dynamically
-                 * @param {string} text 
+                 * @param {string} text
                  */
                 setPlaceholder(text) {
                     this.placeholder = text;
@@ -4681,7 +6153,7 @@ function initialize_light_plugin() {
 
                 /**
                  * Adjust the width of the widget
-                 * @param {number} width 
+                 * @param {number} width
                  */
                 setWidth(width) {
                     this.width = width;
@@ -4709,253 +6181,6 @@ function initialize_light_plugin() {
 
             window.TextInputWidget = TextInputWidget;
 
-            class HorizontalSelectWidget extends Widget {
-                constructor(id, data) {
-                    if (typeof id === 'object') {
-                        data = id;
-                        id = data.id;
-                    }
-                    super(id, data);
-
-                    this.type = 'horizontal_select';
-
-                    // Settings
-                    this.options = data.options || {};
-                    this.selected = []; // Internally we always use an array to support multi-select
-                    this.expand = !!data.expand;
-                    this.bg_color = data.bg_color || 'var(--color-back)';
-                    this.divider_color = data.divider_color || 'var(--color-border)';
-                    this.allow_empty = data.allow_empty !== undefined ? data.allow_empty : true;
-
-                    // Callbacks
-                    this.onSelect = data.onSelect;
-                    this.onChange = data.onChange;
-
-                    // Ensure default selection
-                    if (data.value !== undefined) {
-                        this.selected = Array.isArray(data.value) ? [...data.value] : [data.value];
-                    } else if (!this.allow_empty && Object.keys(this.options).length > 0) {
-                        this.selected = [Object.keys(this.options)[0]];
-                    }
-
-                    // Main Container Node
-                    this.node = document.createElement('div');
-                    this.node.className = 'tool widget horizontal_select_widget';
-                    this.node.setAttribute('toolbar_item', this.id);
-
-                    // Container Styles
-                    this.node.style.backgroundColor = this.bg_color;
-                    this.node.style.border = `1px solid ${this.divider_color}`;
-
-                    if (this.expand) {
-                        this.node.style.flex = '1 1 auto';
-                        this.node.style.width = '100%';
-                    } else {
-                        this.node.style.flex = '0 0 auto';
-                        this.node.style.display = 'inline-flex';
-                    }
-
-                    this.nodes = [this.node];
-                    this.button_nodes = {}; // Store references to individual buttons
-
-                    this.buildDOM();
-                    this.updateSelectionVisuals();
-                }
-
-                /**
-                 * Builds the buttons and dividers inside the main container
-                 */
-                buildDOM() {
-                    this.node.innerHTML = '';
-                    this.button_nodes = {};
-
-                    let keys = Object.keys(this.options);
-
-                    keys.forEach((key, index) => {
-                        let opt = this.options[key];
-
-                        // Create Button Wrapper
-                        let btn = document.createElement('div');
-                        btn.className = 'horizontal_select_btn';
-                        btn.setAttribute('data-key', key);
-
-                        if (this.expand) {
-                            btn.style.flex = '1 1 0';
-                        }
-
-                        // Divider logic
-                        if (index < keys.length - 1) {
-                            btn.style.borderRight = `1px solid ${this.divider_color}`;
-                        }
-
-                        // Disable State
-                        if (opt.disabled) {
-                            btn.classList.add('disabled');
-                        }
-
-                        // Custom Colors (Only applied when NOT selected, CSS handles the selected state)
-                        if (opt.color) {
-                            btn.style.color = opt.color;
-                        }
-
-                        // Icon Element
-                        let hasIcon = !!opt.icon;
-                        let hasName = !!opt.name;
-
-                        if (!hasName) btn.classList.add('icon_only');
-
-                        if (hasIcon) {
-                            let iconElement = Blockbench.getIconNode(opt.icon);
-                            iconElement.classList.add('horizontal_select_icon');
-                            btn.appendChild(iconElement);
-                        }
-
-                        // Text Label Element
-                        if (hasName) {
-                            let labelElement = document.createElement('span');
-                            labelElement.className = 'horizontal_select_label';
-                            labelElement.innerText = tl(opt.name); // Using tl() for Blockbench localization
-                            btn.appendChild(labelElement);
-                        }
-
-                        // Tooltip
-                        if (opt.description || hasName) {
-                            btn.title = opt.description ? tl(opt.description) : tl(opt.name);
-                        }
-
-                        // Click Event Listener
-                        btn.addEventListener('click', (event) => {
-                            if (this.options[key].disabled) return;
-                            this.handleInteraction(key, event);
-                        });
-
-                        this.button_nodes[key] = btn;
-                        this.node.appendChild(btn);
-                    });
-                }
-
-                /**
-                 * Handles user clicks, taking Ctrl/Shift modifiers into account
-                 */
-                handleInteraction(key, event) {
-                    let isMulti = event.ctrlKey || event.shiftKey;
-
-                    if (isMulti) {
-                        // Toggle selection
-                        if (this.selected.includes(key)) {
-                            if (this.allow_empty || this.selected.length > 1) {
-                                this.selected = this.selected.filter(k => k !== key);
-                            }
-                        } else {
-                            this.selected.push(key);
-                        }
-                    } else {
-                        // Single select: If clicking the only selected item, optionally allow deselect
-                        if (this.selected.length === 1 && this.selected[0] === key) {
-                            if (this.allow_empty) {
-                                this.selected = [];
-                            }
-                        } else {
-                            this.selected = [key];
-                        }
-                    }
-
-                    this.updateSelectionVisuals();
-
-                    let returnValue = this.get();
-                    if (this.onSelect) this.onSelect(returnValue, event);
-                    if (this.onChange) this.onChange(returnValue, event);
-                    this.dispatchEvent('change', { value: returnValue, event });
-                }
-
-                /**
-                 * Updates the CSS classes for selected buttons
-                 */
-                updateSelectionVisuals() {
-                    for (let key in this.button_nodes) {
-                        let btn = this.button_nodes[key];
-                        if (this.selected.includes(key)) {
-                            btn.classList.add('selected');
-                            btn.style.color = ''; // Remove custom color so accent stands out
-                        } else {
-                            btn.classList.remove('selected');
-                            if (this.options[key].color) {
-                                btn.style.color = this.options[key].color; // Restore custom color
-                            }
-                        }
-                    }
-                }
-
-                /**
-                 * Set the selected options programmatically
-                 * @param {string|Array<string>} value - Key or array of keys to select
-                 */
-                set(value) {
-                    if (!value && this.allow_empty) {
-                        this.selected = [];
-                    } else {
-                        this.selected = Array.isArray(value) ? [...value] : [value];
-                        // Filter out non-existent keys
-                        this.selected = this.selected.filter(k => this.options[k]);
-                    }
-                    this.updateSelectionVisuals();
-                    return this;
-                }
-
-                /**
-                 * Returns the selected key(s). 
-                 * Returns a string if only one item is selected, or an Array if multiple are selected.
-                 */
-                get() {
-                    if (this.selected.length === 0) return null;
-                    if (this.selected.length === 1) return this.selected[0];
-                    return [...this.selected];
-                }
-
-                /**
-                 * Enable or disable a specific option
-                 * @param {string} key - Option key
-                 * @param {boolean} disabled - True to disable, false to enable
-                 */
-                setDisabled(key, disabled = true) {
-                    if (this.options[key]) {
-                        this.options[key].disabled = disabled;
-                        if (this.button_nodes[key]) {
-                            if (disabled) {
-                                this.button_nodes[key].classList.add('disabled');
-                                // Remove from selection if disabled
-                                if (this.selected.includes(key)) {
-                                    this.selected = this.selected.filter(k => k !== key);
-                                    this.updateSelectionVisuals();
-                                }
-                            } else {
-                                this.button_nodes[key].classList.remove('disabled');
-                            }
-                        }
-                    }
-                    return this;
-                }
-
-                /**
-                 * Replaces all options and rebuilds the widget
-                 */
-                setOptions(newOptions) {
-                    this.options = newOptions || {};
-                    this.selected = this.selected.filter(k => this.options[k]);
-                    this.buildDOM();
-                    this.updateSelectionVisuals();
-                    return this;
-                }
-
-                update() {
-                    let condition_met = Condition(this.condition);
-                    this.node.style.display = condition_met ? (this.expand ? 'flex' : 'inline-flex') : 'none';
-                    this.dispatchEvent('update', {});
-                    return this;
-                }
-            }
-
-            window.HorizontalSelectWidget = HorizontalSelectWidget;
 
             // 1. Estilos CSS ultra-optimizados para encajar en el ancho fijo del Spectrum
             const advancedColorPickerStyles = Blockbench.addCSS(`
@@ -5049,7 +6274,7 @@ function initialize_light_plugin() {
                     this.jq.spectrum({
                         preferredFormat: "hex",
                         color: this.value.toHex8String(),
-                        showAlpha: true,
+                        showAlpha: data.alpha !== undefined ? data.alpha : true,
                         showInput: true,
                         maxSelectionSize: 128,
                         // Match the native picker: hidden by default.
@@ -5073,6 +6298,7 @@ function initialize_light_plugin() {
                             scope.handleMove(c, false);
                         }
                     });
+
                 }
 
                 injectAdvancedUI() {
@@ -5245,7 +6471,7 @@ function initialize_light_plugin() {
             // 3. MARK: FormElement AdvancedColor
             FormElement.types.advanced_color = class FormElementAdvancedColor extends FormElement {
 
-                get uses_wide_inputs() { return true; }
+                get uses_wide_inputs() { return false; }
 
                 setup() {
                     let tempDesc = this.options.description;
@@ -5265,6 +6491,12 @@ function initialize_light_plugin() {
                     bar.style.gap = '8px';
 
                     let data = this.options;
+                    let helpText = '';
+                    if (data.description) {
+                        helpText = tl(data.description);
+                    } else if (data.title) {
+                        helpText = tl(data.title);
+                    }
 
                     if (data.label) {
                         let labelWrapper = document.createElement('div');
@@ -5275,11 +6507,11 @@ function initialize_light_plugin() {
                         labelElement.innerText = tl(data.label);
                         labelWrapper.append(labelElement);
 
-                        if (data.description) {
+                        if (helpText) {
                             let infoIcon = document.createElement('i');
                             infoIcon.className = 'fa fa-question dialog_form_description';
                             infoIcon.style = 'font-size: 14px; cursor: help; margin: 0; color: var(--color-subtle_text);';
-                            infoIcon.title = tl(data.description);
+                            infoIcon.title = helpText;
                             labelWrapper.append(infoIcon);
                         }
                         bar.append(labelWrapper);
@@ -5298,12 +6530,13 @@ function initialize_light_plugin() {
                             },
                             onChange: (tinycolor) => {
                                 this.change();
-                            }
+                            },
+                            alpha: data.alpha !== undefined ? data.alpha : true
                         });
                     }
 
-                    this.colorpicker.node.style.flex = '1 1 auto';
-                    this.colorpicker.node.style.width = '100%';
+                    this.colorpicker.node.style.flex = '0 0 auto';
+                    this.colorpicker.node.style.width = 'auto';
                     this.colorpicker.node.style.margin = '0';
 
                     bar.append(this.colorpicker.getNode());
@@ -5322,9 +6555,8 @@ function initialize_light_plugin() {
                 }
             };
 
-            // MARK: Combo Slider
+            // MARK: Combo Slider Form Element
             FormElement.types.combo_slider = class FormElementComboSlider extends FormElement {
-                // Al devolver 'true', evitamos que Blockbench divida la fila en "Label Izquierda | Input Derecha"
                 get uses_wide_inputs() { return true; }
 
                 setup() {
@@ -5336,14 +6568,18 @@ function initialize_light_plugin() {
 
                 build(bar) {
                     this.bar = bar;
-                    // Make it fill the toolbar width without native margins.
-                    bar.classList.add('full_width_dialog_bar');
-                    bar.style.padding = '0';
-                    bar.style.background = 'transparent';
 
                     let data = this.options;
                     this.value = data.value !== undefined ? data.value : (data.default !== undefined ? data.default : 0);
                     this.isDragging = false;
+                    this.is_compact = !!data.compact; // COMPACT MODE
+
+                    // Almacenar callbacks
+                    this.onBefore = typeof data.onBefore === 'function' ? data.onBefore : null;
+                    this.onAfter = typeof data.onAfter === 'function' ? data.onAfter : null;
+                    this.onDrag = typeof data.onDrag === 'function'
+                        ? data.onDrag
+                        : (typeof data.onMove === 'function' ? data.onMove : null);
 
                     this.settings = {
                         min: data.min !== undefined ? data.min : 0,
@@ -5356,7 +6592,7 @@ function initialize_light_plugin() {
                         reset_value: data.reset_value !== undefined ? data.reset_value : this.value
                     };
 
-                    // Inputs.
+                    // --- 1. BUILD THE INTERNAL SLIDER UI ---
                     let rangeInput = Interface.createElement('input', {
                         type: 'range',
                         value: this.value,
@@ -5367,35 +6603,41 @@ function initialize_light_plugin() {
                         style: `margin: 0;flex: 1 1 auto;width: 100%;min-width: 30px;transition: opacity 0.2s, filter 0.2s;${data.color ? '--color-thumb: ' + data.color + ';' : ''}`
                     });
 
+                    // Usamos type="text" con inputmode, como lo hace Blockbench para evitar que
+                    // los botones nativos del navegador estorben visualmente al ícono "<>".
                     let numberInputOptions = {
-                        type: 'number',
+                        type: 'text',
+                        inputmode: this.settings.min >= 0 ? 'decimal' : '',
+                        lang: 'en',
                         value: this.value,
-                        step: this.settings.step,
                         class: 'dark_bordered focusable_input',
-                        style: `width: 100%;min-width: 45px;height: 24px;box-sizing: border-box;text-align: center;margin: 0;padding: 0 2px;flex: 0 0 auto;`
+                        style: `width: 100%;min-width: 45px;height: 24px;box-sizing: border-box;text-align: center;margin: 0;padding-right: 18px;`
                     };
 
-                    if (!this.settings.allow_lower) numberInputOptions.min = this.settings.min;
-                    if (!this.settings.allow_higher) numberInputOptions.max = this.settings.max;
-
                     let numberInput = Interface.createElement('input', numberInputOptions);
+                    this.rangeInput = rangeInput;
+                    this.numberInput = numberInput;
+
+                    let numSliderIcon = Interface.createElement('div', {
+                        class: 'tool numeric_input_slider'
+                    }, [
+                        Interface.createElement('i', { class: 'material-icons' }, 'code')
+                    ]);
 
                     let numberContainer = Interface.createElement('div', {
                         class: 'numeric_input tool disp_text',
-                        style: `display: flex;align-items: center;margin: 0;flex: 0 0 auto;`
-                    }, [numberInput]);
+                        style: `margin: 0; flex: 0 0 auto; position: relative;`
+                    }, [numberInput, numSliderIcon]);
 
                     let comboWrapper = Interface.createElement('div', {
                         class: 'bar slider_input_combo',
-                        title: data.description ? tl(data.description) : '',
                         style: `display: flex;align-items: center;height: 100%;margin: 0 5px;flex: 1 1 auto;min-width: 0;width: auto;`
                     }, [rangeInput, numberContainer]);
 
-                    // Final widget layout.
                     let containerChildren = [];
 
-                    // Optional left-aligned icon.
-                    if (data.icon) {
+                    // Internal label and icon
+                    if (data.icon && !this.is_compact) {
                         let isFa = data.icon.startsWith('fa-') || data.icon.startsWith('fas ') || data.icon.startsWith('fab ');
                         let iconElement = Interface.createElement('i', {
                             class: isFa ? `fa ${data.icon}` : 'material-icons',
@@ -5404,54 +6646,229 @@ function initialize_light_plugin() {
                         containerChildren.push(iconElement);
                     }
 
-                    // Inline label.
                     if (data.label) {
-                        let labelElement = Interface.createElement('span', {
+                        let labelOptions = {
                             style: 'margin-right: 5px; font-size: 13px; color: var(--color-subtle_text); white-space: nowrap; display: flex; align-items: center;'
-                        }, tl(data.label));
+                        };
+                        if (data.description) {
+                            labelOptions.title = typeof tl !== 'undefined' ? tl(data.description) : data.description;
+                            labelOptions.style += ' cursor: help;';
+                        }
+                        let labelElement = Interface.createElement('span', labelOptions, typeof tl !== 'undefined' ? tl(data.label) : data.label);
                         containerChildren.push(labelElement);
+                    }
+
+                    if (!data.label && data.description) {
+                        comboWrapper.title = typeof tl !== 'undefined' ? tl(data.description) : data.description;
                     }
 
                     containerChildren.push(comboWrapper);
 
-                    // Reset button.
                     if (this.settings.resettable) {
                         this.resetBtn = Interface.createElement('i', {
                             class: 'material-icons icon',
-                            title: translateLightManager('light_manager.generic.reset'),
+                            title: 'Reset',
                             style: `font-size: 18px;cursor: pointer;display: none;margin-left: 2px;color: var(--color-subtle_text);display: flex;align-items: center;`
                         }, 'replay');
 
                         this.resetBtn.onclick = (e) => {
-                            this.setValue(this.settings.reset_value);
-                            this.change();
+                            if (this.is_disabled) return;
+                            if (this.onBefore) this.onBefore(e);
+                            this.setValue(this.settings.reset_value, true);
+                            if (this.onAfter) this.onAfter(e);
                         };
-
                         containerChildren.push(this.resetBtn);
                     }
 
-                    // Root container.
-                    this.node = Interface.createElement('div', {
+                    // Main slider container
+                    this.slider_node = Interface.createElement('div', {
                         class: 'tool widget',
                         style: `display: flex;flex-direction: row;align-items: center;height: 30px;padding: 0 4px;min-width: 0; width: 100%; box-sizing: border-box;`
                     }, containerChildren);
 
-                    bar.append(this.node);
 
-                    // Match native event behavior.
+                    // --- 2. MODE CONFIGURATION ---
+                    if (this.is_compact) {
+                        bar.classList.add('full_width_dialog_bar');
+                        bar.style.padding = '0';
+                        bar.style.background = 'transparent';
+
+                        this.node = document.createElement('div');
+                        this.node.className = 'tool widget compact_dropdown_select';
+                        this.node.style = `display: flex; align-items: center; cursor: pointer; padding: 2px 6px; background: ${data.background || 'var(--color-button)'}; border-radius: 2px; height: 30px; box-sizing: border-box; flex-shrink: 0;`;
+
+                        let icon_wrapper = document.createElement('div');
+                        icon_wrapper.className = 'main_icon_wrapper';
+                        icon_wrapper.style = 'display: flex; align-items: center; margin-right: 4px;';
+
+                        let main_icon = Blockbench.getIconNode(data.icon || 'settings');
+                        if (data.icon_color) {
+                            main_icon.style.color = data.icon_color;
+                        }
+                        icon_wrapper.append(main_icon);
+
+                        let arrow_node = document.createElement('i');
+                        arrow_node.className = 'fas fa-caret-down dropdown_arrow';
+                        arrow_node.style = 'font-size: 12px; color: var(--color-text); display: flex; align-items: center;';
+
+                        this.node.append(icon_wrapper, arrow_node);
+                        bar.append(this.node);
+
+                        this.popup_panel = document.createElement('div');
+                        this.popup_panel.className = 'context_menu combo_slider_popup';
+                        Object.assign(this.popup_panel.style, {
+                            position: 'fixed',
+                            display: 'none',
+                            zIndex: '1000',
+                            background: 'var(--color-menu_bg, var(--color-ui))',
+                            border: '1px solid var(--color-border)',
+                            boxShadow: '0 4px 14px rgba(0,0,0,0.25)',
+                            padding: '4px',
+                            borderRadius: '4px',
+                            width: data.popup_width || '220px',
+                            boxSizing: 'border-box'
+                        });
+                        this.popup_panel.append(this.slider_node);
+
+                        this._isOpen = false;
+
+                        this.closePopup = (e) => {
+                            if (!this._isOpen) return;
+                            if (e.type === 'keydown' && e.key !== 'Escape') return;
+                            if (e.type === 'mousedown' && (this.popup_panel.contains(e.target) || this.node.contains(e.target))) return;
+
+                            this.popup_panel.style.display = 'none';
+                            if (this.popup_panel.parentNode) this.popup_panel.parentNode.removeChild(this.popup_panel);
+                            this._isOpen = false;
+
+                            document.removeEventListener('mousedown', this.closePopup);
+                            document.removeEventListener('keydown', this.closePopup);
+                        };
+
+                        this.node.addEventListener('mousedown', (e) => {
+                            if (this._isOpen) {
+                                this.closePopup({ type: 'mousedown', target: document.body });
+                                return;
+                            }
+
+                            this.popup_panel.style.display = 'block';
+                            document.body.appendChild(this.popup_panel);
+
+                            let rect = this.node.getBoundingClientRect();
+                            this.popup_panel.style.top = (rect.bottom + 4) + 'px';
+
+                            let popupRect = this.popup_panel.getBoundingClientRect();
+                            let leftPos = rect.left;
+                            if (leftPos + popupRect.width > window.innerWidth) {
+                                leftPos = window.innerWidth - popupRect.width - 4;
+                            }
+                            this.popup_panel.style.left = leftPos + 'px';
+
+                            this._isOpen = true;
+
+                            setTimeout(() => {
+                                document.addEventListener('mousedown', this.closePopup);
+                                document.addEventListener('keydown', this.closePopup);
+                            }, 10);
+                        });
+
+                    } else {
+                        bar.classList.add('full_width_dialog_bar');
+                        bar.style.padding = '0';
+                        bar.style.background = 'transparent';
+                        this.node = this.slider_node;
+                        bar.append(this.node);
+                    }
+
+                    // --- 3. INTERNAL SLIDER EVENTS ---
                     let scope = this;
-                    let $inputs = $(this.node).find('input');
-                    let $range = $(this.node).find('input[type="range"]');
-                    let $number = $(this.node).find('input[type="number"]');
+                    let $inputs = $(this.slider_node).find('input');
+                    let $range = $(this.slider_node).find('input[type="range"]');
+                    let $number = $(this.slider_node).find('input[type="text"]');
 
+                    // Lógica de arrastre para el mini-slider del input ("<>")
+                    if (typeof addEventListeners !== 'undefined') {
+                        addEventListeners(numSliderIcon, 'mousedown touchstart', e1 => {
+                            if (scope.is_disabled) return;
+                            if (typeof convertTouchEvent !== 'undefined') convertTouchEvent(e1);
+
+                            let last_difference = 0;
+                            let start_value = parseFloat(scope.numberInput.value) || 0;
+
+                            if (scope.onBefore) scope.onBefore(e1);
+                            scope.isDragging = true;
+
+                            let move = e2 => {
+                                if (typeof convertTouchEvent !== 'undefined') convertTouchEvent(e2);
+                                let difference = Math.trunc((e2.clientX - e1.clientX) / 10) * (scope.settings.step || 1);
+
+                                if (difference !== last_difference) {
+                                    let newValue = start_value + difference;
+
+                                    if (!scope.settings.allow_lower && newValue < scope.settings.min) newValue = scope.settings.min;
+                                    if (!scope.settings.allow_higher && newValue > scope.settings.max) newValue = scope.settings.max;
+
+                                    if (typeof trimFloatNumber !== 'undefined') {
+                                        newValue = trimFloatNumber(newValue, 8);
+                                    } else {
+                                        newValue = Math.round(newValue * 100000000) / 100000000;
+                                    }
+
+                                    scope.setValue(newValue, true, false);
+                                    if (scope.onDrag) scope.onDrag(newValue, e2, true);
+                                    last_difference = difference;
+                                }
+                            };
+
+                            let stop = e2 => {
+                                if (typeof removeEventListeners !== 'undefined') {
+                                    removeEventListeners(document, 'mousemove touchmove', move);
+                                    removeEventListeners(document, 'mouseup touchend', stop);
+                                }
+                                scope.isDragging = false;
+                                scope.updateResetButton();
+                                if (scope.onAfter) scope.onAfter(e2);
+                            };
+
+                            addEventListeners(document, 'mousemove touchmove', move);
+                            addEventListeners(document, 'mouseup touchend', stop);
+                        });
+                    }
+
+                    // Dispara la actualización continua sin onBefore/onAfter
                     $inputs.on('input', function (event) {
                         let val = parseFloat($(event.target).val());
                         if (isNaN(val)) return;
                         let is_number_input = event.target === $number[0];
-                        scope.setValue(val, false, is_number_input);
-                        scope.change();
+                        scope.setValue(val, true, is_number_input);
+                        if (scope.onDrag && (scope.isDragging || event.target === $range[0])) {
+                            scope.onDrag(val, event.originalEvent, is_number_input);
+                        }
                     });
 
+                    // Eventos onBefore (Mismo comportamiento que un Widget)
+                    $range.on('mousedown touchstart', function (event) {
+                        scope.isDragging = true;
+                        if (scope.onBefore) scope.onBefore(event.originalEvent);
+                    });
+
+                    $number.on('focus', function (event) {
+                        if (scope.onBefore) scope.onBefore(event.originalEvent);
+                    });
+
+                    // Eventos onAfter (Cuando se termina de modificar)
+                    $range.on('mouseup touchend', function () {
+                        scope.isDragging = false;
+                        scope.updateResetButton();
+                    });
+
+                    $inputs.on('change', function (event) {
+                        scope.isDragging = false;
+                        scope.updateResetButton();
+                        if (scope.onAfter) scope.onAfter(event.originalEvent);
+                    });
+
+                    // Manejo especial del Number Input
                     $number.on('blur', function (event) {
                         let val = parseFloat($(this).val());
                         if (isNaN(val)) {
@@ -5463,12 +6880,11 @@ function initialize_light_plugin() {
                     $number.on('keydown', function (event) {
                         if (event.key === 'Enter' || event.key === 'Escape') {
                             this.blur();
+                            if (scope.is_compact && event.key === 'Enter') {
+                                scope.closePopup({ type: 'mousedown', target: document.body });
+                            }
                         }
                     });
-
-                    $range.on('mousedown touchstart', function () { scope.isDragging = true; });
-                    $range.on('mouseup touchend', function () { scope.isDragging = false; scope.updateResetButton(); });
-                    $inputs.on('change', function () { scope.isDragging = false; scope.updateResetButton(); });
 
                     this.setValue(this.value, false);
                 }
@@ -5476,6 +6892,7 @@ function initialize_light_plugin() {
                 updateResetButton() {
                     if (!this.settings.resettable || !this.resetBtn) return;
                     if (this.isDragging) return;
+
                     if (parseFloat(this.value) !== parseFloat(this.settings.reset_value)) {
                         this.resetBtn.style.display = 'flex';
                     } else {
@@ -5483,20 +6900,35 @@ function initialize_light_plugin() {
                     }
                 }
 
+                setResetValue(value, refreshButton = true) {
+                    this.settings.reset_value = value;
+                    if (refreshButton) {
+                        this.updateResetButton();
+                    }
+                    return this;
+                }
+
+                setColor(color) {
+                    const normalizedColor = color || '';
+                    if (this.rangeInput) {
+                        this.rangeInput.style.setProperty('--color-thumb', normalizedColor);
+                        this.rangeInput.style.accentColor = normalizedColor;
+                        this.rangeInput.style.color = normalizedColor;
+                    }
+                    return this;
+                }
+
                 getValue() {
                     return this.value;
                 }
 
                 setValue(value, dispatch = true, skip_number_input_update = false) {
-                    if (!this.settings.allow_lower && value < this.settings.min) {
-                        value = this.settings.min;
-                    }
-                    if (!this.settings.allow_higher && value > this.settings.max) {
-                        value = this.settings.max;
-                    }
+                    if (!this.settings.allow_lower && value < this.settings.min) value = this.settings.min;
+                    if (!this.settings.allow_higher && value > this.settings.max) value = this.settings.max;
+
                     this.value = value;
-                    let $range = $(this.node).find('input[type="range"]');
-                    let $number = $(this.node).find('input[type="number"]');
+                    let $range = $(this.slider_node).find('input[type="range"]');
+                    let $number = $(this.slider_node).find('input[type="text"]');
 
                     $range.val(value);
                     if (!skip_number_input_update) {
@@ -5512,8 +6944,16 @@ function initialize_light_plugin() {
                     } else {
                         $range.css({ 'opacity': '1', 'filter': 'none' });
                     }
+
                     this.updateResetButton();
-                    if (dispatch) this.change();
+
+                    if (this.is_compact) {
+                        let baseName = this.options.label ? (typeof tl !== 'undefined' ? tl(this.options.label) : this.options.label) + ': ' : '';
+                        let desc = (this.options.description && !this.options.label) ? '\n' + (typeof tl !== 'undefined' ? tl(this.options.description) : this.options.description) : '';
+                        this.node.title = `${baseName}${this.value}${desc}`;
+                    }
+
+                    if (dispatch) this.change(); // Dispara el update global de Blockbench
                 }
 
                 getDefault() {
@@ -5523,7 +6963,7 @@ function initialize_light_plugin() {
 
             // MARK: Compact Dropdown Select
             FormElement.types.compact_select = class FormElementCompactDropdown extends FormElement {
-                get uses_wide_inputs() { return true; }
+                get uses_wide_inputs() { return false; }
                 setup() {
                     let tempDesc = this.options.description;
                     this.options.description = null;
@@ -5544,7 +6984,7 @@ function initialize_light_plugin() {
                     // Button DOM mirrors the original widget.
                     this.node = document.createElement('div');
                     this.node.className = 'tool widget compact_dropdown_select';
-                    this.node.style = 'display: flex; align-items: center; cursor: pointer; padding: 2px 6px; background: var(--color-button); border-radius: 2px; height: 30px; box-sizing: border-box; flex-shrink: 0;';
+                    this.node.style = `display: flex; align-items: center; cursor: pointer; padding: 2px 6px; background: ${data.background ? data.background : 'var(--color-button)'}; border-radius: 2px; height: 30px; box-sizing: border-box; flex-shrink: 0;`;
 
                     this.icon_wrapper = document.createElement('div');
                     this.icon_wrapper.className = 'main_icon_wrapper';
@@ -5560,11 +7000,19 @@ function initialize_light_plugin() {
                     let outerContainer = document.createElement('div');
                     outerContainer.style = 'display: flex; align-items: center; gap: 8px; width: 100%; height: 30px; padding: 0 4px; box-sizing: border-box;';
 
-                    if (data.label) {
+                    if (data.label && !data.hide_label) {
                         let labelElement = document.createElement('span');
                         labelElement.style = 'font-size: 13px; color: var(--color-text); white-space: nowrap;';
-                        labelElement.innerText = tl(data.label);
+                        labelElement.innerText = typeof tl !== 'undefined' ? tl(data.label) : data.label;
                         outerContainer.append(labelElement);
+
+                        if (data.description) {
+                            let infoIcon = document.createElement('i');
+                            infoIcon.className = 'fa fa-question dialog_form_description';
+                            infoIcon.style = 'font-size: 14px; cursor: help; margin-left: 4px; color: var(--color-subtle_text);';
+                            infoIcon.title = typeof tl !== 'undefined' ? tl(data.description) : data.description;
+                            outerContainer.append(infoIcon);
+                        }
                     }
 
                     outerContainer.append(this.node);
@@ -5599,7 +7047,7 @@ function initialize_light_plugin() {
                             items.push({
                                 name: opt.name || key,
                                 icon: opt.icon,
-                                color: opt.color,
+                                color: undefined,//opt.color ? getStylizedContrastingColor(opt.color, 'var(--color-bright_ui)', {minContrast: 2.5}) : undefined,
                                 condition: opt.condition,
                                 click: (e) => {
                                     scope.setValue(key);
@@ -5621,8 +7069,10 @@ function initialize_light_plugin() {
                     let opt = this.options_dict[this.value];
                     if (!opt) return;
 
-                    let baseName = this.options.label ? tl(this.options.label) + ': ' : '';
-                    this.node.title = `${baseName}${opt.name || this.value}`;
+                    let baseName = this.options.label ? (typeof tl !== 'undefined' ? tl(this.options.label) : this.options.label) + ': ' : '';
+                    let optName = opt.name || this.value;
+                    let desc = (this.options.description /*&& !this.options.label*/) ? '\n' + (typeof tl !== 'undefined' ? tl(this.options.description) : this.options.description) : '';
+                    this.node.title = `${baseName}${optName}${desc}`;
 
                     this.icon_wrapper.innerHTML = '';
                     let iconElement = Blockbench.getIconNode(opt.icon || 'help');
@@ -5644,6 +7094,202 @@ function initialize_light_plugin() {
                 getDefault() {
                     return this.values[0] || '';
                 }
+            };
+
+            // MARK: Horizontal Select
+            // Full-width segmented control implemented directly as a FormElement, without
+            // registering a BarItem or Toolbar child.
+            FormElement.types.horizontal_select = class FormElementHorizontalSelect extends FormElement {
+                get uses_wide_inputs() { return true; }
+
+                setup() {
+                    const description = this.options.description;
+                    this.options.description = null;
+                    super.setup();
+                    this.options.description = description;
+                }
+
+                build(bar) {
+                    this.bar = bar;
+                    bar.classList.add('full_width_dialog_bar');
+                    bar.style.padding = '0';
+                    bar.style.margin = '0';
+                    bar.style.background = 'transparent';
+
+                    const data = this.options;
+                    this.options_dict = data.options || {};
+                    this.allow_empty = data.allow_empty !== undefined ? !!data.allow_empty : true;
+                    this.multi_select = data.multi_select !== false;
+                    this.selected = [];
+
+                    this.node = document.createElement('div');
+                    this.node.className = 'horizontal_select_widget light_manager_horizontal_select';
+                    this.node.setAttribute('role', 'group');
+                    this.node.setAttribute('aria-label', typeof tl === 'function'
+                        ? tl(data.description || data.label || this.id)
+                        : (data.description || data.label || this.id));
+                    this.node.style.backgroundColor = data.background || data.bg_color || 'var(--color-back)';
+                    this.node.style.border = `1px solid ${data.divider_color || 'var(--color-border)'}`;
+                    this.node.style.display = 'flex';
+                    this.node.style.width = data.expand === false ? 'auto' : '100%';
+                    this.node.style.flex = data.expand === false ? '0 0 auto' : '1 1 auto';
+                    this.button_nodes = {};
+
+                    Object.entries(this.options_dict).forEach(([key, option], index, entries) => {
+                        const button = document.createElement('button');
+                        button.type = 'button';
+                        button.className = 'horizontal_select_btn';
+                        button.dataset.key = key;
+                        button.style.flex = data.expand === false ? '0 0 auto' : '1 1 0';
+                        button.style.border = '0';
+                        button.style.borderRadius = '0';
+                        button.style.fontFamily = 'inherit';
+                        if (index < entries.length - 1) {
+                            button.style.borderRight = `1px solid ${data.divider_color || 'var(--color-border)'}`;
+                        }
+                        if (option.color) button.style.color = option.color;
+                        if (option.disabled) button.classList.add('disabled');
+
+                        if (option.icon) {
+                            const icon = Blockbench.getIconNode(option.icon);
+                            icon.classList.add('horizontal_select_icon');
+                            button.append(icon);
+                        }
+                        if (option.name) {
+                            const label = document.createElement('span');
+                            label.className = 'horizontal_select_label';
+                            label.textContent = typeof tl === 'function' ? tl(option.name) : option.name;
+                            button.append(label);
+                        } else {
+                            button.classList.add('icon_only');
+                        }
+
+                        const title = option.description || option.name || key;
+                        button.title = typeof tl === 'function' ? tl(title) : title;
+                        button.setAttribute('aria-label', button.title);
+                        button.addEventListener('click', event => {
+                            if (this.is_disabled || option.disabled) return;
+                            const toggle = this.multi_select && (event.ctrlKey || event.shiftKey);
+                            if (toggle) {
+                                if (this.selected.includes(key)) {
+                                    if (this.allow_empty || this.selected.length > 1) {
+                                        this.selected = this.selected.filter(selected => selected !== key);
+                                    }
+                                } else {
+                                    this.selected.push(key);
+                                }
+                            } else if (this.selected.length === 1 && this.selected[0] === key && this.allow_empty) {
+                                this.selected = [];
+                            } else {
+                                this.selected = [key];
+                            }
+                            this.updateVisuals();
+                            this.change();
+                        });
+
+                        this.button_nodes[key] = button;
+                        this.node.append(button);
+                    });
+
+                    bar.append(this.node);
+                    this.setValue(data.value !== undefined ? data.value : data.default);
+                }
+
+                updateVisuals() {
+                    Object.entries(this.button_nodes || {}).forEach(([key, button]) => {
+                        const selected = this.selected.includes(key);
+                        const option = this.options_dict[key] || {};
+                        button.classList.toggle('selected', selected);
+                        button.setAttribute('aria-pressed', selected ? 'true' : 'false');
+                        button.style.color = selected ? '' : (option.color || '');
+                    });
+                }
+
+                getValue() {
+                    if (!this.selected.length) return null;
+                    return this.selected.length === 1 ? this.selected[0] : this.selected.slice();
+                }
+
+                setValue(value) {
+                    const requested = value === undefined || value === null
+                        ? []
+                        : (Array.isArray(value) ? value : [value]);
+                    this.selected = requested.filter(key => this.options_dict[key]);
+                    if (!this.selected.length && !this.allow_empty) {
+                        const first = Object.keys(this.options_dict)[0];
+                        if (first) this.selected = [first];
+                    }
+                    this.updateVisuals();
+                }
+
+                getDefault() {
+                    if (this.options.default !== undefined) return this.options.default;
+                    return this.allow_empty ? null : (Object.keys(this.options_dict)[0] || null);
+                }
+            };
+
+            // MARK: Compact Text
+            FormElement.types.compact_text = class FormElementCompactText extends FormElement {
+                get uses_wide_inputs() { return true; }
+
+                setup() {
+                    const description = this.options.description;
+                    this.options.description = null;
+                    super.setup();
+                    this.options.description = description;
+                }
+
+                build(bar) {
+                    this.bar = bar;
+                    bar.classList.add('full_width_dialog_bar');
+                    bar.style.padding = '0';
+                    bar.style.margin = '0';
+                    bar.style.background = 'transparent';
+
+                    const data = this.options;
+                    this.value = String(data.value ?? data.default ?? '');
+                    this.node = document.createElement('input');
+                    this.node.type = 'text';
+                    this.node.className = 'dark_bordered focusable_input light_manager_compact_text';
+                    this.node.value = this.value;
+                    this.node.placeholder = typeof tl === 'function'
+                        ? tl(data.placeholder || '')
+                        : (data.placeholder || '');
+                    this.node.title = typeof tl === 'function'
+                        ? tl(data.description || data.label || '')
+                        : (data.description || data.label || '');
+                    this.node.setAttribute('aria-label', this.node.title || this.node.placeholder || this.id);
+                    Object.assign(this.node.style, {
+                        width: '100%',
+                        minWidth: '45px',
+                        height: data.height || '30px',
+                        margin: '0',
+                        padding: '0 8px',
+                        boxSizing: 'border-box',
+                        flex: '1 1 auto'
+                    });
+                    this.node.addEventListener('input', () => {
+                        this.value = this.node.value;
+                    });
+                    this.node.addEventListener('change', () => {
+                        this.value = this.node.value;
+                        this.change();
+                    });
+                    this.node.addEventListener('keydown', event => {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                            this.node.blur();
+                        }
+                    });
+                    bar.append(this.node);
+                }
+
+                getValue() { return this.value; }
+                setValue(value) {
+                    this.value = String(value ?? '');
+                    if (this.node && this.node.value !== this.value) this.node.value = this.value;
+                }
+                getDefault() { return String(this.options.default ?? ''); }
             };
 
             // MARK: Bar Display
@@ -5669,10 +7315,11 @@ function initialize_light_plugin() {
                     this.is_paragraph = !!data.paragraph;
                     this.expand = !!data.expand;
                     this.text_alignment = data.text_alignment || 'left';
+                    this.description = data.description || data.title || '';
 
                     this.node = document.createElement('div');
                     this.node.className = `tool widget bar_display ${this.is_paragraph ? 'bar_display_paragraph' : ''}`;
-                    this.node.style = 'display: flex; gap: 6px; padding: 0 4px; cursor: default; width: 100%; box-sizing: border-box; align-items: ' + (this.is_paragraph ? 'flex-start' : 'center') + ';';
+                    this.node.style = `display: flex; ${this.text ? `gap: 6px;` : ''} padding: 0 4px; cursor: default; width: 100%; box-sizing: border-box; align-items: ${this.is_paragraph ? 'flex-start' : 'center'};`;
 
                     if (this.color) this.node.style.color = this.color;
 
@@ -5698,8 +7345,18 @@ function initialize_light_plugin() {
                         label_node.style.opacity = '0.85';
                         label_node.style.display = 'flex';
                         label_node.style.alignItems = 'center';
-                        label_node.innerText = tl(this.inline_label);
+                        label_node.innerText = typeof tl !== 'undefined' ? tl(this.inline_label) : this.inline_label;
                         this.node.append(label_node);
+
+                        if (this.description) {
+                            let infoIcon = document.createElement('i');
+                            infoIcon.className = 'fa fa-question dialog_form_description';
+                            infoIcon.style = 'font-size: 14px; cursor: help; margin-left: 4px; color: var(--color-subtle_text); display: flex; align-items: center;';
+                            infoIcon.title = typeof tl !== 'undefined' ? tl(this.description) : this.description;
+                            this.node.append(infoIcon);
+                        }
+                    } else if (this.description) {
+                        this.node.title = typeof tl !== 'undefined' ? tl(this.description) : this.description;
                     }
 
                     this.content_node = document.createElement('span');
@@ -5795,7 +7452,7 @@ function initialize_light_plugin() {
 
                     // Native Tooltip (Description)
                     if (data.description) {
-                        this.node.title = tl(data.description);
+                        this.node.title = typeof tl !== 'undefined' ? tl(data.description) : data.description;
                     }
 
                     // --- Create Icon Wrapper & Node ---
@@ -5835,7 +7492,7 @@ function initialize_light_plugin() {
                     });
 
                     if (data.label) {
-                        this.label_node.innerText = tl(data.label);
+                        this.label_node.innerText = typeof tl !== 'undefined' ? tl(data.label) : data.label;
                     }
 
                     // --- Layout Configuration ---
@@ -5910,6 +7567,222 @@ function initialize_light_plugin() {
                 getDefault() {
                     return false;
                 }
+            };
+
+            // MARK: Custom Action Toggle
+            FormElement.types.action_toggle = class FormElementActionToggle extends FormElement {
+                get uses_wide_inputs() { return true; }
+
+                setup() {
+                    let tempDesc = this.options.description;
+                    this.options.description = null;
+                    super.setup();
+                    this.options.description = tempDesc;
+                }
+
+                build(bar) {
+                    this.bar = bar;
+                    bar.classList.add('full_width_dialog_bar');
+
+                    bar.style.padding = '0';
+                    bar.style.margin = '0';
+                    bar.style.background = 'transparent';
+                    bar.style.display = 'flex';
+                    bar.style.alignItems = 'center';
+                    bar.style.gap = '8px';
+
+                    let data = this.options;
+                    this.value = data.value !== undefined ? !!data.value : (data.default !== undefined ? !!data.default : false);
+
+                    this.icon_on = data.icon_on || 'check_box';
+                    this.icon_off = data.icon_off || 'check_box_outline_blank';
+                    this.bg_on = data.bg_on || 'var(--color-accent)';
+                    this.bg_off = data.bg_off || 'transparent';
+                    this.color_on = data.color_on || 'var(--color-light)';
+                    this.color_off = data.color_off || 'var(--color-text)';
+
+                    this.animate_click = data.animate !== false;
+                    this.icon_size = data.icon_size || '18px';
+                    this.button_size = data.button_size || '30px';
+
+                    // --- Wrapper del Label ---
+                    let has_label = !!data.label;
+                    if (has_label) {
+                        bar.style.width = '100%';
+                        bar.style.justifyContent = 'space-between';
+
+                        let labelWrapper = document.createElement('div');
+                        labelWrapper.style = 'display: flex; align-items: center; gap: 4px; flex: 1 1 auto; min-width: 0;';
+
+                        let labelElement = document.createElement('span');
+                        labelElement.style = 'font-size: 13px; color: var(--color-subtle_text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis;';
+                        labelElement.innerText = typeof tl !== 'undefined' ? tl(data.label) : data.label;
+                        labelWrapper.append(labelElement);
+
+                        if (data.description) {
+                            let infoIcon = document.createElement('i');
+                            infoIcon.className = 'fa fa-question dialog_form_description';
+                            infoIcon.style = 'font-size: 14px; cursor: help; margin: 0; color: var(--color-subtle_text);';
+                            infoIcon.title = typeof tl !== 'undefined' ? tl(data.description) : data.description;
+                            labelWrapper.append(infoIcon);
+                        }
+                        bar.append(labelWrapper);
+                    } else {
+                        bar.style.width = 'auto';
+                        bar.style.justifyContent = 'flex-start';
+                    }
+
+                    // --- Botón Toggle ---
+                    this.toggle_btn = document.createElement('div');
+                    this.toggle_btn.className = 'tool widget action_toggle_btn';
+                    Object.assign(this.toggle_btn.style, {
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: this.button_size,
+                        height: this.button_size,
+                        borderRadius: '2px',
+                        cursor: 'pointer',
+                        flexShrink: '0',
+                        margin: '0',
+                        position: 'relative', // Importante para que el tooltip se posicione bien
+                        transition: this.animate_click ? 'background 0.2s ease, color 0.2s ease' : 'none'
+                    });
+
+                    // --- Tooltip Nativo de Blockbench ---
+                    let tooltip_text = data.title || data.description || data.label;
+                    if (tooltip_text) {
+                        this.toggle_btn.title = typeof tl !== 'undefined' ? tl(tooltip_text) : tooltip_text;
+                    }
+
+                    // --- Icono ---
+                    this.icon_node = document.createElement('i');
+                    Object.assign(this.icon_node.style, {
+                        fontSize: this.icon_size,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        transition: this.animate_click ? 'transform 0.15s cubic-bezier(0.2, 1.5, 0.4, 1)' : 'none'
+                    });
+
+                    this.toggle_btn.append(this.icon_node);
+                    bar.append(this.toggle_btn);
+
+                    this.toggle_btn.addEventListener('click', () => {
+                        this.setValue(!this.value);
+                    });
+
+                    this.updateVisuals(false);
+                }
+
+                updateVisuals(trigger_anim = true) {
+                    let current_icon = this.value ? this.icon_on : this.icon_off;
+                    let current_bg = this.value ? this.bg_on : this.bg_off;
+                    let current_color = this.value ? this.color_on : this.color_off;
+
+                    this.toggle_btn.style.background = current_bg;
+                    this.icon_node.style.color = current_color;
+
+                    this.icon_node.className = '';
+                    this.icon_node.innerText = '';
+
+                    let isFa = /^(fa-|fas |fab |far )/.test(current_icon);
+                    if (isFa) {
+                        this.icon_node.className = `fa ${current_icon}`;
+                    } else {
+                        this.icon_node.className = 'material-icons';
+                        this.icon_node.innerText = current_icon;
+                    }
+
+                    if (this.animate_click && trigger_anim) {
+                        this.icon_node.style.transform = 'scale(0.6)';
+                        setTimeout(() => {
+                            this.icon_node.style.transform = 'scale(1)';
+                        }, 50);
+                    } else {
+                        this.icon_node.style.transform = 'scale(1)';
+                    }
+                }
+
+                getValue() { return this.value; }
+                setValue(val, dispatch = true) {
+                    this.value = !!val;
+                    this.updateVisuals(true);
+                    if (dispatch) this.change();
+                }
+                getDefault() { return false; }
+            };
+
+            // MARK: Compact Action Button
+            FormElement.types.action_button = class FormElementActionButton extends FormElement {
+                get uses_wide_inputs() { return true; }
+
+                setup() {
+                    const description = this.options.description;
+                    this.options.description = null;
+                    super.setup();
+                    this.options.description = description;
+                }
+
+                build(bar) {
+                    this.bar = bar;
+                    bar.classList.add('full_width_dialog_bar');
+                    bar.style.padding = '0';
+                    bar.style.margin = '0';
+                    bar.style.background = 'transparent';
+
+                    const data = this.options;
+                    const label = data.label ? (typeof tl === 'function' ? tl(data.label) : data.label) : '';
+                    const description = data.description || data.title || data.label || '';
+                    const translatedDescription = description && typeof tl === 'function' ? tl(description) : description;
+
+                    this.node = document.createElement('button');
+                    this.node.type = 'button';
+                    this.node.className = 'tool widget light_manager_action_button';
+                    this.node.title = translatedDescription || label;
+                    this.node.setAttribute('aria-label', label || translatedDescription || data.icon || 'Action');
+                    Object.assign(this.node.style, {
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: label ? '6px' : '0',
+                        minWidth: data.button_size || '30px',
+                        width: label ? 'auto' : (data.button_size || '30px'),
+                        height: data.button_size || '30px',
+                        padding: label ? '0 8px' : '0',
+                        margin: '0',
+                        border: '0',
+                        borderRadius: '2px',
+                        boxSizing: 'border-box',
+                        background: data.background || 'transparent',
+                        color: data.color || 'var(--color-text)',
+                        cursor: 'pointer',
+                        flexShrink: '0'
+                    });
+
+                    const icon = Blockbench.getIconNode(data.icon || 'tune');
+                    icon.style.fontSize = data.icon_size || '20px';
+                    icon.style.color = data.icon_color || data.color || 'var(--color-text)';
+                    this.node.append(icon);
+
+                    if (label) {
+                        const labelNode = document.createElement('span');
+                        labelNode.textContent = label;
+                        labelNode.style.whiteSpace = 'nowrap';
+                        this.node.append(labelNode);
+                    }
+
+                    const trigger = event => {
+                        if (this.is_disabled) return;
+                        if (typeof data.click === 'function') data.click(event, this);
+                    };
+                    this.node.addEventListener('click', trigger);
+                    bar.append(this.node);
+                }
+
+                getValue() { return undefined; }
+                setValue() { }
+                getDefault() { return undefined; }
             };
 
             // MARK: Custom Vector
@@ -6603,7 +8476,37 @@ function initialize_light_plugin() {
 
 
 
-            window.HorizontalSelectWidget = HorizontalSelectWidget;
+            const lightManagerFormElementTypes = [
+                'advanced_color',
+                'combo_slider',
+                'compact_select',
+                'horizontal_select',
+                'compact_text',
+                'bar_display',
+                'custom_checkbox',
+                'action_toggle',
+                'action_button',
+                'custom_vector'
+            ];
+            for (const typeId of lightManagerFormElementTypes) {
+                const Type = FormElement.types[typeId];
+                if (!Type || Type.prototype._lightManagerFormStateWrapped) continue;
+                const originalSetup = Type.prototype.setup;
+                Type.prototype.setup = function () {
+                    originalSetup.call(this);
+                    setupLightManagerFormElementState(this);
+                };
+                Type.prototype._lightManagerFormStateWrapped = true;
+            }
+
+            window.applyIndestructibleFormGroups = applyIndestructibleFormGroups;
+            lightManagerUIApi = {
+                applyFormGroups: window.applyIndestructibleFormGroups,
+                addCompactPanelStyles: addLightManagerCompactPanelStyles,
+                markerColor: getLightManagerMarkerColor,
+                formElementTypes: lightManagerFormElementTypes.slice()
+            };
+            window.LightManagerUI = lightManagerUIApi;
 
             const compactWidgetStyles = Blockbench.addCSS(
                 `.compact_dropdown_select {
@@ -6634,7 +8537,7 @@ function initialize_light_plugin() {
                     color: var(--color-text);
                     opacity: 0.6;
                 }
-                    
+
                 .horizontal_select_widget {
                     display: flex;
                     align-items: stretch;
@@ -7464,34 +9367,12 @@ function initialize_light_plugin() {
             window.LightManagerViewportControls.install();
             window.LightManagerViewportControls.updateAll();
 
-            let LIGHT_SETTINGS_GROUP = {};
             let syncingLightSettings = false;
             let activeLightUndoLabel = null;
 
-            let light_type_select;
-            let light_intensity_slider;
-
-            let light_color_picker;
-            let light_temperature_slider;
-            let light_distance_slider;
-            let light_cone_angle_slider;
-            let light_cone_penumbra_slider;
-            let cast_shadows_toggle;
-            let light_shadow_resolution_select;
-            let light_studio_shadow_resolution_select;
-            let light_shadow_near_sliderbox;
-            let light_shadow_far_sliderbox;
-            let light_shadow_bounds_slider;
-            let light_shadow_softness_sliderbox;
-            let light_shadow_bias_sliderbox;
-            let light_shadow_normal_bias_sliderbox;
+            let lightPropertiesPanel;
 
             const getSelectedLight = () => LightElement.selected.length === 1 ? LightElement.selected[0] : null;
-            const singleLightCondition = () => !!getSelectedLight();
-            const rangeLightCondition = () => {
-                const light = getSelectedLight();
-                return !!light && (light.light_type === 'point' || light.light_type === 'spot');
-            };
             const spotLightCondition = () => {
                 const light = getSelectedLight();
                 return !!light && light.light_type === 'spot';
@@ -7522,33 +9403,6 @@ function initialize_light_plugin() {
                 if (syncingLightSettings || !activeLightUndoLabel) return;
                 Undo.finishEdit(label || activeLightUndoLabel);
                 activeLightUndoLabel = null;
-            };
-
-            const setBarControl = (control, value) => {
-                if (control && typeof control.set === 'function') control.set(value);
-            };
-
-            const setNumControl = (control, value) => {
-                if (!control) return;
-                if (typeof control.set === 'function') {
-                    control.set(value);
-                    return;
-                }
-                control.value = value;
-                if (typeof control.update === 'function') control.update();
-            };
-
-            const updateConditionalLightToolbars = () => {
-                [
-                    'light_gizmo_tools_toolbar',
-                    'light_settings_toolbar',
-                    'light_quickbuttons_toolbar',
-                    'light_shadow_quality_toolbar',
-                    'light_shadow_clip_settings_toolbar',
-                    'light_shadow_bounds_settings_toolbar',
-
-                    'light_shadow_bias_settings_toolbar'
-                ].forEach(key => LIGHT_SETTINGS_GROUP[key]?.update?.());
             };
 
             const normalizeLightPanelValue = (light, property, value) => {
@@ -7626,40 +9480,6 @@ function initialize_light_plugin() {
                 return {};
             };
 
-            const syncLightSettingsPanel = (light) => {
-                if (!light) return;
-                syncingLightSettings = true;
-                try {
-                    setBarControl(light_type_select, light.light_type);
-                    setBarControl(light_intensity_slider, light.intensity);
-
-                    light_color_picker?.set?.(LightManagerUtils.colorHex(light.color));
-
-                    let selectedTemp = light.temperature || 6500;
-                    setBarControl(light_temperature_slider, selectedTemp);
-
-                    setBarControl(light_distance_slider, light.distance);
-                    setBarControl(light_cone_angle_slider, light.angle);
-                    setBarControl(light_cone_penumbra_slider, light.penumbra);
-
-                    cast_shadows_toggle?.set?.(light.has_shadow !== false);
-                    setBarControl(light_shadow_resolution_select, String(LightManagerUtils.shadowResolution(light.shadow_resolution)));
-                    setBarControl(light_studio_shadow_resolution_select, String(LightManagerUtils.studioShadowResolution(light.studio_shadow_resolution)));
-                    setNumControl(light_shadow_near_sliderbox, light.shadow_near);
-                    setNumControl(light_shadow_far_sliderbox, light.shadow_far);
-                    setNumControl(light_shadow_bounds_slider, light.shadow_bounds);
-                    setNumControl(light_shadow_softness_sliderbox, light.shadow_softness);
-                    setNumControl(light_shadow_bias_sliderbox, light.shadow_bias);
-                    if (light_shadow_normal_bias_sliderbox) {
-                        light_shadow_normal_bias_sliderbox.reset_value = LightManagerUtils.defaultShadowNormalBias(light);
-                    }
-                    setNumControl(light_shadow_normal_bias_sliderbox, light.shadow_normal_bias);
-                } finally {
-                    syncingLightSettings = false;
-                }
-                updateConditionalLightToolbars();
-            };
-
             const applyLightPanelValue = (property, value, undoLabel) => {
                 if (syncingLightSettings) return false;
 
@@ -7671,23 +9491,35 @@ function initialize_light_plugin() {
                     LIGHT_MANAGER_AUTO_NORMAL_BIAS_PROPERTIES.includes(property) &&
                     LightManagerUtils.isAutomaticShadowNormalBiasValue(light.shadow_normal_bias, light)
                 );
-                const nextNormalBiasContext = {
-                    ...light,
-                    [property]: nextValue
-                };
-                if (property === 'shadow_near' && nextNormalBiasContext.shadow_far <= nextNormalBiasContext.shadow_near) {
-                    nextNormalBiasContext.shadow_far = nextNormalBiasContext.shadow_near + 0.001;
-                }
-                const nextAutomaticNormalBias = updateAutomaticNormalBias
-                    ? LightManagerUtils.defaultShadowNormalBias(nextNormalBiasContext)
-                    : null;
-                const normalBiasNeedsAutoUpdate = (
-                    updateAutomaticNormalBias &&
-                    !lightValuesEqual(light.shadow_normal_bias, nextAutomaticNormalBias)
-                );
-                if (lightValuesEqual(light[property], nextValue) && !normalBiasNeedsAutoUpdate) return false;
 
-                const directUndo = undoLabel && !activeLightUndoLabel;
+                // Avoid computing expensive automatic normal bias unless the property value actually changes
+                let nextAutomaticNormalBias = null;
+                let normalBiasNeedsAutoUpdate = false;
+                const valueChanged = !lightValuesEqual(light[property], nextValue);
+                if (valueChanged) {
+                    if (updateAutomaticNormalBias) {
+                        const nextNormalBiasContext = { ...light, [property]: nextValue };
+                        if (property === 'shadow_near' && nextNormalBiasContext.shadow_far <= nextNormalBiasContext.shadow_near) {
+                            nextNormalBiasContext.shadow_far = nextNormalBiasContext.shadow_near + 0.001;
+                        }
+                        nextAutomaticNormalBias = LightManagerUtils.defaultShadowNormalBias(nextNormalBiasContext);
+                        normalBiasNeedsAutoUpdate = !lightValuesEqual(light.shadow_normal_bias, nextAutomaticNormalBias);
+                    }
+                } else if (updateAutomaticNormalBias) {
+                    // Only compute automatic bias if current automatic bias would change even when property value
+                    // itself remains equal (rare), so do the computation here to decide whether to proceed.
+                    const nextNormalBiasContext = { ...light, [property]: nextValue };
+                    if (property === 'shadow_near' && nextNormalBiasContext.shadow_far <= nextNormalBiasContext.shadow_near) {
+                        nextNormalBiasContext.shadow_far = nextNormalBiasContext.shadow_near + 0.001;
+                    }
+                    nextAutomaticNormalBias = LightManagerUtils.defaultShadowNormalBias(nextNormalBiasContext);
+                    normalBiasNeedsAutoUpdate = !lightValuesEqual(light.shadow_normal_bias, nextAutomaticNormalBias);
+                }
+
+                const willChange = valueChanged || normalBiasNeedsAutoUpdate;
+                if (!willChange) return false;
+
+                const directUndo = undoLabel && !activeLightUndoLabel && willChange;
                 if (directUndo) Undo.initEdit({ elements: [light] });
 
                 light[property] = Array.isArray(nextValue) ? nextValue.slice() : nextValue;
@@ -7714,6 +9546,11 @@ function initialize_light_plugin() {
                     LightElement.preview_controller?.updateSelection(light);
                 }
 
+                if (['temperature', 'color', 'intensity'].includes(property)) {
+                    LightElement.preview_controller?.updateSelection(light);
+                    window.LightManagerAreaGizmos?.updateAll();
+                }
+
                 const updateOptions = getLightPanelUpdateOptions(property);
                 window.update_light_element_callback?.(updateOptions);
                 if (updateOptions.gizmos !== false) {
@@ -7723,412 +9560,29 @@ function initialize_light_plugin() {
                 if (['light_type', 'has_shadow'].includes(property)) {
                     syncLightSettingsPanel(light);
                 } else if (normalBiasNeedsAutoUpdate) {
-                    setNumControl(light_shadow_normal_bias_sliderbox, light.shadow_normal_bias);
-                } else if (['shadow_resolution', 'studio_shadow_resolution'].includes(property)) {
-                    updateConditionalLightToolbars();
+                    const normalBiasControl = lightPropertiesPanel?.form?.form_data?.shadow_normal_bias;
+                    normalBiasControl?.setResetValue?.(LightManagerUtils.defaultShadowNormalBias(light));
+                    normalBiasControl?.setValue?.(light.shadow_normal_bias);
                 }
 
                 if (directUndo) Undo.finishEdit(undoLabel);
                 return true;
             };
 
-            light_type_select = new CompactDropdownSelect('light_type_select', {
-                name: 'property.light_type',
-                icon_mode: true,
-                options: {
-                    point: { name: 'property.light_type.point', icon: 'lightbulb' },
-                    directional: { name: 'property.light_type.directional', icon: 'light_mode' },
-                    spot: { name: 'property.light_type.spot', icon: 'highlight' }
-                },
-                condition: singleLightCondition,
-                onChange: function () {
-                    applyLightPanelValue('light_type', this.value, translateLightManager('light_manager.undo.change_type'));
+            let renderWorkspaceMode = new Mode('render', {
+                name: 'Lightflow Render',
+                icon: 'photo_camera_back',
+                category: 'navigate',
+                condition: () => Project,
+                onSelect() {
+
                 }
             });
+            deletables.push(renderWorkspaceMode);
 
-            light_color_picker = new AdvancedColorPicker({
-                id: 'light_color_picker',
-                name: tl('property.light_color'),
-                label: false,
-                value: tinycolor('ffffff'),
-                condition: singleLightCondition,
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_color')),
-                onChange: function (color) {
-                    let newColor = tinycolor(color);
-                    applyLightPanelValue('color', [newColor._r, newColor._g, newColor._b], translateLightManager('light_manager.undo.change_color'));
-                },
-                onMove: function (color) {
-                    let newColor = tinycolor(color);
-                    applyLightPanelValue('color', [newColor._r, newColor._g, newColor._b], translateLightManager('light_manager.undo.change_color'));
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_color'))
-            });
+            Panels.outliner.condition.modes.push('render');
 
-            light_temperature_slider = new ComboSlider('light_temperature_slider', {
-                label: 'property.light_temperature',
-                title: 'property.light_temperature.desc',
-                grow: true,
-                color: 'var(--color-warning)',
-                condition: singleLightCondition,
-                value: 6500,
-                reset_value: 6500,
-                min: 2700,
-                max: 6500,
-                step: 100,
-                circular: true,
-                allow_higher: false,
-                allow_lower: false,
-                get: function () {
-                    let light = getSelectedLight();
-                    return light ? (light.temperature || 6500) : 6500;
-                },
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_temperature')),
-                onChange: function () {
-                    applyLightPanelValue('temperature', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_temperature'))
-            });
-
-            cast_shadows_toggle = new Toggle('cast_shadows', {
-                icon: 'ev_shadow',
-                name: 'property.cast_shadows',
-                category: 'edit',
-                condition: singleLightCondition,
-                default: true,
-                onChange(toggle_value) {
-                    applyLightPanelValue('has_shadow', toggle_value, translateLightManager('light_manager.undo.toggle_shadows'));
-                }
-            });
-
-            light_shadow_resolution_select = new BarSelect('light_shadow_resolution_select', {
-                name: 'property.shadow_resolution',
-                options: {
-                    256: { name: '256' },
-                    512: { name: '512' },
-                    1024: { name: '1024' },
-                    2048: { name: '2048' },
-                    4096: { name: '4096' }
-                },
-                condition: shadowLightCondition,
-                onChange: function () {
-                    applyLightPanelValue('shadow_resolution', this.value, translateLightManager('light_manager.undo.change_shadow_resolution'));
-                }
-            });
-
-            light_studio_shadow_resolution_select = new BarSelect('light_studio_shadow_resolution_select', {
-                name: 'property.studio_shadow_resolution',
-                description: 'property.studio_shadow_resolution.desc',
-                options: {
-                    0: { name: 'light_manager.option.shadow_same_preview' },
-                    256: { name: '256' },
-                    512: { name: '512' },
-                    1024: { name: '1024' },
-                    2048: { name: '2048' },
-                    4096: { name: '4096' },
-                    8192: { name: '8192 — Render Pro' },
-                    16384: { name: '16384 — Render Ultra' }
-                },
-                condition: shadowLightCondition,
-                onChange: function () {
-                    applyLightPanelValue('studio_shadow_resolution', this.value, translateLightManager('light_manager.undo.change_studio_shadow_resolution'));
-                }
-            });
-
-            let light_quickbuttons_toolbar = new Toolbar({
-                id: 'light_quickbuttons',
-                name: 'property.light.quickbuttons',
-                label: true,
-                condition: singleLightCondition,
-                children: ['light_type_select', 'light_color_picker', '#', 'light_temperature_slider']
-            });
-
-            let light_shadow_quality_toolbar = new Toolbar({
-                id: 'light_shadow_quality',
-                name: 'property.light.shadows',
-                label: true,
-                condition: singleLightCondition,
-                children: ['cast_shadows', '#', 'light_shadow_resolution_select', 'light_studio_shadow_resolution_select']
-            });
-
-            let light_gizmo_tools_toolbar = new Toolbar({
-                id: 'light_gizmo_tools',
-                name: 'property.light.viewport_tools',
-                label: true,
-                condition: singleLightCondition,
-                children: ['light_manager_edit_tool', 'light_manager_free_move']
-            });
-
-            light_intensity_slider = new ComboSlider('light_intensity_slider', {
-                label: 'property.light_intensity',
-                icon: 'flare',
-                title: 'property.light_intensity.desc',
-                grow: true,
-                color: 'var(--color-axis-w)',
-                value: 1.0,
-                reset_value: 1.0,
-                min: 0.0,
-                max: 3.0,
-                step: 0.1,
-                allow_higher: true,
-                allow_lower: false,
-                get: function () {
-                    let light = getSelectedLight();
-                    return light ? light.intensity : 0;
-                },
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_intensity')),
-                onChange: function () {
-                    applyLightPanelValue('intensity', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_intensity'))
-            });
-
-            light_distance_slider = new ComboSlider('light_distance_slider', {
-                label: 'property.distance',
-                title: 'property.distance.desc',
-                grow: true,
-                color: '#00CE71',
-                condition: rangeLightCondition,
-                value: 0,
-                reset_value: 0,
-                min: 0,
-                max: 100,
-                step: 0.5,
-                allow_higher: true,
-                allow_lower: false,
-                get: function () {
-                    let light = getSelectedLight();
-                    return light ? light.distance : 0;
-                },
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_distance')),
-                onChange: function () {
-                    applyLightPanelValue('distance', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_distance'))
-            });
-
-            light_cone_angle_slider = new ComboSlider('light_cone_angle_slider', {
-                label: 'property.cone_angle',
-                title: 'property.cone_angle.desc',
-                grow: true,
-                color: '#F4D714',
-                condition: spotLightCondition,
-                value: 45,
-                reset_value: 45,
-                min: 0.1,
-                max: 89.9,
-                step: 0.1,
-                allow_higher: false,
-                allow_lower: false,
-                get: function () {
-                    let light = getSelectedLight();
-                    return light ? light.angle : 45;
-                },
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_cone_angle')),
-                onChange: function () {
-                    applyLightPanelValue('angle', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_cone_angle'))
-            });
-
-            light_cone_penumbra_slider = new ComboSlider('light_cone_penumbra_slider', {
-                label: 'property.cone_penumbra',
-                title: 'property.cone_penumbra.desc',
-                grow: true,
-                color: '#F96BC5',
-                condition: spotLightCondition,
-                value: 0,
-                reset_value: 0,
-                min: 0,
-                max: 1,
-                step: 0.01,
-                allow_higher: false,
-                allow_lower: false,
-                get: function () {
-                    let light = getSelectedLight();
-                    return light ? light.penumbra : 0;
-                },
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_penumbra')),
-                onChange: function () {
-                    applyLightPanelValue('penumbra', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_penumbra'))
-            });
-
-
-
-            let light_settings_toolbar = new Toolbar({
-                id: 'light_settings',
-                name: 'property.light_settings',
-                condition: singleLightCondition,
-                label: true,
-                children: ['light_intensity_slider', '#', 'light_distance_slider', '#', 'light_cone_angle_slider', '#', 'light_cone_penumbra_slider']
-            });
-
-            light_shadow_near_sliderbox = new ComboSlider('light_shadow_near_sliderbox', {
-                label: 'property.shadow_near',
-                title: 'light_manager.property.shadow_near',
-                color: '#EC9218',
-                grow: true,
-                value: 0.1,
-                reset_value: 0.1,
-                min: 0,
-                max: 100000,
-                step: 0.05,
-                allow_higher: true,
-                condition: shadowLightCondition,
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_clip')),
-                onChange: function () {
-                    applyLightPanelValue('shadow_near', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_clip'))
-            });
-
-            light_shadow_far_sliderbox = new ComboSlider('light_shadow_far_sliderbox', {
-                label: 'property.shadow_far',
-                title: 'light_manager.property.shadow_far',
-                color: '#FA565D',
-                grow: true,
-                value: 200,
-                reset_value: 200,
-                min: 0.001,
-                max: 100000,
-                step: 1,
-                allow_higher: true,
-                condition: shadowLightCondition,
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_clip')),
-                onChange: function () {
-                    applyLightPanelValue('shadow_far', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_clip'))
-            });
-
-            light_shadow_bounds_slider = new ComboSlider('light_shadow_bounds_slider', {
-                label: 'property.shadow_bounds',
-                title: 'light_manager.property.sun_shadow_area.desc',
-                color: '#B55AF8',
-                grow: true,
-                value: 35,
-                reset_value: 35,
-                min: 1,
-                max: 128,
-                step: 1,
-                allow_higher: true,
-                condition: directionalShadowCondition,
-                get: function () {
-                    let light = getSelectedLight();
-                    return light ? light.shadow_bounds : 35;
-                },
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_bounds')),
-                onChange: function () {
-                    applyLightPanelValue('shadow_bounds', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_bounds'))
-            });
-
-            let light_shadow_clip_settings_toolbar = new Toolbar({
-                id: 'light_shadow_clip_settings',
-                name: 'property.shadow_clip',
-                label: true,
-                condition: shadowLightCondition,
-                children: ['light_shadow_near_sliderbox', 'light_shadow_far_sliderbox']
-            });
-
-            let light_shadow_bounds_settings_toolbar = new Toolbar({
-                id: 'light_shadow_bounds_settings',
-                name: 'property.shadow_area',
-                label: true,
-                condition: directionalShadowCondition,
-                children: ['light_shadow_bounds_slider']
-            });
-
-            light_shadow_softness_sliderbox = new ComboSlider('light_shadow_softness_sliderbox', {
-                label: tl('property.shadow_softness'),
-                title: 'property.shadow_softness.desc',
-                color: 'var(--color-accent)',
-                grow: true,
-                value: DEFAULT_SHADOW_SOFTNESS,
-                reset_value: DEFAULT_SHADOW_SOFTNESS,
-                min: 0, max: 8, step: 0.05,
-                condition: shadowLightCondition,
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_softness')),
-                onChange: function () {
-                    applyLightPanelValue('shadow_softness', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_softness'))
-            });
-
-            light_shadow_bias_sliderbox = new ComboSlider('light_shadow_bias_sliderbox', {
-                label: tl('property.shadow_bias'),
-                color: 'var(--color-axis-z)',
-                grow: true,
-                value: DEFAULT_SHADOW_BIAS,
-                reset_value: DEFAULT_SHADOW_BIAS,
-                min: -1, max: 1, step: 0.0001,
-                condition: shadowLightCondition,
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_bias')),
-                onChange: function () {
-                    applyLightPanelValue('shadow_bias', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_bias'))
-            });
-
-            light_shadow_normal_bias_sliderbox = new ComboSlider('light_shadow_normal_bias_sliderbox', {
-                label: tl('property.shadow_normal_bias'),
-                color: 'var(--color-axis-u)',
-                grow: true,
-                description: tl('property.shadow_normal_bias.desc'),
-                value: DEFAULT_SHADOW_NORMAL_BIAS,
-                reset_value: DEFAULT_SHADOW_NORMAL_BIAS,
-                min: -1, max: 1, step: 0.0001,
-                condition: shadowLightCondition,
-                onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_normal_bias')),
-                onChange: function () {
-                    applyLightPanelValue('shadow_normal_bias', this.value);
-                },
-                onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_normal_bias'))
-            });
-
-            let light_shadow_bias_settings_toolbar = new Toolbar({
-                id: 'light_shadow_bias_settings',
-                name: 'property.shadow_biases',
-                label: true,
-                condition: shadowLightCondition,
-                children: ['light_shadow_softness_sliderbox', '#', 'light_shadow_bias_sliderbox', '#', 'light_shadow_normal_bias_sliderbox']
-            });
-
-            Object.assign(LIGHT_SETTINGS_GROUP, {
-                light_type_select,
-                light_intensity_slider,
-
-                light_settings_toolbar,
-                light_color_picker,
-                light_temperature_slider,
-
-                light_distance_slider,
-
-                light_cone_angle_slider,
-
-                light_cone_penumbra_slider,
-
-                cast_shadows_toggle,
-                light_shadow_resolution_select,
-                light_studio_shadow_resolution_select,
-                light_gizmo_tools_toolbar,
-                light_quickbuttons_toolbar,
-                light_shadow_quality_toolbar,
-                light_shadow_near_sliderbox,
-                light_shadow_far_sliderbox,
-                light_shadow_clip_settings_toolbar,
-                light_shadow_bounds_slider,
-                light_shadow_bounds_settings_toolbar,
-
-                light_shadow_softness_sliderbox,
-                light_shadow_bias_sliderbox,
-                light_shadow_normal_bias_sliderbox,
-                light_shadow_bias_settings_toolbar
-            });
-
-            let lightPropertiesPanel = new Panel('light_properties', {
+            lightPropertiesPanel = new Panel('light_properties', {
                 icon: 'lightbulb',
                 growable: true,
                 resizable: true,
@@ -8137,8 +9591,8 @@ function initialize_light_plugin() {
                 default_position: {
                     slot: 'right_bar',
                     float_position: [0, 0],
-                    float_size: [320, 520],
-                    height: 520,
+                    float_size: [314, 200],
+                    height: 200,
                     attached_to: 'transform',
                     attached_index: 1,
                     sidebar_index: 2,
@@ -8147,8 +9601,8 @@ function initialize_light_plugin() {
                     edit: {
                         slot: 'right_bar',
                         float_position: [0, 0],
-                        float_size: [320, 520],
-                        height: 520,
+                        float_size: [314, 200],
+                        height: 200,
                         attached_to: 'transform',
                         attached_index: 1,
                         sidebar_index: 2,
@@ -8161,27 +9615,453 @@ function initialize_light_plugin() {
                         ],
                         float_size: [
                             314,
-                            520
+                            200
                         ],
-                        height: 520,
+                        height: 200,
                         folded: false,
                         fixed_height: false,
                         attached_to: "material_properties",
                         sidebar_index: 1
                     }
                 },
-                toolbars: [
-                    light_gizmo_tools_toolbar,
-                    light_quickbuttons_toolbar,
-                    light_shadow_quality_toolbar,
-                    light_settings_toolbar,
-                    light_shadow_clip_settings_toolbar,
-                    light_shadow_bounds_settings_toolbar,
-                    light_shadow_bias_settings_toolbar
-                ]
+                form: {
+                    light_properties_label: {
+                        type: 'bar_display',
+                        value: tl('property.light_settings'),
+                        icon: 'light',
+                        paragraph: false,
+                        expand: true,
+                        color: 'var(--color-text)'
+                    },
+                    light_type: {
+                        type: 'compact_select',
+                        description: tl('property.light_type'),
+                        background: 'transparent',
+                        icon_mode: true,
+                        options: {
+                            point: { name: tl('property.light_type.point'), icon: 'lightbulb' },
+                            directional: { name: tl('property.light_type.directional'), icon: 'light_mode' },
+                            spot: { name: tl('property.light_type.spot'), icon: 'highlight' }
+                        }
+                    },
+                    light_color: {
+                        type: 'advanced_color',
+                        value: tinycolor('ffffff'),
+                        title: tl('property.light_color'),
+                        description: tl('property.light_color'),
+                        alpha: false
+                    },
+                    light_temperature: {
+                        type: 'combo_slider',
+                        label: tl('property.light_temperature'),
+                        description: tl('property.light_temperature.desc'),
+                        icon: 'thermostat',
+                        background: 'transparent',
+                        color: 'var(--color-warning)',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 6500,
+                        resettable: true,
+                        reset_value: 6500,
+                        min: 2700,
+                        max: 6500,
+                        step: 100,
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_temperature')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_temperature')),
+                        onDrag: (value, event, isNumberInput) => {
+                            lightPropertiesPanel.form.form_data.light_color.setValue(kelvinToTinyColor(value));
+                        }
+                    },
+                    cast_shadows: {
+                        type: 'action_toggle',
+                        description: tl('property.cast_shadows') + '\n' + tl('property.cast_shadows.desc'),
+                        icon_size: '24px',
+                        animate: false,
+                        icon_on: 'stroke_partial',
+                        icon_off: 'contrast_rtl_off',
+                        bg_on: 'var(--color-accent)',       // Red background when locked
+                        bg_off: 'transparent',
+                        color_on: 'var(--color-ui)',    // White icon when locked
+                        color_off: 'var(--color-subtle_text)', // Dimmed icon when unlocked
+                        value: false
+                    },
+                    shadow_resolution: {
+                        type: 'compact_select',
+                        label: tl('property.shadow_resolution'),
+                        hide_label: true,
+                        description: tl('property.shadow_resolution.desc'),
+                        background: 'transparent',
+                        icon_mode: true,
+                        disable: false,
+                        disable_condition: () => { return false; },
+                        options: {
+                            256: { name: '256', icon: 'switch_access' },
+                            512: { name: '512', icon: 'high_density' },
+                            1024: { name: '1024', icon: '1k' },
+                            2048: { name: '2048', icon: '2k' },
+                            4096: { name: '4096', icon: '4k' }
+                        },
+                        disable: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc')
+                    },
+                    studio_shadow_resolution: {
+                        type: 'compact_select',
+                        label: tl('property.studio_shadow_resolution'),
+                        hide_label: true,
+                        description: tl('property.studio_shadow_resolution.desc'),
+                        background: 'transparent',
+                        icon_mode: true,
+                        options: {
+                            0: { name: tl('light_manager.option.shadow_same_preview'), icon: 'monitor' },
+                            256: { name: '256', icon: 'switch_access' },
+                            512: { name: '512', icon: 'high_density' },
+                            1024: { name: '1024', icon: '1k' },
+                            2048: { name: '2048', icon: '2k' },
+                            4096: { name: '4096', icon: '4k' },
+                            8192: { name: '8192 — Pro', icon: '8k' },
+                            16384: { name: '16384 — Ultra', icon: 'pages' }
+                        },
+                        disable: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc')
+                    },
+                    light_intensity: {
+                        type: 'combo_slider',
+                        label: tl('property.light_intensity'),
+                        description: tl('property.light_intensity.desc'),
+                        color: 'var(--color-axis-w)',
+                        value: 1.0,
+                        resettable: true,
+                        reset_value: 1.0,
+                        min: 0.0,
+                        max: 10.0,
+                        step: 0.1,
+                        allow_higher: true,
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_intensity')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_intensity'))
+                    },
+
+                    light_area_label: {
+                        type: 'bar_display',
+                        icon: 'wb_incandescent',
+                        paragraph: false,
+                        expand: false,
+                        color: 'var(--color-subtle_text)',
+                        description: tl('property.light_settings')
+                    },
+
+                    light_distance: {
+                        type: 'combo_slider',
+                        label: tl('property.distance'),
+                        description: tl('property.distance.desc'),
+                        icon: 'filter_tilt_shift',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 7 ? markerColors[7].pastel : '#BDFFA6') : '#BDFFA6',
+                        icon_color: markerColors ? (markerColors.length >= 7 ? markerColors[7].pastel : '#BDFFA6') : '#BDFFA6',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 0.0,
+                        resettable: true,
+                        reset_value: 0.0,
+                        min: 0.0,
+                        max: 128.0,
+                        step: 0.01,
+                        allow_higher: true,
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_distance')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_distance'))
+                    },
+
+                    light_cone_settings_label: {
+                        type: 'bar_display',
+                        icon: 'highlight',
+                        paragraph: false,
+                        expand: false,
+                        color: 'var(--color-subtle_text)',
+                        description: tl('property.light_cone_settings')
+                    },
+
+                    light_cone_angle: {
+                        type: 'combo_slider',
+                        label: tl('property.cone_angle'),
+                        description: tl('property.cone_angle.desc'),
+                        icon: 'wifi_tethering',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 1 ? markerColors[1].pastel : '#FFF899') : '#FFF899',
+                        icon_color: markerColors ? (markerColors.length >= 1 ? markerColors[1].pastel : '#FFF899') : '#FFF899',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 45.0,
+                        resettable: true,
+                        reset_value: 45.0,
+                        min: 0.1,
+                        max: 89.9,
+                        step: 0.01,
+                        disable: false,
+                        disable_condition: () => { return !spotLightCondition(); },
+                        disable_desc: tl('property.light_spot_settings.disabled.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_cone_angle')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_cone_angle'))
+                    },
+
+                    light_cone_penumbra: {
+                        type: 'combo_slider',
+                        label: tl('property.cone_penumbra'),
+                        description: tl('property.cone_penumbra.desc'),
+                        icon: 'deblur',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 0 ? markerColors[0].pastel : '#A2EBFF') : '#A2EBFF',
+                        icon_color: markerColors ? (markerColors.length >= 0 ? markerColors[0].pastel : '#A2EBFF') : '#A2EBFF',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 0.0,
+                        resettable: true,
+                        reset_value: 0.0,
+                        min: 0.0,
+                        max: 1.0,
+                        step: 0.01,
+                        disable: false,
+                        disable_condition: () => { return !spotLightCondition(); },
+                        disable_desc: tl('property.light_spot_settings.disabled.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_penumbra')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_penumbra'))
+                    },
+
+
+                    shadow_properties_label: {
+                        type: 'bar_display',
+                        value: tl('property.shadow_settings'),
+                        icon: 'sunny_snowing',
+                        paragraph: false,
+                        expand: false,
+                        color: 'var(--color-text)',
+                        disable: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc')
+                    },
+
+                    shadow_tuning: {
+                        type: 'bar_display',
+                        icon: 'settings_motion_mode',
+                        paragraph: false,
+                        expand: false,
+                        color: 'var(--color-subtle_text)'
+                    },
+                    shadow_softness: {
+                        type: 'combo_slider',
+                        label: tl('property.shadow_softness'),
+                        description: tl('property.shadow_softness.desc'),
+                        icon: 'motion_mode',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 9 ? markerColors[9].pastel : '#E0E9FB') : '#E0E9FB',
+                        icon_color: markerColors ? (markerColors.length >= 9 ? markerColors[9].pastel : '#E0E9FB') : '#E0E9FB',
+                        compact: true,
+                        popup_width: '340px',
+                        value: DEFAULT_SHADOW_SOFTNESS,
+                        resettable: true,
+                        reset_value: DEFAULT_SHADOW_SOFTNESS,
+                        min: 0.0,
+                        max: 8.0,
+                        step: 0.05,
+                        disable: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_softness')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_softness'))
+                    },
+                    shadow_clip_label: {
+                        type: 'bar_display',
+                        icon: 'content_cut',
+                        paragraph: false,
+                        expand: false,
+                        color: 'var(--color-subtle_text)',
+                        description: tl('property.shadow_clip') + '\n' + tl('property.shadow_clip.desc')
+                    },
+                    shadow_near: {
+                        type: 'combo_slider',
+                        label: tl('property.shadow_near'),
+                        icon: 'arrows_input',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 2 ? markerColors[2].pastel : '#F1BB75') : '#F1BB75',
+                        icon_color: markerColors ? (markerColors.length >= 2 ? markerColors[2].pastel : '#F1BB75') : '#F1BB75',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 0.1,
+                        resettable: true,
+                        reset_value: 0.1,
+                        min: 0.0,
+                        max: 1.0,
+                        step: 0.1,
+                        allow_higher: true,
+                        disable: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_clip')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_clip'))
+                    },
+                    shadow_far: {
+                        type: 'combo_slider',
+                        label: tl('property.shadow_far'),
+                        icon: 'arrows_output',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 3 ? markerColors[3].pastel : '#FF9B97') : '#FF9B97',
+                        icon_color: markerColors ? (markerColors.length >= 3 ? markerColors[3].pastel : '#FF9B97') : '#FF9B97',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 128.0,
+                        resettable: true,
+                        reset_value: 128.0,
+                        min: 0.1,
+                        max: 128.0,
+                        step: 0.1,
+                        allow_higher: true,
+                        disable: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_clip')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_clip'))
+                    },
+                    shadow_bounds: {
+                        type: 'combo_slider',
+                        label: tl('property.shadow_bounds'),
+                        description: tl('property.shadow_bounds.desc'),
+                        icon: 'activity_zone',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 4 ? markerColors[4].pastel : '#C5A6E8') : '#C5A6E8',
+                        icon_color: markerColors ? (markerColors.length >= 4 ? markerColors[4].pastel : '#C5A6E8') : '#C5A6E8',
+                        compact: true,
+                        popup_width: '340px',
+                        value: 32.0,
+                        resettable: true,
+                        reset_value: 32.0,
+                        min: 1.0,
+                        max: 64.0,
+                        step: 1.0,
+                        allow_higher: true,
+                        disable: false,
+                        disable_condition: () => { return !directionalShadowCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_bounds')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_bounds'))
+                    },
+                    shadow_biases_label: {
+                        type: 'bar_display',
+                        icon: 'transition_fade',
+                        paragraph: false,
+                        expand: false,
+                        color: 'var(--color-subtle_text)',
+                        description: tl('property.shadow_biases') + '\n' + tl('property.shadow_biases.desc')
+                    },
+                    shadow_bias: {
+                        type: 'combo_slider',
+                        label: tl('property.shadow_bias'),
+                        description: tl('property.shadow_bias.desc'),
+                        icon: 'blur_circular',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 5 ? markerColors[5].pastel : '#A6C8FF') : '#A6C8FF',
+                        icon_color: markerColors ? (markerColors.length >= 5 ? markerColors[5].pastel : '#A6C8FF') : '#A6C8FF',
+                        compact: true,
+                        popup_width: '340px',
+                        value: DEFAULT_SHADOW_BIAS,
+                        resettable: true,
+                        reset_value: DEFAULT_SHADOW_BIAS,
+                        min: -0.05,
+                        max: 0.05,
+                        step: 0.0001,
+                        allow_higher: true,
+                        allow_lower: true,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_bias')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_bias'))
+                    },
+                    shadow_normal_bias: {
+                        type: 'combo_slider',
+                        label: tl('property.shadow_normal_bias'),
+                        description: tl('property.shadow_normal_bias.desc'),
+                        icon: 'stroke_full',
+                        background: 'transparent',
+                        color: markerColors ? (markerColors.length >= 6 ? markerColors[6].pastel : '#7BFFA3') : '#7BFFA3',
+                        icon_color: markerColors ? (markerColors.length >= 6 ? markerColors[6].pastel : '#7BFFA3') : '#7BFFA3',
+                        compact: true,
+                        popup_width: '340px',
+                        value: DEFAULT_SHADOW_NORMAL_BIAS,
+                        resettable: true,
+                        reset_value: DEFAULT_SHADOW_NORMAL_BIAS,
+                        min: -1.0,
+                        max: 1.0,
+                        step: 0.05,
+                        allow_higher: false,
+                        allow_lower: false,
+                        disable_condition: () => { return !shadowLightCondition(); },
+                        disable_desc: tl('property.cast_shadows_off.desc'),
+                        onBefore: () => beginLightEdit(translateLightManager('light_manager.undo.change_shadow_normal_bias')),
+                        onAfter: () => finishLightEdit(translateLightManager('light_manager.undo.change_shadow_normal_bias'))
+                    }
+                }
             });
             window.light_properties_panel = lightPropertiesPanel;
-            window.LIGHT_SETTINGS_GROUP = LIGHT_SETTINGS_GROUP;
+
+            window.applyIndestructibleFormGroups(lightPropertiesPanel.form, [
+                {
+
+                    elements: ['light_type', 'light_color', 'light_temperature', '+', '_', '+', 'cast_shadows', 'shadow_resolution', 'studio_shadow_resolution'],
+                    gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: {
+                        light_type: '0 0 auto',
+                        light_color: '0 0 auto',
+                        light_temperature: '0 0 auto',
+                        cast_shadows: '0 0 auto',
+                        shadow_resolution: '0 0 auto',
+                        studio_shadow_resolution: '0 0 auto'
+                    }
+                },
+                {
+                    elements: ['light_intensity'],
+                    gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: {
+                        light_intensity: '1 1 100%'
+                    }
+                },
+                {
+                    elements: ['light_area_label', 'light_distance', '+', '_', '+', 'light_cone_settings_label', 'light_cone_angle', 'light_cone_penumbra', '-'],
+                    gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: {
+                        light_area_label: '0 0 auto',
+                        light_distance: '0 0 auto',
+                        light_cone_settings_label: '0 0 auto',
+                        light_cone_angle: '0 0 auto',
+                        light_cone_penumbra: '0 0 auto'
+                    }
+                },
+                {
+                    elements: ['shadow_properties_label', '+', 'shadow_tuning', 'shadow_softness'],
+                    gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: {
+                        shadow_properties_label: '0 0 auto',
+                        shadow_tuning: '0 0 auto',
+                        shadow_softness: '0 0 auto'
+                    }
+                },
+                {
+                    elements: ['shadow_clip_label', 'shadow_near', 'shadow_far', 'shadow_bounds', '+', '_', '+', 'shadow_biases_label', 'shadow_bias', 'shadow_normal_bias'],
+                    gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: {
+                        shadow_clip_label: '0 0 auto',
+                        shadow_near: '0 0 auto',
+                        shadow_far: '0 0 auto',
+                        shadow_bounds: '0 0 auto',
+                        shadow_biases_label: '0 0 auto',
+                        shadow_bias: '0 0 auto',
+                        shadow_normal_bias: '0 0 auto'
+                    }
+                }
+            ]);
 
             const lightPanelStyles = Blockbench.addCSS(`
                 #panel_light_properties {
@@ -8337,6 +10217,117 @@ function initialize_light_plugin() {
             `);
             deletables.push(lightPanelStyles);
 
+            lightPropertiesPanel.form.form_data.light_color.colorpicker.onChange = (color) => {
+                if (syncingLightSettings) return;
+                let newColor = tinycolor(color);
+                applyLightPanelValue('color', [newColor._r, newColor._g, newColor._b], translateLightManager('light_manager.undo.change_color'));
+            };
+
+            lightPropertiesPanel.form.form_data.light_color.colorpicker.onBefore = () => beginLightEdit(translateLightManager('light_manager.undo.change_color'));
+            lightPropertiesPanel.form.form_data.light_color.colorpicker.onAfter = () => finishLightEdit(translateLightManager('light_manager.undo.change_color'));
+            lightPropertiesPanel.form.on('change', ({ result }) => {
+                if (syncingLightSettings) return;
+
+                if (result.light_type !== undefined) {
+                    applyLightPanelValue('light_type', result.light_type, translateLightManager('light_manager.undo.change_type'));
+                }
+
+                if (result.light_color !== undefined) {
+                    const newColor = tinycolor(result.light_color);
+                    applyLightPanelValue('color', [newColor._r, newColor._g, newColor._b], translateLightManager('light_manager.undo.change_color'));
+                }
+
+                if (result.light_temperature !== undefined) {
+                    applyLightPanelValue('temperature', result.light_temperature);
+                    lightPropertiesPanel.form.form_data.light_temperature.setColor(kelvinToTinyColor(result.light_temperature));
+                }
+
+                if (result.light_intensity !== undefined) {
+                    applyLightPanelValue('intensity', result.light_intensity);
+                }
+
+                if (result.light_distance !== undefined) {
+                    applyLightPanelValue('distance', result.light_distance);
+                }
+
+                if (result.light_cone_angle !== undefined) {
+                    applyLightPanelValue('angle', result.light_cone_angle);
+                }
+
+                if (result.light_cone_penumbra !== undefined) {
+                    applyLightPanelValue('penumbra', result.light_cone_penumbra);
+                }
+
+                if (result.cast_shadows !== undefined) {
+                    applyLightPanelValue('has_shadow', result.cast_shadows, translateLightManager('light_manager.undo.toggle_shadows'));
+                }
+
+                if (result.shadow_resolution !== undefined) {
+                    applyLightPanelValue('shadow_resolution', result.shadow_resolution, translateLightManager('light_manager.undo.change_shadow_resolution'));
+                }
+
+                if (result.studio_shadow_resolution !== undefined) {
+                    applyLightPanelValue('studio_shadow_resolution', result.studio_shadow_resolution, translateLightManager('light_manager.undo.change_studio_shadow_resolution'));
+                }
+
+                if (result.shadow_softness !== undefined) {
+                    applyLightPanelValue('shadow_softness', result.shadow_softness);
+                }
+
+                if (result.shadow_near !== undefined) {
+                    applyLightPanelValue('shadow_near', result.shadow_near);
+                }
+
+                if (result.shadow_far !== undefined) {
+                    applyLightPanelValue('shadow_far', result.shadow_far);
+                }
+
+                if (result.shadow_bounds !== undefined) {
+                    applyLightPanelValue('shadow_bounds', result.shadow_bounds);
+                }
+
+                if (result.shadow_bias !== undefined) {
+                    applyLightPanelValue('shadow_bias', result.shadow_bias);
+                }
+
+                if (result.shadow_normal_bias !== undefined) {
+                    applyLightPanelValue('shadow_normal_bias', result.shadow_normal_bias);
+                }
+            });
+
+            const syncLightSettingsPanel = (light) => {
+                if (!light) return;
+                if (!lightPropertiesPanel) return;
+                if (!lightPropertiesPanel.form.form_data) return;
+                syncingLightSettings = true;
+                try {
+                    lightPropertiesPanel.form.form_data.light_type.setValue(light.light_type);
+                    lightPropertiesPanel.form.form_data.light_intensity.setValue(light.intensity);
+                    lightPropertiesPanel.form.form_data.light_color.setValue(LightManagerUtils.colorHex(light.color));
+
+                    let selectedTemp = light.temperature || 6500;
+                    lightPropertiesPanel.form.form_data.light_temperature.setValue(selectedTemp);
+                    lightPropertiesPanel.form.form_data.light_temperature.setColor(kelvinToTinyColor(selectedTemp));
+                    lightPropertiesPanel.form.form_data.light_distance.setValue(light.distance);
+                    lightPropertiesPanel.form.form_data.light_cone_angle.setValue(light.angle);
+                    lightPropertiesPanel.form.form_data.light_cone_penumbra.setValue(light.penumbra);
+
+                    lightPropertiesPanel.form.form_data.cast_shadows.setValue(light.has_shadow !== false);
+                    lightPropertiesPanel.form.form_data.shadow_resolution.setValue(String(LightManagerUtils.shadowResolution(light.shadow_resolution)));
+                    lightPropertiesPanel.form.form_data.studio_shadow_resolution.setValue(String(LightManagerUtils.studioShadowResolution(light.studio_shadow_resolution)));
+                    lightPropertiesPanel.form.form_data.shadow_near.setValue(light.shadow_near);
+                    lightPropertiesPanel.form.form_data.shadow_far.setValue(light.shadow_far);
+                    lightPropertiesPanel.form.form_data.shadow_bounds.setValue(light.shadow_bounds);
+                    lightPropertiesPanel.form.form_data.shadow_softness.setValue(light.shadow_softness);
+                    lightPropertiesPanel.form.form_data.shadow_bias.setValue(light.shadow_bias);
+                    lightPropertiesPanel.form.form_data.shadow_normal_bias.setResetValue(LightManagerUtils.defaultShadowNormalBias(light));
+                    lightPropertiesPanel.form.form_data.shadow_normal_bias.setValue(light.shadow_normal_bias);
+                } finally {
+                    syncingLightSettings = false;
+                }
+                lightPropertiesPanel.form.update();
+            };
+
             const syncLightManagerShadows = (options = {}) => {
                 markLightManagerShadowsDirty(options);
                 configureLightManagerRenderers();
@@ -8400,9 +10391,6 @@ function initialize_light_plugin() {
                 }
             });
             deletables.push(lightPanelSelectionListener);
-            Object.values(LIGHT_SETTINGS_GROUP).forEach(item => {
-                if (item && typeof item.delete === 'function') deletables.push(item);
-            });
             deletables.push(lightPropertiesPanel);
 
             window.LIGHT_MANAGER_LOADED = true;
@@ -8445,12 +10433,16 @@ function initialize_light_plugin() {
             }
 
             delete window.LIGHT_MANAGER_LOADED;
+            if (window.applyIndestructibleFormGroups === applyIndestructibleFormGroups) {
+                delete window.applyIndestructibleFormGroups;
+            }
+            if (window.LightManagerUI === lightManagerUIApi) delete window.LightManagerUI;
+            lightManagerUIApi = null;
             delete window.ComboSlider;
             delete window.CompactDropdownSelect;
             delete window.BarDisplay;
             delete window.TextInputWidget;
             delete window.light_properties_panel;
-            delete window.LIGHT_SETTINGS_GROUP;
             delete window.LightElement;
             delete window.LightAnimator;
             delete window.LightManagerAreaGizmos;

--- a/light_manager.js
+++ b/light_manager.js
@@ -53,6 +53,256 @@ async function generateIconBase64(iconName, size, {
 
 window.generateIconBase64 = generateIconBase64;
 
+/*
+ * Shared project lifecycle for the Lightflow suite.
+ *
+ * Blockbench only deserializes properties and custom outliner types that are
+ * registered when the project codec starts parsing. A plugin installed or
+ * enabled after a project is already open therefore needs the original model
+ * JSON to recover those fields. Keep that recovery in one place and give all
+ * Lightflow plugins the same project-generation guard so work queued by the
+ * previous project can never render into the next one.
+ */
+function createLightflowLifecycleRuntime() {
+    const modelByProject = new WeakMap();
+    const modelRequestByProject = new WeakMap();
+    const hydrators = new Map();
+    const listeners = [];
+    let activeProject = typeof Project !== 'undefined' ? (Project || null) : null;
+    let generation = activeProject ? 1 : 0;
+    let disposed = false;
+    let ownerAttached = true;
+    let runtimeApi = null;
+
+    const parseModel = content => {
+        if (content && typeof content === 'object') return content;
+        if (typeof content !== 'string' || !content.trim()) return null;
+        try {
+            return typeof autoParseJSON === 'function'
+                ? autoParseJSON(content, false)
+                : JSON.parse(content);
+        } catch (error) {
+            return null;
+        }
+    };
+
+    const captureModel = (project, model) => {
+        if (!project || !model || typeof model !== 'object') return null;
+        modelByProject.set(project, model);
+        return model;
+    };
+
+    const readProjectModel = project => {
+        if (!project) return Promise.resolve(null);
+        const captured = modelByProject.get(project);
+        if (captured) return Promise.resolve(captured);
+        const pending = modelRequestByProject.get(project);
+        if (pending) return pending;
+
+        const path = project.save_path || project.path || '';
+        if (!path || typeof Blockbench?.read !== 'function') return Promise.resolve(null);
+
+        const request = new Promise(resolve => {
+            let settled = false;
+            const fallbackTimer = setTimeout(() => finish(null), 5000);
+            const finish = value => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(fallbackTimer);
+                resolve(value || null);
+            };
+            try {
+                const result = Blockbench.read([path], { errorbox: false }, files => {
+                    const model = parseModel(files?.[0]?.content);
+                    if (model) captureModel(project, model);
+                    finish(model);
+                });
+                if (result === false) finish(null);
+            } catch (error) {
+                finish(null);
+            }
+        });
+        modelRequestByProject.set(project, request);
+        return request;
+    };
+
+    const isCurrent = (project, expectedGeneration = generation) => {
+        return !disposed && expectedGeneration === generation && project === activeProject && project === window.Project;
+    };
+
+    const runHydrator = async (entry, reason) => {
+        if (!entry || entry.lastGeneration === generation) return;
+        const runGeneration = generation;
+        const project = activeProject;
+        entry.lastGeneration = runGeneration;
+        let model = project ? (modelByProject.get(project) || null) : null;
+        if (project && !model && (project.save_path || project.path)) {
+            model = await readProjectModel(project);
+        }
+        if (disposed || runGeneration !== generation || project !== activeProject) return;
+        try {
+            await entry.callback({
+                project,
+                model,
+                reason,
+                generation: runGeneration,
+                isCurrent: () => isCurrent(project, runGeneration)
+            });
+        } catch (error) {
+            console.warn(`[Lightflow] Project hydration failed for ${entry.id}`, error);
+        }
+    };
+
+    const hydrateAll = reason => {
+        hydrators.forEach(entry => runHydrator(entry, reason));
+    };
+
+    const notifyDeferredTransition = reason => {
+        const transitionGeneration = generation;
+        const project = activeProject;
+        hydrators.forEach(entry => {
+            try {
+                Promise.resolve(entry.callback({
+                    project,
+                    model: project ? (modelByProject.get(project) || null) : null,
+                    reason,
+                    deferred: true,
+                    generation: transitionGeneration,
+                    isCurrent: () => isCurrent(project, transitionGeneration)
+                })).catch(error => {
+                    console.warn(`[Lightflow] Project transition failed for ${entry.id}`, error);
+                });
+            } catch (error) {
+                console.warn(`[Lightflow] Project transition failed for ${entry.id}`, error);
+            }
+        });
+    };
+
+    const begin = (project, reason, model, options = {}) => {
+        const nextProject = project || null;
+        if (model && nextProject) captureModel(nextProject, model);
+        const changed = nextProject !== activeProject || options.force === true;
+        if (changed) {
+            activeProject = nextProject;
+            generation += 1;
+        }
+        if (changed && options.deferHydration === true) {
+            notifyDeferredTransition(reason);
+        } else if (changed || options.hydrate === true) {
+            hydrateAll(reason);
+        }
+    };
+
+    const registerHydrator = (id, callback) => {
+        const entry = { id, callback, lastGeneration: -1 };
+        hydrators.set(id, entry);
+        Promise.resolve().then(() => runHydrator(entry, 'plugin_ready'));
+        return {
+            delete() {
+                if (hydrators.get(id) === entry) hydrators.delete(id);
+                if (!ownerAttached && hydrators.size === 0) disposeRuntime();
+            }
+        };
+    };
+
+    const restoreCustomElements = (model, type, ElementType) => {
+        if (!model || !Array.isArray(model.elements) || !ElementType || !window.Outliner) {
+            return { restored: 0, updated: 0 };
+        }
+        let restored = 0;
+        let updated = 0;
+        model.elements.filter(template => template?.type === type && template.uuid).forEach(template => {
+            const existing = (Outliner.elements || []).find(element => element?.uuid === template.uuid);
+            if (existing instanceof ElementType) {
+                existing.extend?.(template);
+                updated += 1;
+                return;
+            }
+
+            const parent = existing?.parent || 'root';
+            const parentArray = existing?.getParentArray?.() || (parent === 'root' ? Outliner.root : parent?.children);
+            const index = Array.isArray(parentArray) ? parentArray.indexOf(existing) : -1;
+            const wasSelected = !!existing?.selected;
+            existing?.remove?.();
+
+            const replacement = new ElementType(template, template.uuid).init();
+            replacement.addTo(parent, index >= 0 ? index : -1);
+            if (wasSelected) replacement.markAsSelected?.();
+            restored += 1;
+        });
+        if (restored && typeof Blockbench?.dispatchEvent === 'function') {
+            Blockbench.dispatchEvent('update_selection');
+        }
+        return { restored, updated };
+    };
+
+    if (typeof Blockbench?.on === 'function') {
+        listeners.push(Blockbench.on('load_project', event => {
+            const project = window.Project || activeProject;
+            if (project && event?.model) captureModel(project, event.model);
+            begin(project, 'load_project', event?.model, { force: true, deferHydration: true });
+        }));
+        listeners.push(Blockbench.on('select_project', event => {
+            const project = event?.project || window.Project || null;
+            begin(project, 'select_project', null, { force: true, deferHydration: true });
+            const selectedGeneration = generation;
+            Promise.resolve().then(() => {
+                if (disposed || selectedGeneration !== generation || project !== activeProject) return;
+                begin(project, 'select_project_ready', null, { hydrate: true });
+            });
+        }));
+        listeners.push(Blockbench.on('new_project', event => {
+            begin(event?.project || window.Project || null, 'new_project', null, { force: true, hydrate: true });
+        }));
+        listeners.push(Blockbench.on('close_project', () => {
+            // Blockbench emits close_project before it clears ProjectData and
+            // Outliner registries. Cancel old work immediately, then hydrate
+            // the empty state once its synchronous close cleanup has run.
+            begin(null, 'close_project', null, { force: true, deferHydration: true });
+            const closeGeneration = generation;
+            Promise.resolve().then(() => {
+                if (disposed || closeGeneration !== generation || activeProject !== null) return;
+                begin(null, 'close_project_ready', null, { hydrate: true });
+            });
+        }));
+    }
+    const parsedListener = window.Codecs?.project?.on?.('parsed', () => {
+        begin(window.Project || activeProject, 'parsed', null, { hydrate: true });
+    });
+    if (parsedListener) listeners.push(parsedListener);
+
+    const disposeRuntime = () => {
+        if (disposed) return;
+        disposed = true;
+        generation += 1;
+        hydrators.clear();
+        listeners.splice(0).forEach(listener => listener?.delete?.());
+        if (window.LightflowLifecycle === runtimeApi) delete window.LightflowLifecycle;
+    };
+
+    runtimeApi = {
+        apiVersion: 1,
+        get disposed() { return disposed; },
+        get hydratorCount() { return hydrators.size; },
+        get generation() { return generation; },
+        get project() { return activeProject; },
+        captureModel,
+        readProjectModel,
+        isCurrent,
+        registerHydrator,
+        restoreCustomElements,
+        attachOwner() {
+            if (!disposed) ownerAttached = true;
+        },
+        releaseOwner() {
+            ownerAttached = false;
+            if (hydrators.size === 0) disposeRuntime();
+        },
+        dispose: disposeRuntime
+    };
+    return runtimeApi;
+}
+
 const LIGHT_MANAGER_STORAGE_KEYS = {
     areaGizmos: 'light_manager_show_area_gizmos'
 };
@@ -212,7 +462,9 @@ const LIGHT_MANAGER_DEFAULT_UPDATE_OPTIONS = {
     shadows: true,
     scene: true,
     gizmos: true,
-    studio: false
+    studio: false,
+    elements: null,
+    cleanup: true
 };
 
 function translateLightManager(key, fallback) {
@@ -814,14 +1066,14 @@ function configureLightManagerRendererShadows(renderer) {
     }
 
     /*
-     * A resolution change disposes shadow.map and creates a fresh GPU target.
-     * Do not lock WebGLShadowMap in manual mode here: with autoUpdate = false,
-     * a later normal preview render can sample the newly allocated-but-empty
-     * target before a shadow pass has populated it, which makes the whole
-     * scene look fully occluded.
+     * Shadow maps are the most expensive part of an otherwise simple slider
+     * interaction. Lightflow tracks every transform, geometry and shadow
+     * mutation, so normal viewports can render them on demand. Studio Render
+     * temporarily opts its own renderer back into automatic updates while it
+     * owns the shared shadow targets.
      */
-    if (renderer.shadowMap.autoUpdate !== true) {
-        renderer.shadowMap.autoUpdate = true;
+    if (renderer.shadowMap.autoUpdate !== false) {
+        renderer.shadowMap.autoUpdate = false;
         changed = true;
     }
 
@@ -1873,22 +2125,33 @@ function cancelLightManagerElementUpdate() {
 }
 
 function normalizeLightManagerUpdateOptions(options = {}) {
+    const requestedElements = Array.isArray(options.elements)
+        ? options.elements.filter(Boolean)
+        : (options.element ? [options.element] : null);
     return {
         shadows: options.shadows !== false,
         scene: options.scene !== false,
         gizmos: options.gizmos !== false,
-        studio: !!(options.studio || options.studioRender)
+        studio: !!(options.studio || options.studioRender),
+        elements: requestedElements,
+        cleanup: options.cleanup !== false && !requestedElements
     };
 }
 
 function mergeLightManagerUpdateOptions(previous, next) {
     if (!previous) return next;
 
+    const elements = previous.elements === null || next.elements === null
+        ? null
+        : Array.from(new Set([...(previous.elements || []), ...(next.elements || [])]));
+
     return {
         shadows: previous.shadows || next.shadows,
         scene: previous.scene || next.scene,
         gizmos: previous.gizmos || next.gizmos,
-        studio: previous.studio || next.studio
+        studio: previous.studio || next.studio,
+        elements,
+        cleanup: previous.cleanup || next.cleanup || elements === null
     };
 }
 
@@ -2753,11 +3016,13 @@ window.LightManagerViewportControls = {
             if (property === 'rotation' || property === 'position') {
                 LightElement.preview_controller.updateTransform(light);
             }
-            LightElement.preview_controller.updateSelection(light);
+            LightElement.preview_controller.updateSelection(light, { gizmos: false });
         }
-        window.update_light_element_callback?.(this.getLightUpdateOptions(property));
-        window.LightManagerAreaGizmos?.updateAll();
-        this.updateAll();
+        window.update_light_element_callback?.({
+            ...this.getLightUpdateOptions(property),
+            elements: [light],
+            cleanup: false
+        });
     },
 
     getMovableSelection() {
@@ -2881,15 +3146,21 @@ window.LightManagerViewportControls = {
         if (window.Canvas && typeof Canvas.updateView === 'function') {
             Canvas.updateView({
                 elements,
-                element_aspects: { transform: true, geometry: true }
+                element_aspects: { transform: true }
             });
         }
         lightElements.forEach(light => {
             LightManagerUtils.sanitizeLight(light);
-            LightElement.preview_controller?.updateSelection(light);
+            LightElement.preview_controller?.updateSelection(light, { gizmos: false });
         });
         if (lightElements.length) {
-            window.update_light_element_callback?.({ shadows: true, scene: false, gizmos: true });
+            window.update_light_element_callback?.({
+                shadows: true,
+                scene: false,
+                gizmos: false,
+                elements: lightElements,
+                cleanup: false
+            });
         }
         window.LightManagerAreaGizmos?.updateAll();
         this.updateAll();
@@ -3377,14 +3648,23 @@ function runLightManagerElementUpdate(options = LIGHT_MANAGER_DEFAULT_UPDATE_OPT
         window.scene.add(window.three_lights_group);
     }
 
-    // Keep track of active UUIDs to remove deleted lights
-    const activeUuids = LIGHT_MANAGER_UPDATE_STATE.activeUuids;
-    activeUuids.clear();
+    // A direct control edit only needs to touch the edited light. Full
+    // registry scans are reserved for project/lifecycle and deletion updates.
+    const allLights = typeof LightElement !== 'undefined' && Array.isArray(LightElement.all)
+        ? LightElement.all
+        : [];
+    const targetLights = updateOptions.elements
+        ? updateOptions.elements.filter(element => allLights.includes(element))
+        : allLights;
 
-    if (typeof LightElement !== 'undefined' && LightElement.all) {
-        LightElement.all.forEach(element => {
+    // Keep track of active UUIDs to remove deleted lights on full updates.
+    const activeUuids = LIGHT_MANAGER_UPDATE_STATE.activeUuids;
+    if (updateOptions.cleanup) activeUuids.clear();
+
+    if (targetLights.length) {
+        targetLights.forEach(element => {
             LightManagerUtils.sanitizeLight(element);
-            activeUuids.add(element.uuid);
+            if (updateOptions.cleanup) activeUuids.add(element.uuid);
 
             let light = window.three_lights[element.uuid];
 
@@ -3472,16 +3752,19 @@ function runLightManagerElementUpdate(options = LIGHT_MANAGER_DEFAULT_UPDATE_OPT
         });
     }
 
-    // Cleanup deleted lights
-    for (const uuid in window.three_lights) {
-        if (!activeUuids.has(uuid)) {
+    // Cleanup deleted lights only when the caller requested a registry pass.
+    if (updateOptions.cleanup) {
+        for (const uuid in window.three_lights) {
             const light = window.three_lights[uuid];
-            if (light) {
-                window.three_lights_group.remove(light);
-                if (light.target) window.three_lights_group.remove(light.target);
-                if (light.dispose) light.dispose();
+            if (light?.userData?.lightflowEnvironmentVirtual) continue;
+            if (!activeUuids.has(uuid)) {
+                if (light) {
+                    window.three_lights_group.remove(light);
+                    if (light.target) window.three_lights_group.remove(light.target);
+                    if (light.dispose) light.dispose();
+                }
+                delete window.three_lights[uuid];
             }
-            delete window.three_lights[uuid];
         }
     }
 
@@ -4929,12 +5212,14 @@ function initialize_light_plugin() {
     let lightManagerUIApi = null;
     let lightTextures = {}; // THREE.Texture instances will be loaded here
     let originalAnimatorPreview = null;
+    let lightflowLifecycle = null;
 
     const animationSign = Blockbench.isNewerThan('4.99') ? 1 : -1;
 
     function markLightManagerAnimationFrameShadowsDirty() {
         if (!lightManagerHasActiveShadowLights()) return;
         markLightManagerShadowsDirty();
+        invalidateLightManagerShadowMaps();
     }
 
     function patchLightManagerAnimatorPreview() {
@@ -5154,7 +5439,7 @@ function initialize_light_plugin() {
         author: 'MidFord327',
         description: 'Add production-ready point, spot, and directional lights to Blockbench with viewport gizmos, animation support, shadows, and Studio Render controls. Provides the Lightflow lighting foundation for Shader Architect and Studio Render.',
         tags: ['Lightflow', 'Lighting', 'Shadows', 'Animation', 'Rendering', 'Studio'],
-        version: '1.6.5',
+        version: '1.7.0',
         min_version: '4.9.0',
         variant: 'both',
 
@@ -5167,6 +5452,19 @@ function initialize_light_plugin() {
             resetLightManagerShadowState();
             window.LightManagerMarkShadowsDirty = markLightManagerShadowsDirty;
             patchLightManagerAnimatorPreview();
+            const existingLifecycle = window.LightflowLifecycle;
+            if (
+                existingLifecycle?.apiVersion === 1 &&
+                existingLifecycle.disposed === false &&
+                typeof existingLifecycle.registerHydrator === 'function'
+            ) {
+                lightflowLifecycle = existingLifecycle;
+                lightflowLifecycle.attachOwner?.();
+            } else {
+                existingLifecycle?.dispose?.();
+                lightflowLifecycle = createLightflowLifecycleRuntime();
+                window.LightflowLifecycle = lightflowLifecycle;
+            }
 
             // Shared condition/disabled-state support for Light Manager custom FormElements.
             // `show_condition` is normalized to Blockbench's native form condition path. The
@@ -8588,12 +8886,29 @@ function initialize_light_plugin() {
             deletables.push(compactWidgetStyles);
 
 
-            // Configure three-dimensional textures based on the base64 dictionary
-            for (let key in light_icons_b64) {
-                let tex = new THREE.TextureLoader().load(light_icons_b64[key]);
-                tex.magFilter = tex.minFilter = THREE.NearestFilter;
-                lightTextures[key] = tex;
-            }
+            const installLightIconTextures = sources => {
+                Object.entries(sources || {}).forEach(([key, source]) => {
+                    if (!source) return;
+                    const previous = lightTextures[key];
+                    let texture = null;
+                    texture = new THREE.TextureLoader().load(source, () => {
+                        if (lightTextures[key] !== texture) {
+                            texture.dispose?.();
+                            return;
+                        }
+                        if (previous && previous !== texture) previous.dispose?.();
+                        window.LightElement?.all?.forEach?.(element => {
+                            if (element?.light_type === key) {
+                                window.LightElement.preview_controller?.updateSelection?.(element, { gizmos: false });
+                            }
+                        });
+                    });
+                    texture.magFilter = texture.minFilter = THREE.NearestFilter;
+                    lightTextures[key] = texture;
+                });
+            };
+            installLightIconTextures(light_icons_b64);
+            window.LightManagerRefreshIconTextures = installLightIconTextures;
 
             class LightElement extends OutlinerElement {
                 constructor(data, uuid) {
@@ -8830,9 +9145,15 @@ function initialize_light_plugin() {
                     element.mesh.fix_position.copy(element.mesh.position);
                     element.mesh.fix_rotation.copy(element.mesh.rotation);
                     this.updateWindowSize(element);
-                    window.update_light_element_callback?.({ shadows: true, scene: false, gizmos: true });
+                    window.update_light_element_callback?.({
+                        shadows: true,
+                        scene: false,
+                        gizmos: true,
+                        elements: [element],
+                        cleanup: false
+                    });
                 },
-                updateSelection(element) {
+                updateSelection(element, options = {}) {
                     let { mesh } = element;
 
                     let desiredTexture = lightTextures[element.light_type] || lightTextures.point;
@@ -8884,8 +9205,10 @@ function initialize_light_plugin() {
                     mesh.sprite.material.depthTest = !element.selected;
                     mesh.renderOrder = element.selected ? 100 : 0;
 
-                    window.LightManagerAreaGizmos?.updateAll();
-                    window.LightManagerViewportControls?.updateAll();
+                    if (options.gizmos !== false) {
+                        window.LightManagerAreaGizmos?.updateAll();
+                        window.LightManagerViewportControls?.updateAll();
+                    }
                     this.dispatchEvent('update_selection', { element });
                 },
                 updateWindowSize(element) {
@@ -8895,6 +9218,32 @@ function initialize_light_plugin() {
                     }
                 }
             });
+
+            const lightProjectHydrator = lightflowLifecycle?.registerHydrator?.(
+                'light_manager_elements',
+                ({ project, model, isCurrent, deferred }) => {
+                    cancelLightManagerElementUpdate();
+                    if (deferred) return;
+                    if (project && !isCurrent()) return;
+                    if (project) {
+                        lightflowLifecycle.restoreCustomElements(model, 'light', LightElement);
+                    }
+                    if (project && !isCurrent()) return;
+
+                    // A project can legitimately contain no lights. Always do
+                    // one full registry pass so lights owned by the previous
+                    // tab/project are removed instead of leaking into it.
+                    markLightManagerShadowsDirty({ scene: true });
+                    window.update_light_element_callback?.({
+                        immediate: true,
+                        shadows: true,
+                        scene: true,
+                        gizmos: !!project,
+                        cleanup: true
+                    });
+                }
+            );
+            if (lightProjectHydrator) deletables.push(lightProjectHydrator);
 
             // -------------------------------------------------------------
             // TIMELINE OVERRIDES
@@ -9058,7 +9407,13 @@ function initialize_light_plugin() {
                     if (!this.muted.intensity) this.displayIntensity(this.interpolate('intensity'), multiplier);
 
                     this.element.mesh.updateMatrixWorld();
-                    window.update_light_element_callback?.();
+                    window.update_light_element_callback?.({
+                        shadows: true,
+                        scene: false,
+                        gizmos: false,
+                        elements: [this.element],
+                        cleanup: false
+                    });
                 }
             }
 
@@ -9444,9 +9799,14 @@ function initialize_light_plugin() {
                 }
             };
 
-            const getLightPanelUpdateOptions = (property) => {
+            const getLightPanelUpdateOptions = (property, light) => {
+                const partial = {
+                    elements: light ? [light] : [],
+                    cleanup: false
+                };
                 if (property === 'studio_shadow_resolution') {
                     return {
+                        ...partial,
                         shadows: false,
                         scene: false,
                         gizmos: false
@@ -9455,6 +9815,7 @@ function initialize_light_plugin() {
 
                 if (['color', 'temperature', 'intensity'].includes(property)) {
                     return {
+                        ...partial,
                         shadows: false,
                         scene: false,
                         gizmos: false
@@ -9463,6 +9824,7 @@ function initialize_light_plugin() {
 
                 if (['distance'].includes(property)) {
                     return {
+                        ...partial,
                         shadows: false,
                         scene: false,
                         gizmos: true
@@ -9471,13 +9833,30 @@ function initialize_light_plugin() {
 
                 if (['shadow_bias', 'shadow_normal_bias', 'shadow_softness'].includes(property)) {
                     return {
+                        ...partial,
                         shadows: true,
                         scene: false,
                         gizmos: false
                     };
                 }
 
-                return {};
+                if (property === 'has_shadow') {
+                    return {
+                        ...partial,
+                        shadows: true,
+                        // Caster/receiver flags only need the expensive scene
+                        // walk when the first active shadow is enabled.
+                        scene: light?.has_shadow !== false && LIGHT_MANAGER_SHADOW_STATE.sceneDirty,
+                        gizmos: true
+                    };
+                }
+
+                return {
+                    ...partial,
+                    shadows: true,
+                    scene: false,
+                    gizmos: true
+                };
             };
 
             const applyLightPanelValue = (property, value, undoLabel) => {
@@ -9543,15 +9922,14 @@ function initialize_light_plugin() {
 
                 if (property === 'light_type') {
                     light.updateLightIcon();
-                    LightElement.preview_controller?.updateSelection(light);
+                    LightElement.preview_controller?.updateSelection(light, { gizmos: false });
                 }
 
                 if (['temperature', 'color', 'intensity'].includes(property)) {
-                    LightElement.preview_controller?.updateSelection(light);
-                    window.LightManagerAreaGizmos?.updateAll();
+                    LightElement.preview_controller?.updateSelection(light, { gizmos: false });
                 }
 
-                const updateOptions = getLightPanelUpdateOptions(property);
+                const updateOptions = getLightPanelUpdateOptions(property, light);
                 window.update_light_element_callback?.(updateOptions);
                 if (updateOptions.gizmos !== false) {
                     window.LightManagerViewportControls?.updateAll();
@@ -10360,16 +10738,47 @@ function initialize_light_plugin() {
 
                 if (!touchesElements && !touchesGroups) return;
 
-                const sceneChanged = touchesGroups || elements.some(element => {
-                    return element && element.type !== 'light' && !(window.LightElement && element instanceof window.LightElement);
+                const sceneTopologyChanged = elements.some(element => {
+                    const renderElement = element && element.type !== 'light' && !(window.LightElement && element instanceof window.LightElement);
+                    return !!(renderElement && elementAspects.geometry);
                 });
-                syncLightManagerShadows({ scene: sceneChanged });
+                // Transforms change the shadow image, not caster/receiver
+                // membership. Avoid walking every scene mesh while dragging a
+                // Cube or Group; only newly replaced geometry needs that pass.
+                syncLightManagerShadows({ scene: sceneTopologyChanged });
             });
             deletables.push(viewUpdateShadowListener);
 
-            ['finish_edit', 'undo', 'redo', 'load_undo_save', 'select_project'].forEach(eventName => {
+            const finishEditShadowListener = Blockbench.on('finish_edit', ({ aspects } = {}) => {
+                // Direct light controls and transform previews already enqueue
+                // their precise updates. Only an outliner edit can add/remove
+                // registry entries and needs the full cleanup pass.
+                if (!aspects?.outliner) return;
+                window.update_light_element_callback?.({
+                    shadows: true,
+                    scene: false,
+                    gizmos: false,
+                    cleanup: true
+                });
+            });
+            deletables.push(finishEditShadowListener);
+
+            ['undo', 'redo', 'load_undo_save'].forEach(eventName => {
                 const listener = Blockbench.on(eventName, () => {
-                    syncLightManagerShadows({ scene: true });
+                    markLightManagerShadowsDirty({ scene: true });
+                    window.update_light_element_callback?.({
+                        shadows: true,
+                        scene: true,
+                        gizmos: true,
+                        cleanup: true
+                    });
+                });
+                deletables.push(listener);
+            });
+
+            ['add_cube', 'add_mesh', 'add_texture_mesh', 'add_lightflow_volume'].forEach(eventName => {
+                const listener = Blockbench.on(eventName, () => {
+                    markLightManagerShadowsDirty({ scene: true });
                 });
                 deletables.push(listener);
             });
@@ -10452,7 +10861,12 @@ function initialize_light_plugin() {
             delete window.LightManagerMarkShadowsDirty;
             delete window.LightManagerDebugShadows;
             delete window.LightManagerSyncLights;
+            delete window.LightManagerRefreshIconTextures;
             delete window.update_light_element_callback;
+            if (window.LightflowLifecycle === lightflowLifecycle) {
+                lightflowLifecycle?.releaseOwner?.();
+            }
+            lightflowLifecycle = null;
             restoreLightManagerAnimatorPreview();
             restoreLightManagerRendererShadowSettings();
             resetLightManagerShadowState();
@@ -10469,22 +10883,35 @@ async function load_textures() {
         ['spot', 'highlight', 'S']
     ];
 
-    for (const [key, icon, fallbackLabel] of specs) {
+    const generated = await Promise.all(specs.map(async ([key, icon, fallbackLabel]) => {
         try {
-            light_icons_b64[key] = await generateIconBase64(icon, 128, {
+            const source = await generateIconBase64(icon, 128, {
                 fontFamily: 'Material Icons',
                 color: 'rgba(255, 255, 255, 1)'
             });
+            return [key, source];
         } catch (error) {
-            light_icons_b64[key] = lightManagerFallbackIconDataUrl(fallbackLabel);
+            return [key, lightManagerFallbackIconDataUrl(fallbackLabel)];
         }
-    }
+    }));
+    generated.forEach(([key, source]) => { light_icons_b64[key] = source; });
+    window.LightManagerRefreshIconTextures?.(light_icons_b64);
 }
 
-load_textures().catch(() => {
-    light_icons_b64.point = lightManagerFallbackIconDataUrl('P');
-    light_icons_b64.directional = lightManagerFallbackIconDataUrl('D');
-    light_icons_b64.spot = lightManagerFallbackIconDataUrl('S');
-}).then(() => {
-    initialize_light_plugin();
+// Register the plugin and its custom outliner type synchronously. Icon polish
+// is cosmetic and must never delay project parsing.
+light_icons_b64.point = lightManagerFallbackIconDataUrl('P');
+light_icons_b64.directional = lightManagerFallbackIconDataUrl('D');
+light_icons_b64.spot = lightManagerFallbackIconDataUrl('S');
+initialize_light_plugin();
+
+const scheduleLightManagerIconUpgrade = callback => {
+    if (typeof requestIdleCallback === 'function') {
+        requestIdleCallback(callback, { timeout: 1800 });
+    } else {
+        setTimeout(callback, 0);
+    }
+};
+scheduleLightManagerIconUpgrade(() => {
+    load_textures().catch(() => { /* SVG fallback icons are already active. */ });
 });

--- a/light_manager.js
+++ b/light_manager.js
@@ -218,7 +218,11 @@ const LIGHT_MANAGER_UPDATE_STATE = {
     running: false,
     rerun: false,
     options: null,
-    preparingLights: false
+    preparingLights: false,
+    activeUuids: new Set(),
+    worldPosition: new THREE.Vector3(),
+    worldQuaternion: new THREE.Quaternion(),
+    worldDirection: new THREE.Vector3()
 };
 
 const LIGHT_MANAGER_DEFAULT_UPDATE_OPTIONS = {
@@ -3363,7 +3367,8 @@ function runLightManagerElementUpdate(options = LIGHT_MANAGER_DEFAULT_UPDATE_OPT
     }
 
     // Keep track of active UUIDs to remove deleted lights
-    const activeUuids = new Set();
+    const activeUuids = LIGHT_MANAGER_UPDATE_STATE.activeUuids;
+    activeUuids.clear();
 
     if (typeof LightElement !== 'undefined' && LightElement.all) {
         LightElement.all.forEach(element => {
@@ -3439,15 +3444,15 @@ function runLightManagerElementUpdate(options = LIGHT_MANAGER_DEFAULT_UPDATE_OPT
 
             // Sync Position and Rotation
             if (element.mesh) {
-                let worldPos = new THREE.Vector3();
-                let worldQuat = new THREE.Quaternion();
+                const worldPos = LIGHT_MANAGER_UPDATE_STATE.worldPosition;
+                const worldQuat = LIGHT_MANAGER_UPDATE_STATE.worldQuaternion;
                 element.mesh.getWorldPosition(worldPos);
                 element.mesh.getWorldQuaternion(worldQuat);
 
                 light.position.copy(worldPos);
 
                 if (light.target) {
-                    let direction = new THREE.Vector3(0, 0, -1);
+                    const direction = LIGHT_MANAGER_UPDATE_STATE.worldDirection.set(0, 0, -1);
                     direction.applyQuaternion(worldQuat);
                     light.target.position.copy(worldPos).add(direction);
                     light.target.updateMatrixWorld(true);
@@ -3926,7 +3931,7 @@ function initialize_light_plugin() {
         author: 'MidFord327',
         description: 'Add production-ready point, spot, and directional lights to Blockbench with viewport gizmos, animation support, shadows, and Studio Render controls. Provides the Lightflow lighting foundation for Shader Architect and Studio Render.',
         tags: ['Lightflow', 'Lighting', 'Shadows', 'Animation', 'Rendering', 'Studio'],
-        version: '1.6.4',
+        version: '1.6.5',
         min_version: '4.9.0',
         variant: 'both',
 
@@ -6922,7 +6927,7 @@ function initialize_light_plugin() {
                     element.mesh.fix_position.copy(element.mesh.position);
                     element.mesh.fix_rotation.copy(element.mesh.rotation);
                     this.updateWindowSize(element);
-                    window.update_light_element_callback?.();
+                    window.update_light_element_callback?.({ shadows: true, scene: false, gizmos: true });
                 },
                 updateSelection(element) {
                     let { mesh } = element;

--- a/light_manager.js
+++ b/light_manager.js
@@ -875,14 +875,30 @@ function configureLightManagerSceneShadowMeshes(force = false) {
     const elements = Array.isArray(window.Outliner?.elements) ? window.Outliner.elements : [];
 
     elements.forEach(element => {
-        if (!element || element.type === 'light' || (window.LightElement && element instanceof window.LightElement)) return;
+        if (
+            !element ||
+            element.type === 'light' ||
+            (window.LightElement && element instanceof window.LightElement)
+        ) return;
 
         const mesh = element.mesh;
         if (!mesh || typeof mesh.traverse !== 'function') return;
 
+        const suppressElementShadows = element.type === 'lightflow_volume';
         mesh.traverse(object => {
             if (!object || object.isLight || object.isCamera) return;
             if (object.isMesh) {
+                if (suppressElementShadows || object.userData?.lightflowNoShadow) {
+                    if (object.castShadow !== false) {
+                        object.castShadow = false;
+                        changed = true;
+                    }
+                    if (object.receiveShadow !== false) {
+                        object.receiveShadow = false;
+                        changed = true;
+                    }
+                    return;
+                }
                 if (object.castShadow !== true) {
                     object.castShadow = true;
                     changed = true;
@@ -3910,7 +3926,7 @@ function initialize_light_plugin() {
         author: 'MidFord327',
         description: 'Add production-ready point, spot, and directional lights to Blockbench with viewport gizmos, animation support, shadows, and Studio Render controls. Provides the Lightflow lighting foundation for Shader Architect and Studio Render.',
         tags: ['Lightflow', 'Lighting', 'Shadows', 'Animation', 'Rendering', 'Studio'],
-        version: '1.6.3',
+        version: '1.6.4',
         min_version: '4.9.0',
         variant: 'both',
 

--- a/lightflow_atmosphere.js
+++ b/lightflow_atmosphere.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_atmosphere';
-    const PLUGIN_VERSION = '1.0.1';
+    const PLUGIN_VERSION = '1.1.0';
     const MAX_VOLUMES = 4;
     const MAX_LIGHTS = 4;
     const MAX_SHADOWS = 2;
@@ -77,6 +77,7 @@
     let settingsAction = null;
     let stylesheet = null;
     let animationFrame = null;
+    let previewRenderFrame = null;
     let lastAnimatedFrame = 0;
     let lastPreviewPatchCheck = 0;
     let syncingPanel = false;
@@ -186,9 +187,19 @@
 
     function requestPreviewRender() {
         if (window.LightManagerStudioRenderSession) return;
-        const preview = window.Preview && Preview.selected;
-        if (preview && typeof preview.render === 'function') preview.render();
-        else if (window.Canvas && typeof Canvas.updateView === 'function') Canvas.updateView({ elements: [], element_aspects: {} });
+        if (previewRenderFrame !== null) return;
+        const render = () => {
+            previewRenderFrame = null;
+            if (window.LightManagerStudioRenderSession) return;
+            const preview = window.Preview && Preview.selected;
+            if (preview && typeof preview.render === 'function') preview.render();
+            else if (window.Canvas && typeof Canvas.updateView === 'function') Canvas.updateView({ elements: [], element_aspects: {} });
+        };
+        if (typeof requestAnimationFrame === 'function') previewRenderFrame = requestAnimationFrame(render);
+        else {
+            previewRenderFrame = 'microtask';
+            queueMicrotask(render);
+        }
     }
 
     const FULLSCREEN_VERTEX_SHADER = `
@@ -772,7 +783,19 @@
 
         invalidateSceneCache() {
             this.scenePartitionCache = null;
+            this.invalidateDepthCache();
+        },
+
+        invalidateDepthCache() {
             this.sceneRevision = (this.sceneRevision + 1) >>> 0;
+            this.states.forEach(state => {
+                state.lastFrameSignature = null;
+                state.lastNormalVolumeReady = false;
+                state.lastDepthSignature = null;
+            });
+        },
+
+        invalidateVolumeCache() {
             this.states.forEach(state => {
                 state.lastFrameSignature = null;
                 state.lastNormalVolumeReady = false;
@@ -937,8 +960,10 @@
                 lastNormalStudio: false,
                 lastBloomMultiplier: 1,
                 lastFrameSignature: null,
+                lastDepthSignature: null,
                 lastDepthSources: null,
                 lightCandidates: [],
+                lightElementByUuid: new Map(),
                 scratch: {
                     scaleMatrix: new THREE.Matrix4(),
                     worldMatrix: new THREE.Matrix4(),
@@ -994,6 +1019,7 @@
                 configureRenderTarget(state.sceneTarget, volumeWidth, volumeHeight);
                 configureRenderTarget(state.cubeTarget, volumeWidth, volumeHeight);
                 state.lastFrameSignature = null;
+                state.lastDepthSignature = null;
             }
             state.compositeUniforms.uBilateralUpsample.value = volumeWidth < sceneWidth || volumeHeight < sceneHeight;
         },
@@ -1331,6 +1357,11 @@
         updateLightUniforms(state) {
             const uniforms = state.volumeUniforms;
             const candidates = state.lightCandidates;
+            const elementByUuid = state.lightElementByUuid;
+            elementByUuid.clear();
+            window.LightElement?.all?.forEach?.(element => {
+                if (element?.uuid) elementByUuid.set(element.uuid, element);
+            });
             let candidateCount = 0;
             const lights = window.three_lights || {};
             for (const uuid in lights) {
@@ -1360,7 +1391,7 @@
                     continue;
                 }
                 const { uuid, light } = entry;
-                const element = window.LightElement?.all?.find?.(candidate => candidate?.uuid === uuid);
+                const element = elementByUuid.get(uuid);
                 light.getWorldPosition?.(position);
                 if (light.target?.getWorldPosition) {
                     light.target.getWorldPosition(targetPosition);
@@ -1510,6 +1541,29 @@
             return hash >>> 0;
         },
 
+        computeDepthSignature(state, preview, studio) {
+            let hash = 2166136261;
+            hash = this.hashNumber(hash, this.sceneRevision);
+            hash = this.hashNumber(hash, state.depthWidth);
+            hash = this.hashNumber(hash, state.depthHeight);
+            hash = this.hashNumber(hash, this.settings.helper_mask ? 1 : 0);
+            const camera = preview.camera;
+            hash = this.hashArray(hash, camera?.matrixWorld?.elements);
+            hash = this.hashArray(hash, camera?.projectionMatrix?.elements);
+            hash = this.hashNumber(hash, camera?.near);
+            hash = this.hashNumber(hash, camera?.far);
+            const tile = studio && this.studioTile?.preview === preview ? this.studioTile.tile : null;
+            if (tile) {
+                hash = this.hashNumber(hash, tile.viewX);
+                hash = this.hashNumber(hash, tile.viewY);
+                hash = this.hashNumber(hash, tile.viewWidth);
+                hash = this.hashNumber(hash, tile.viewHeight);
+                hash = this.hashNumber(hash, tile.sampleX);
+                hash = this.hashNumber(hash, tile.sampleY);
+            }
+            return hash >>> 0;
+        },
+
         performance() {
             const result = { states: this.states.size, raymarches: 0, cacheHits: 0, depthCaptures: 0, cacheHitRate: 0 };
             this.states.forEach(state => {
@@ -1582,6 +1636,7 @@
             state.rendering = true;
             this.resize(state, studio);
             const frameSignature = this.computeFrameSignature(state, preview, volumes, studio);
+            const depthSignature = this.computeDepthSignature(state, preview, studio);
             const previousTarget = renderer.getRenderTarget?.() || null;
             const previousTargetViewport = previousTarget?.viewport?.clone?.() || null;
             const previousTargetScissor = previousTarget?.scissor?.clone?.() || null;
@@ -1604,9 +1659,14 @@
                     // pipeline. Reuse its fresh depth buffers when they cover
                     // every visible cube; this removes two full scene draws
                     // per tile while preserving alpha-tested foliage depth.
-                    const depthSources = this.findFreshSharedDepthSources(preview, state) || this.captureDepth(state, preview);
+                    const sharedDepth = this.findFreshSharedDepthSources(preview, state);
+                    const cachedDepth = state.lastDepthSignature === depthSignature
+                        ? state.lastDepthSources
+                        : null;
+                    const depthSources = sharedDepth || cachedDepth || this.captureDepth(state, preview);
                     if (!depthSources) return false;
                     state.lastDepthSources = depthSources;
+                    state.lastDepthSignature = depthSignature;
                     this.updateUniforms(state, preview, volumes, studio, !!settings.bloomMask, depthSources);
                     renderer.autoClear = true;
                     renderer.setScissorTest?.(false);
@@ -1948,7 +2008,7 @@
             updateTransform(element) {
                 NodePreviewController.prototype.updateTransform.call(this, element);
                 updateVolumeGizmo(element);
-                AtmosphereManager.invalidateSceneCache();
+                AtmosphereManager.invalidateDepthCache();
                 requestPreviewRender();
                 this.dispatchEvent('update_transform', { element });
             },
@@ -1994,11 +2054,20 @@
 
     function applyVolumeConfig(volume, config) {
         if (!volume || !config) return;
+        const transformKeys = new Set(['position', 'rotation', 'size', 'shape', 'visibility']);
+        let transformChanged = false;
         Object.keys(config).forEach(key => {
-            if (VolumeElement.properties[key]) volume[key] = Array.isArray(config[key]) ? config[key].slice() : config[key];
+            if (!VolumeElement.properties[key]) return;
+            volume[key] = Array.isArray(config[key]) ? config[key].slice() : config[key];
+            if (transformKeys.has(key)) transformChanged = true;
         });
         sanitizeVolume(volume);
-        VolumeElement.preview_controller?.updateTransform(volume);
+        if (transformChanged) {
+            VolumeElement.preview_controller?.updateTransform(volume);
+        } else {
+            updateVolumeGizmo(volume);
+            AtmosphereManager.invalidateVolumeCache();
+        }
         VolumeElement.preview_controller?.updateSelection(volume);
     }
 
@@ -2480,10 +2549,7 @@
             window.LightflowAtmosphere = AtmosphereManager;
 
             const studioListener = Blockbench.on('studio_render_pre_tile', event => AtmosphereManager.prepareStudioTile(event));
-            const selectionListener = Blockbench.on('update_selection', () => {
-                AtmosphereManager.invalidateSceneCache();
-                syncAtmospherePanel();
-            });
+            const selectionListener = Blockbench.on('update_selection', () => syncAtmospherePanel());
             const projectListener = Blockbench.on('select_project', () => {
                 AtmosphereManager.invalidateSceneCache();
                 AtmosphereManager.patchAllPreviews();
@@ -2496,12 +2562,14 @@
                 requestPreviewRender();
             };
             window.addEventListener('light_manager_initialized', lightManagerListener);
+            const depthMutationListeners = [
+                'update_transform', 'update_geometry', 'update_faces', 'update_uv'
+            ].map(eventName => Blockbench.on(eventName, () => AtmosphereManager.invalidateDepthCache()));
             const sceneMutationListeners = [
-                'update_transform', 'update_geometry', 'update_faces', 'update_uv',
                 'add_cube', 'add_mesh', 'add_texture_mesh', 'remove_cube', 'remove_mesh',
                 'undo', 'redo', 'load_project'
             ].map(eventName => Blockbench.on(eventName, () => AtmosphereManager.invalidateSceneCache()));
-            deletables.push(studioListener, selectionListener, projectListener, ...sceneMutationListeners, {
+            deletables.push(studioListener, selectionListener, projectListener, ...depthMutationListeners, ...sceneMutationListeners, {
                 delete() { window.removeEventListener('light_manager_initialized', lightManagerListener); }
             });
             syncAtmospherePanel();
@@ -2512,6 +2580,8 @@
         onunload() {
             if (animationFrame !== null) cancelAnimationFrame(animationFrame);
             animationFrame = null;
+            if (typeof previewRenderFrame === 'number') cancelAnimationFrame(previewRenderFrame);
+            previewRenderFrame = null;
             AtmosphereManager.dispose();
             deletables.splice(0).reverse().forEach(item => item?.delete?.());
             if (VolumeElement?.all) {

--- a/lightflow_atmosphere.js
+++ b/lightflow_atmosphere.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_atmosphere';
-    const PLUGIN_VERSION = '1.0.0';
+    const PLUGIN_VERSION = '1.0.1';
     const MAX_VOLUMES = 4;
     const MAX_LIGHTS = 4;
     const MAX_SHADOWS = 2;
@@ -1193,6 +1193,9 @@
             const scene = window.Canvas?.scene;
             if (!scene || !camera) return null;
             const previousTarget = renderer.getRenderTarget?.() || null;
+            const previousTargetViewport = previousTarget?.viewport?.clone?.() || null;
+            const previousTargetScissor = previousTarget?.scissor?.clone?.() || null;
+            const previousTargetScissorTest = previousTarget?.scissorTest ?? false;
             const previousAutoClear = renderer.autoClear;
             const previousViewport = renderer.getViewport?.(new THREE.Vector4()) || null;
             const previousScissor = renderer.getScissor?.(new THREE.Vector4()) || null;
@@ -1239,10 +1242,17 @@
                     cubeDepth: state.cubeTarget.depthTexture
                 };
             } finally {
-                renderer.setRenderTarget?.(previousTarget);
-                if (previousViewport) renderer.setViewport?.(previousViewport);
-                if (previousScissor) renderer.setScissor?.(previousScissor);
-                renderer.setScissorTest?.(previousScissorTest);
+                if (previousTarget) {
+                    if (previousTargetViewport && previousTarget.viewport) previousTarget.viewport.copy(previousTargetViewport);
+                    if (previousTargetScissor && previousTarget.scissor) previousTarget.scissor.copy(previousTargetScissor);
+                    previousTarget.scissorTest = previousTargetScissorTest;
+                    renderer.setRenderTarget?.(previousTarget);
+                } else {
+                    renderer.setRenderTarget?.(null);
+                    if (previousViewport) renderer.setViewport?.(previousViewport);
+                    if (previousScissor) renderer.setScissor?.(previousScissor);
+                    renderer.setScissorTest?.(previousScissorTest);
+                }
                 renderer.autoClear = previousAutoClear;
                 renderer.setClearColor?.(clearColor, clearAlpha);
                 if (renderer.shadowMap && previousShadowAutoUpdate !== undefined) renderer.shadowMap.autoUpdate = previousShadowAutoUpdate;
@@ -1573,6 +1583,9 @@
             this.resize(state, studio);
             const frameSignature = this.computeFrameSignature(state, preview, volumes, studio);
             const previousTarget = renderer.getRenderTarget?.() || null;
+            const previousTargetViewport = previousTarget?.viewport?.clone?.() || null;
+            const previousTargetScissor = previousTarget?.scissor?.clone?.() || null;
+            const previousTargetScissorTest = previousTarget?.scissorTest ?? false;
             const previousAutoClear = renderer.autoClear;
             const previousViewport = renderer.getViewport?.(new THREE.Vector4()) || null;
             const previousScissor = renderer.getScissor?.(new THREE.Vector4()) || null;
@@ -1618,17 +1631,16 @@
                 }
 
                 renderer.autoClear = false;
-                renderer.setRenderTarget?.(previousTarget);
-                /*
-                 * getDrawingBufferSize() is expressed in physical pixels,
-                 * while setViewport() on the default framebuffer expects
-                 * logical pixels and applies renderer.pixelRatio itself.
-                 * Reusing the saved viewport prevents a second DPI scaling,
-                 * which was the source of the Windows viewport offset.
-                 */
-                if (previousViewport) renderer.setViewport?.(previousViewport);
-                else if (previousTarget) renderer.setViewport?.(0, 0, previousTarget.width, previousTarget.height);
-                renderer.setScissorTest?.(false);
+                if (previousTarget) {
+                    if (previousTargetViewport && previousTarget.viewport) previousTarget.viewport.copy(previousTargetViewport);
+                    if (previousTargetScissor && previousTarget.scissor) previousTarget.scissor.copy(previousTargetScissor);
+                    previousTarget.scissorTest = false;
+                    renderer.setRenderTarget?.(previousTarget);
+                } else {
+                    renderer.setRenderTarget?.(null);
+                    if (previousViewport) renderer.setViewport?.(previousViewport);
+                    renderer.setScissorTest?.(false);
+                }
                 state.compositeUniforms.uBloomComposite.value = !!settings.bloomMask;
                 state.compositeUniforms.uBloomMultiplier.value = useCachedBloom ? state.lastBloomMultiplier : 1;
                 renderer.render(state.compositeScene, state.postCamera);
@@ -1644,10 +1656,17 @@
                 saveSettings(this.settings);
                 return false;
             } finally {
-                renderer.setRenderTarget?.(previousTarget);
-                if (previousViewport) renderer.setViewport?.(previousViewport);
-                if (previousScissor) renderer.setScissor?.(previousScissor);
-                renderer.setScissorTest?.(previousScissorTest);
+                if (previousTarget) {
+                    if (previousTargetViewport && previousTarget.viewport) previousTarget.viewport.copy(previousTargetViewport);
+                    if (previousTargetScissor && previousTarget.scissor) previousTarget.scissor.copy(previousTargetScissor);
+                    previousTarget.scissorTest = previousTargetScissorTest;
+                    renderer.setRenderTarget?.(previousTarget);
+                } else {
+                    renderer.setRenderTarget?.(null);
+                    if (previousViewport) renderer.setViewport?.(previousViewport);
+                    if (previousScissor) renderer.setScissor?.(previousScissor);
+                    renderer.setScissorTest?.(previousScissorTest);
+                }
                 renderer.autoClear = previousAutoClear;
                 renderer.setClearColor?.(previousClearColor, previousClearAlpha);
                 state.rendering = false;
@@ -1740,6 +1759,14 @@
             mesh.sphereSelection.scale.set(size[0], size[1], size[2]);
         }
         const selected = !!volume.selected;
+        [mesh.boxSelection, mesh.sphereSelection].forEach(proxy => {
+            if (!proxy) return;
+            proxy.castShadow = false;
+            proxy.receiveShadow = false;
+            proxy.userData = proxy.userData || {};
+            proxy.userData.lightflowNoShadow = true;
+            proxy.userData.lightflowVolumeSelectionProxy = true;
+        });
         [mesh.boxGizmo, mesh.sphereGizmo].forEach(gizmo => {
             if (!gizmo?.material) return;
             gizmo.material.color.set(selected ? 0x5ba7ff : 0x67d7e8);
@@ -1868,6 +1895,8 @@
                 mesh.name = element.uuid;
                 mesh.type = element.type;
                 mesh.isElement = true;
+                mesh.userData = mesh.userData || {};
+                mesh.userData.lightflowNoShadow = true;
                 mesh.rotation.order = window.Format?.euler_order || 'ZYX';
 
                 const lineMaterial = new THREE.LineBasicMaterial({
@@ -1898,6 +1927,11 @@
                     proxy.name = element.uuid;
                     proxy.type = element.type;
                     proxy.isElement = true;
+                    proxy.castShadow = false;
+                    proxy.receiveShadow = false;
+                    proxy.userData = proxy.userData || {};
+                    proxy.userData.lightflowNoShadow = true;
+                    proxy.userData.lightflowVolumeSelectionProxy = true;
                 });
                 mesh.add(mesh.boxSelection, mesh.sphereSelection);
                 mesh.geometry = new THREE.BufferGeometry();

--- a/lightflow_atmosphere.js
+++ b/lightflow_atmosphere.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_atmosphere';
-    const PLUGIN_VERSION = '1.1.0';
+    const PLUGIN_VERSION = '1.2.0';
     const MAX_VOLUMES = 4;
     const MAX_LIGHTS = 4;
     const MAX_SHADOWS = 2;
@@ -81,6 +81,8 @@
     let lastAnimatedFrame = 0;
     let lastPreviewPatchCheck = 0;
     let syncingPanel = false;
+    let atmosphereRevision = 0;
+    let atmosphereProject = null;
     const deletables = [];
 
     function clamp(value, min, max) {
@@ -117,30 +119,6 @@
 
     function markerColor(index, tone = 'pastel', fallback = 'var(--color-accent)') {
         return window.LightManagerUI?.markerColor?.(index, tone, fallback) || fallback;
-    }
-
-    function waitForLightManager(timeout = 5000) {
-        return new Promise((resolve, reject) => {
-            if (window.LIGHT_MANAGER_LOADED && window.LightManagerUI && typeof window.applyIndestructibleFormGroups === 'function') {
-                resolve(window.LightManagerUI);
-                return;
-            }
-            let finished = false;
-            const timer = setTimeout(() => {
-                if (finished) return;
-                finished = true;
-                window.removeEventListener('light_manager_initialized', onReady);
-                reject(new Error('Lightflow Atmosphere requires Light Manager.'));
-            }, timeout);
-            function onReady() {
-                if (finished || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') return;
-                finished = true;
-                clearTimeout(timer);
-                window.removeEventListener('light_manager_initialized', onReady);
-                resolve(window.LightManagerUI);
-            }
-            window.addEventListener('light_manager_initialized', onReady);
-        });
     }
 
     function colorArrayToHex(value) {
@@ -216,9 +194,16 @@
     function requestPreviewRender() {
         if (window.LightManagerStudioRenderSession) return;
         if (previewRenderFrame !== null) return;
+        const revision = atmosphereRevision;
+        const project = window.Project || null;
         const render = () => {
             previewRenderFrame = null;
             if (window.LightManagerStudioRenderSession) return;
+            if (
+                revision !== atmosphereRevision ||
+                project !== atmosphereProject ||
+                project !== (window.Project || null)
+            ) return;
             const preview = window.Preview && Preview.selected;
             if (preview && typeof preview.render === 'function') preview.render();
             else if (window.Canvas && typeof Canvas.updateView === 'function') Canvas.updateView({ elements: [], element_aspects: {} });
@@ -228,6 +213,15 @@
             previewRenderFrame = 'microtask';
             queueMicrotask(render);
         }
+    }
+
+    function beginAtmosphereProject(project) {
+        atmosphereRevision += 1;
+        atmosphereProject = project || null;
+        if (typeof previewRenderFrame === 'number' && typeof cancelAnimationFrame === 'function') {
+            cancelAnimationFrame(previewRenderFrame);
+        }
+        previewRenderFrame = null;
     }
 
     const FULLSCREEN_VERTEX_SHADER = `
@@ -2630,10 +2624,8 @@
         variant: 'both',
         dependencies: ['light_manager'],
 
-        async onload() {
-            try {
-                await waitForLightManager();
-            } catch (error) {
+        onload() {
+            if (!window.LIGHT_MANAGER_LOADED || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') {
                 Blockbench.showToastNotification({
                     text: tr('lightflow_atmosphere.message.light_manager_required', 'Lightflow Atmosphere requires Light Manager.'),
                     icon: 'error',
@@ -2649,12 +2641,25 @@
 
             const studioListener = Blockbench.on('studio_render_pre_tile', event => AtmosphereManager.prepareStudioTile(event));
             const selectionListener = Blockbench.on('update_selection', () => syncAtmospherePanel());
-            const projectListener = Blockbench.on('select_project', () => {
-                AtmosphereManager.invalidateSceneCache();
-                AtmosphereManager.patchAllPreviews();
-                syncAtmospherePanel();
-                requestPreviewRender();
-            });
+            const lifecycleHydrator = window.LightflowLifecycle?.registerHydrator?.(
+                'lightflow_atmosphere',
+                ({ project, model, isCurrent, deferred }) => {
+                    beginAtmosphereProject(project);
+                    if (deferred) return;
+                    if (!project || !isCurrent()) {
+                        AtmosphereManager.invalidateSceneCache();
+                        return;
+                    }
+                    window.LightflowLifecycle.restoreCustomElements(model, 'lightflow_volume', VolumeElement);
+                    if (!isCurrent()) return;
+                    AtmosphereManager.invalidateSceneCache();
+                    AtmosphereManager.patchAllPreviews();
+                    syncAtmospherePanel();
+                    requestPreviewRender();
+                }
+            );
+            if (lifecycleHydrator) deletables.push(lifecycleHydrator);
+            else beginAtmosphereProject(window.Project || null);
             const lightManagerListener = () => {
                 AtmosphereManager.invalidateSceneCache();
                 AtmosphereManager.patchAllPreviews();
@@ -2666,9 +2671,9 @@
             ].map(eventName => Blockbench.on(eventName, () => AtmosphereManager.invalidateDepthCache()));
             const sceneMutationListeners = [
                 'add_cube', 'add_mesh', 'add_texture_mesh', 'remove_cube', 'remove_mesh',
-                'undo', 'redo', 'load_project'
+                'undo', 'redo'
             ].map(eventName => Blockbench.on(eventName, () => AtmosphereManager.invalidateSceneCache()));
-            deletables.push(studioListener, selectionListener, projectListener, ...depthMutationListeners, ...sceneMutationListeners, {
+            deletables.push(studioListener, selectionListener, ...depthMutationListeners, ...sceneMutationListeners, {
                 delete() { window.removeEventListener('light_manager_initialized', lightManagerListener); }
             });
             syncAtmospherePanel();
@@ -2677,6 +2682,7 @@
         },
 
         onunload() {
+            beginAtmosphereProject(null);
             if (animationFrame !== null) cancelAnimationFrame(animationFrame);
             animationFrame = null;
             if (typeof previewRenderFrame === 'number') cancelAnimationFrame(previewRenderFrame);

--- a/lightflow_atmosphere.js
+++ b/lightflow_atmosphere.js
@@ -115,6 +115,34 @@
         return translated === key ? (fallback || key) : translated;
     }
 
+    function markerColor(index, tone = 'pastel', fallback = 'var(--color-accent)') {
+        return window.LightManagerUI?.markerColor?.(index, tone, fallback) || fallback;
+    }
+
+    function waitForLightManager(timeout = 5000) {
+        return new Promise((resolve, reject) => {
+            if (window.LIGHT_MANAGER_LOADED && window.LightManagerUI && typeof window.applyIndestructibleFormGroups === 'function') {
+                resolve(window.LightManagerUI);
+                return;
+            }
+            let finished = false;
+            const timer = setTimeout(() => {
+                if (finished) return;
+                finished = true;
+                window.removeEventListener('light_manager_initialized', onReady);
+                reject(new Error('Lightflow Atmosphere requires Light Manager.'));
+            }, timeout);
+            function onReady() {
+                if (finished || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') return;
+                finished = true;
+                clearTimeout(timer);
+                window.removeEventListener('light_manager_initialized', onReady);
+                resolve(window.LightManagerUI);
+            }
+            window.addEventListener('light_manager_initialized', onReady);
+        });
+    }
+
     function colorArrayToHex(value) {
         const source = Array.isArray(value) ? value : [255, 255, 255];
         return '#' + source.slice(0, 3).map(channel => {
@@ -2240,22 +2268,63 @@
                 type: 'bar_display', value: volume.name, icon: volume.density_mode === 'cloud' ? 'cloud' : 'blur_on',
                 paragraph: false, expand: true, color: 'var(--color-text)'
             },
-            panel_enabled: { type: 'checkbox', label: 'lightflow_atmosphere.field.enabled', value: volume.enabled !== false },
+            panel_enabled: {
+                type: 'action_toggle', value: volume.enabled !== false, description: 'lightflow_atmosphere.field.enabled',
+                icon_on: 'blur_on', icon_off: 'blur_off', bg_on: markerColor(0, 'standard', '#58C0FF'),
+                color_on: 'var(--color-ui)', color_off: 'var(--color-subtle_text)', icon_size: '22px'
+            },
             panel_mode: {
-                type: 'select', label: 'lightflow_atmosphere.field.density_mode', value: volume.density_mode,
-                options: { uniform: 'lightflow_atmosphere.option.uniform', height: 'lightflow_atmosphere.option.height', cloud: 'lightflow_atmosphere.option.cloud' }
+                type: 'compact_select', label: 'lightflow_atmosphere.field.density_mode', hide_label: true,
+                description: 'lightflow_atmosphere.field.density_mode', background: 'transparent', value: volume.density_mode,
+                options: {
+                    uniform: { name: 'lightflow_atmosphere.option.uniform', icon: 'blur_on', color: markerColor(9, 'pastel', '#E0E9FB') },
+                    height: { name: 'lightflow_atmosphere.option.height', icon: 'gradient', color: markerColor(0, 'pastel', '#A2EBFF') },
+                    cloud: { name: 'lightflow_atmosphere.option.cloud', icon: 'cloud', color: markerColor(4, 'pastel', '#C5A6E8') }
+                }
             },
             panel_composite: {
-                type: 'select', label: 'lightflow_atmosphere.field.composite_mode', value: volume.composite_mode,
-                options: { physical: 'lightflow_atmosphere.option.physical', shafts: 'lightflow_atmosphere.option.shafts' }
+                type: 'compact_select', label: 'lightflow_atmosphere.field.composite_mode', hide_label: true,
+                description: 'lightflow_atmosphere.field.composite_mode', background: 'transparent', value: volume.composite_mode,
+                options: {
+                    physical: { name: 'lightflow_atmosphere.option.physical', icon: 'air', color: markerColor(6, 'pastel', '#7BFFA3') },
+                    shafts: { name: 'lightflow_atmosphere.option.shafts', icon: 'flare', color: markerColor(1, 'pastel', '#FFF899') }
+                }
             },
-            panel_density: { type: 'range', label: 'lightflow_atmosphere.field.density', value: volume.density, min: 0, max: 0.3, step: 0.001 },
-            panel_scattering: { type: 'range', label: 'lightflow_atmosphere.field.scattering', value: volume.scattering_strength, min: 0, max: 4, step: 0.01 },
-            panel_anisotropy: { type: 'range', label: 'lightflow_atmosphere.field.anisotropy', value: volume.anisotropy, min: -0.92, max: 0.92, step: 0.01 },
-            panel_shadows: { type: 'checkbox', label: 'lightflow_atmosphere.field.receive_shadows', value: volume.receive_shadows !== false },
+            panel_density: {
+                type: 'combo_slider', label: 'lightflow_atmosphere.field.density', icon: 'opacity',
+                color: markerColor(0, 'pastel', '#A2EBFF'), value: volume.density,
+                resettable: true, reset_value: 0.032, min: 0, max: 0.3, step: 0.001
+            },
+            optics_label: {
+                type: 'bar_display', icon: 'lens_blur', paragraph: false, expand: false,
+                color: 'var(--color-subtle_text)', description: 'lightflow_atmosphere.field.scattering'
+            },
+            panel_scattering: {
+                type: 'combo_slider', label: 'lightflow_atmosphere.field.scattering', icon: 'light_mode',
+                background: 'transparent', color: markerColor(1, 'pastel', '#FFF899'),
+                icon_color: markerColor(1, 'pastel', '#FFF899'), compact: true, popup_width: '300px',
+                value: volume.scattering_strength, resettable: true, reset_value: 1, min: 0, max: 4, step: 0.01
+            },
+            panel_anisotropy: {
+                type: 'combo_slider', label: 'lightflow_atmosphere.field.anisotropy', icon: 'compare_arrows',
+                background: 'transparent', color: markerColor(8, 'pastel', '#FFA5D5'),
+                icon_color: markerColor(8, 'pastel', '#FFA5D5'), compact: true, popup_width: '300px',
+                value: volume.anisotropy, resettable: true, reset_value: 0.18,
+                min: -0.92, max: 0.92, step: 0.01, allow_lower: true
+            },
+            panel_shadows: {
+                type: 'action_toggle', value: volume.receive_shadows !== false,
+                description: 'lightflow_atmosphere.field.receive_shadows', icon_on: 'ev_shadow', icon_off: 'contrast_rtl_off',
+                bg_on: markerColor(5, 'standard', '#4D89FF'), color_on: 'var(--color-ui)',
+                color_off: markerColor(5, 'pastel', '#A6C8FF')
+            },
             advanced: {
-                type: 'buttons', buttons: ['lightflow_atmosphere.button.advanced'],
-                click() { openVolumeDialog(); }
+                type: 'action_button', icon: 'tune', description: 'lightflow_atmosphere.button.advanced',
+                color: markerColor(4, 'pastel', '#C5A6E8'), click: openVolumeDialog
+            },
+            quality: {
+                type: 'action_button', icon: 'speed', description: 'lightflow_atmosphere.action.settings',
+                color: markerColor(6, 'pastel', '#7BFFA3'), click: openSettingsDialog
             }
         };
     }
@@ -2276,12 +2345,12 @@
             resizable: true,
             condition: { modes: ['edit', 'render'], method: () => getSelectedVolumes().length > 0 },
             default_position: {
-                slot: 'right_bar', float_position: [0, 0], float_size: [320, 430], height: 430,
+                slot: 'right_bar', float_position: [0, 0], float_size: [314, 200], height: 200,
                 attached_to: 'transform', attached_index: 1, sidebar_index: 2
             },
             mode_positions: {
-                edit: { slot: 'right_bar', height: 430, attached_to: 'transform', attached_index: 1, sidebar_index: 2 },
-                render: { slot: 'left_bar', height: 430, attached_to: 'material_properties', attached_index: 2, sidebar_index: 2 }
+                edit: { slot: 'right_bar', height: 200, attached_to: 'transform', attached_index: 1, sidebar_index: 2 },
+                render: { slot: 'left_bar', height: 200, attached_to: 'material_properties', attached_index: 2, sidebar_index: 2 }
             },
             form: panelForm(getSelectedVolumes()[0])
         });
@@ -2305,7 +2374,24 @@
             Undo.finishEdit(tr('lightflow_atmosphere.undo.edit', 'Edit Volume Domain'));
             requestPreviewRender();
         });
-        deletables.push(atmospherePanel);
+        window.applyIndestructibleFormGroups(atmospherePanel.form, [
+            {
+                elements: ['summary', '+', 'panel_enabled', 'panel_mode', 'panel_composite'], gap: '2px',
+                divider_color: 'var(--color-grid)',
+                flex: { summary: '1 1 auto', panel_enabled: '0 0 auto', panel_mode: '0 0 auto', panel_composite: '0 0 auto' }
+            },
+            { elements: ['panel_density'], gap: '2px', flex: { panel_density: '1 1 100%' } },
+            {
+                elements: ['optics_label', 'panel_scattering', 'panel_anisotropy', '+', 'panel_shadows', 'advanced', 'quality'], gap: '2px',
+                divider_color: 'var(--color-grid)',
+                flex: {
+                    optics_label: '0 0 auto', panel_scattering: '0 0 auto', panel_anisotropy: '0 0 auto',
+                    panel_shadows: '0 0 auto', advanced: '0 0 auto', quality: '0 0 auto'
+                }
+            }
+        ]);
+        const panelStyles = window.LightManagerUI.addCompactPanelStyles('lightflow_atmosphere_properties');
+        deletables.push(atmospherePanel, panelStyles);
     }
 
     function openSettingsDialog() {
@@ -2387,7 +2473,7 @@
             'lightflow_atmosphere.action.edit': 'Edit Volume Domain',
             'lightflow_atmosphere.action.fit': 'Fit Volume to Selection',
             'lightflow_atmosphere.action.settings': 'Atmosphere Quality...',
-            'lightflow_atmosphere.panel.title': 'ATMOSPHERE',
+            'lightflow_atmosphere.panel.title': 'VOLUME',
             'lightflow_atmosphere.panel.none': 'Select a Volume Domain',
             'lightflow_atmosphere.dialog.edit': 'Volume Domain',
             'lightflow_atmosphere.dialog.edit_many': 'Edit Volume Domains',
@@ -2442,7 +2528,8 @@
             'lightflow_atmosphere.undo.add': 'Add Volume Domain',
             'lightflow_atmosphere.undo.edit': 'Edit Volume Domain',
             'lightflow_atmosphere.undo.fit': 'Fit Volume Domain',
-            'lightflow_atmosphere.message.render_failed': 'Atmosphere disabled after a GPU render error'
+            'lightflow_atmosphere.message.render_failed': 'Atmosphere disabled after a GPU render error',
+            'lightflow_atmosphere.message.light_manager_required': 'Lightflow Atmosphere requires Light Manager.'
         });
         Language.addTranslations('es', {
             'lightflow_atmosphere.plugin.title': 'Atmósfera Lightflow',
@@ -2451,7 +2538,7 @@
             'lightflow_atmosphere.action.edit': 'Editar dominio volumétrico',
             'lightflow_atmosphere.action.fit': 'Ajustar volumen a la selección',
             'lightflow_atmosphere.action.settings': 'Calidad de atmósfera...',
-            'lightflow_atmosphere.panel.title': 'ATMÓSFERA',
+            'lightflow_atmosphere.panel.title': 'VOLUMEN',
             'lightflow_atmosphere.panel.none': 'Selecciona un dominio volumétrico',
             'lightflow_atmosphere.dialog.edit': 'Dominio volumétrico',
             'lightflow_atmosphere.dialog.edit_many': 'Editar dominios volumétricos',
@@ -2506,7 +2593,8 @@
             'lightflow_atmosphere.undo.add': 'Añadir dominio volumétrico',
             'lightflow_atmosphere.undo.edit': 'Editar dominio volumétrico',
             'lightflow_atmosphere.undo.fit': 'Ajustar dominio volumétrico',
-            'lightflow_atmosphere.message.render_failed': 'La atmósfera se desactivó tras un error de render de la GPU'
+            'lightflow_atmosphere.message.render_failed': 'La atmósfera se desactivó tras un error de render de la GPU',
+            'lightflow_atmosphere.message.light_manager_required': 'Lightflow Atmosphere requiere Light Manager.'
         });
     }
 
@@ -2540,8 +2628,19 @@
         version: PLUGIN_VERSION,
         min_version: '4.9.0',
         variant: 'both',
+        dependencies: ['light_manager'],
 
-        onload() {
+        async onload() {
+            try {
+                await waitForLightManager();
+            } catch (error) {
+                Blockbench.showToastNotification({
+                    text: tr('lightflow_atmosphere.message.light_manager_required', 'Lightflow Atmosphere requires Light Manager.'),
+                    icon: 'error',
+                    expire: 10000
+                });
+                return;
+            }
             registerVolumeElement();
             installActions();
             createAtmospherePanel();

--- a/lightflow_environment.js
+++ b/lightflow_environment.js
@@ -57,6 +57,9 @@
         shadow_resolution: 2048,
         shadow_bias: -0.00035,
         shadow_normal_bias: 0.025,
+        shadow_auto_fit: true,
+        shadow_fit_corners: null,
+        show_shadow_gizmo: true,
         pixelated_shadows: false,
         pixel_shadow_steps: 4,
         pixel_shadow_scale: 2
@@ -86,9 +89,13 @@
     let skyMaterial = null;
     let sunLight = null;
     let sunTarget = null;
+    let sunShadowGizmo = null;
+    let sunShadowGizmoDrag = null;
+    let sunShadowGizmoRaycaster = null;
+    let sunShadowGizmoMouse = null;
+    let effectiveShadowFrustum = null;
+    const sunShadowGizmoListeners = [];
     let settingsAction = null;
-    let timeSlider = null;
-    let animateToggle = null;
     let environmentPanel = null;
     let syncingEnvironmentPanel = false;
     let vanillaCloudTexture = null;
@@ -117,6 +124,34 @@
         if (typeof tl !== 'function') return fallback || key;
         const translated = tl(key);
         return translated === key ? (fallback || key) : translated;
+    }
+
+    function markerColor(index, tone = 'pastel', fallback = 'var(--color-accent)') {
+        return window.LightManagerUI?.markerColor?.(index, tone, fallback) || fallback;
+    }
+
+    function waitForLightManager(timeout = 5000) {
+        return new Promise((resolve, reject) => {
+            if (window.LIGHT_MANAGER_LOADED && window.LightManagerUI && typeof window.applyIndestructibleFormGroups === 'function') {
+                resolve(window.LightManagerUI);
+                return;
+            }
+            let finished = false;
+            const timer = setTimeout(() => {
+                if (finished) return;
+                finished = true;
+                window.removeEventListener('light_manager_initialized', onReady);
+                reject(new Error('Lightflow Environment requires Light Manager.'));
+            }, timeout);
+            function onReady() {
+                if (finished || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') return;
+                finished = true;
+                clearTimeout(timer);
+                window.removeEventListener('light_manager_initialized', onReady);
+                resolve(window.LightManagerUI);
+            }
+            window.addEventListener('light_manager_initialized', onReady);
+        });
     }
 
     function normalizeHex(value, fallback) {
@@ -169,13 +204,19 @@
         result.cloud_contrast = clamp(finite(result.cloud_contrast, 1), 0.1, 4);
         result.cloud_brightness = clamp(finite(result.cloud_brightness, 1), 0, 4);
         result.sun_cast_shadows = result.sun_cast_shadows !== false;
-        result.shadow_area = clamp(finite(result.shadow_area, 48), 2, 1024);
-        result.shadow_near = clamp(finite(result.shadow_near, 0.1), 0.001, 10000);
-        result.shadow_far = Math.max(result.shadow_near + 1, clamp(finite(result.shadow_far, 480), 2, 10000));
+        result.shadow_area = clamp(finite(result.shadow_area, 48), 2, 100000);
+        result.shadow_near = clamp(finite(result.shadow_near, 0.1), 0.001, 100000);
+        result.shadow_far = Math.max(result.shadow_near + 1, clamp(finite(result.shadow_far, 480), 2, 100000));
         result.shadow_resolution = [256, 512, 1024, 2048, 4096, 8192].includes(Number(result.shadow_resolution))
             ? Number(result.shadow_resolution) : 2048;
         result.shadow_bias = clamp(finite(result.shadow_bias, -0.00035), -0.1, 0.1);
         result.shadow_normal_bias = clamp(finite(result.shadow_normal_bias, 0.025), 0, 2);
+        result.shadow_auto_fit = result.shadow_auto_fit !== false;
+        result.shadow_fit_corners = Array.isArray(result.shadow_fit_corners) && result.shadow_fit_corners.length === 24 &&
+            result.shadow_fit_corners.every(value => Number.isFinite(Number(value)))
+            ? result.shadow_fit_corners.map(Number)
+            : null;
+        result.show_shadow_gizmo = result.show_shadow_gizmo !== false;
         result.pixelated_shadows = !!result.pixelated_shadows;
         result.pixel_shadow_steps = Math.round(clamp(finite(result.pixel_shadow_steps, 4), 2, 16));
         result.pixel_shadow_scale = Math.round(clamp(finite(result.pixel_shadow_scale, 2), 1, 16));
@@ -563,6 +604,159 @@
         return true;
     }
 
+    function getActiveShadowFrustum() {
+        return effectiveShadowFrustum || {
+            area: settings.shadow_area,
+            near: settings.shadow_near,
+            far: settings.shadow_far
+        };
+    }
+
+    function getShadowViewQuaternion(position, target) {
+        const matrix = new THREE.Matrix4();
+        matrix.lookAt(position, target, new THREE.Vector3(0, 1, 0));
+        return new THREE.Quaternion().setFromRotationMatrix(matrix);
+    }
+
+    function buildShadowFrustumWorldCorners(frustum, position, quaternion) {
+        const area = Math.max(0.001, finite(frustum.area, settings.shadow_area));
+        const near = Math.max(0.001, finite(frustum.near, settings.shadow_near));
+        const far = Math.max(near + 0.001, finite(frustum.far, settings.shadow_far));
+        const corners = [];
+        [-near, -far].forEach(z => {
+            [-area, area].forEach(x => {
+                [-area, area].forEach(y => {
+                    corners.push(new THREE.Vector3(x, y, z).applyQuaternion(quaternion).add(position));
+                });
+            });
+        });
+        return corners;
+    }
+
+    function getBoxWorldCorners(box) {
+        const min = box.min;
+        const max = box.max;
+        return [
+            new THREE.Vector3(min.x, min.y, min.z), new THREE.Vector3(max.x, min.y, min.z),
+            new THREE.Vector3(max.x, max.y, min.z), new THREE.Vector3(min.x, max.y, min.z),
+            new THREE.Vector3(min.x, min.y, max.z), new THREE.Vector3(max.x, min.y, max.z),
+            new THREE.Vector3(max.x, max.y, max.z), new THREE.Vector3(min.x, max.y, max.z)
+        ];
+    }
+
+    function getWorldAlignedShadowCorners(corners) {
+        const box = new THREE.Box3().setFromPoints(corners);
+        return box.isEmpty() ? [] : getBoxWorldCorners(box);
+    }
+
+    function getReferenceShadowFitCorners() {
+        const referenceDirection = new THREE.Vector3().fromArray(getSunDirection(6000)).normalize();
+        const referenceDistance = Math.max(160, settings.shadow_far * 0.38);
+        const position = referenceDirection.multiplyScalar(referenceDistance);
+        const target = new THREE.Vector3(0, 0, 0);
+        const quaternion = getShadowViewQuaternion(position, target);
+        return getWorldAlignedShadowCorners(buildShadowFrustumWorldCorners({
+            area: settings.shadow_area,
+            near: settings.shadow_near,
+            far: settings.shadow_far
+        }, position, quaternion));
+    }
+
+    function getShadowFitCorners() {
+        if (Array.isArray(settings.shadow_fit_corners) && settings.shadow_fit_corners.length === 24) {
+            const corners = [];
+            for (let index = 0; index < settings.shadow_fit_corners.length; index += 3) {
+                corners.push(new THREE.Vector3(
+                    settings.shadow_fit_corners[index],
+                    settings.shadow_fit_corners[index + 1],
+                    settings.shadow_fit_corners[index + 2]
+                ));
+            }
+            return getWorldAlignedShadowCorners(corners);
+        }
+        return getReferenceShadowFitCorners();
+    }
+
+    function updateSunShadowPlacement(celestialDirection) {
+        if (!sunLight || !sunTarget) return;
+        const direction = new THREE.Vector3().fromArray(celestialDirection);
+        if (direction.lengthSq() < 1e-8) direction.set(0, 1, 0);
+        else direction.normalize();
+
+        /*
+         * The marked region stays fixed in world space. Only the directional
+         * shadow camera moves with the celestial light, so refit its symmetric
+         * orthographic bounds and depth range around the same eight corners.
+        */
+        const fitCorners = settings.shadow_auto_fit ? getShadowFitCorners() : null;
+        const targetPosition = fitCorners
+            ? new THREE.Box3().setFromPoints(fitCorners).getCenter(new THREE.Vector3())
+            : new THREE.Vector3(0, 0, 0);
+        const nearestRegionProjection = fitCorners
+            ? fitCorners.reduce((projection, corner) => Math.max(
+                projection,
+                corner.clone().sub(targetPosition).dot(direction)
+            ), -Infinity)
+            : 0;
+        const distance = settings.shadow_auto_fit
+            ? Math.max(160, nearestRegionProjection + 1)
+            : Math.max(160, settings.shadow_far * 0.38);
+        const lightPosition = targetPosition.clone().add(direction.multiplyScalar(distance));
+        sunLight.position.copy(lightPosition);
+        sunTarget.position.copy(targetPosition);
+        sunLight.updateMatrixWorld(true);
+        sunTarget.updateMatrixWorld(true);
+
+        if (!fitCorners) {
+            effectiveShadowFrustum = {
+                area: settings.shadow_area,
+                near: settings.shadow_near,
+                far: settings.shadow_far
+            };
+            return;
+        }
+
+        const viewQuaternion = getShadowViewQuaternion(lightPosition, targetPosition);
+        const inverseViewQuaternion = viewQuaternion.clone().invert();
+        let area = 0;
+        let near = Infinity;
+        let far = -Infinity;
+        fitCorners.forEach(corner => {
+            const local = corner.clone().sub(lightPosition).applyQuaternion(inverseViewQuaternion);
+            area = Math.max(area, Math.abs(local.x), Math.abs(local.y));
+            const depth = -local.z;
+            near = Math.min(near, depth);
+            far = Math.max(far, depth);
+        });
+
+        const lateralPadding = Math.max(0.25, area * 0.015);
+        const depthSpan = Math.max(1, far - near);
+        const depthPadding = Math.max(0.5, depthSpan * 0.01);
+        effectiveShadowFrustum = {
+            area: Math.max(2, area + lateralPadding),
+            near: Math.max(0.001, near - depthPadding),
+            far: Math.max(Math.max(0.001, near - depthPadding) + 1, far + depthPadding)
+        };
+    }
+
+    function captureShadowFitRegion(frustum) {
+        if (!sunLight || !sunTarget) return;
+        const position = new THREE.Vector3();
+        const target = new THREE.Vector3();
+        sunLight.getWorldPosition(position);
+        sunTarget.getWorldPosition(target);
+        if (sunShadowGizmoDrag?.viewPosition) position.copy(sunShadowGizmoDrag.viewPosition);
+        const quaternion = sunShadowGizmoDrag?.viewQuaternion
+            ? sunShadowGizmoDrag.viewQuaternion.clone()
+            : sunShadowGizmo?.root
+                ? sunShadowGizmo.root.quaternion.clone()
+                : getShadowViewQuaternion(position, target);
+        const corners = getWorldAlignedShadowCorners(
+            buildShadowFrustumWorldCorners(frustum, position, quaternion)
+        );
+        settings.shadow_fit_corners = corners.flatMap(corner => corner.toArray());
+    }
+
     function configureSunShadow(force) {
         if (!sunLight?.shadow) return;
         const renderer = window.Preview?.selected?.renderer || window.main_preview?.renderer;
@@ -574,14 +768,15 @@
             // Use the conservative fallback.
         }
         const resolution = Math.min(settings.shadow_resolution, maxTextureSize);
-        const area = settings.shadow_area;
+        const frustum = getActiveShadowFrustum();
+        const area = frustum.area;
         const shadow = sunLight.shadow;
-        const recreate = force || shadow.mapSize.width !== resolution || shadow.camera.left !== -area;
+        const recreate = force || shadow.mapSize.width !== resolution || shadow.mapSize.height !== resolution;
         sunLight.castShadow = !!settings.sun_cast_shadows;
         shadow.mapSize.set(resolution, resolution);
         Object.assign(shadow.camera, {
             left: -area, right: area, top: area, bottom: -area,
-            near: settings.shadow_near, far: settings.shadow_far
+            near: frustum.near, far: frustum.far
         });
         shadow.bias = settings.shadow_bias;
         shadow.normalBias = settings.shadow_normal_bias;
@@ -592,6 +787,294 @@
             shadow.map = null;
         }
         shadow.needsUpdate = true;
+    }
+
+    function registerSunShadowCanvasGizmo(object) {
+        if (!object || !window.Canvas || !Array.isArray(Canvas.gizmos)) return;
+        if (!Canvas.gizmos.includes(object)) Canvas.gizmos.push(object);
+    }
+
+    function unregisterSunShadowCanvasGizmo(object) {
+        if (!object || !window.Canvas || !Array.isArray(Canvas.gizmos)) return;
+        const index = Canvas.gizmos.indexOf(object);
+        if (index >= 0) Canvas.gizmos.splice(index, 1);
+    }
+
+    function pushSunShadowGizmoLine(vertices, a, b) {
+        vertices.push(a[0], a[1], a[2], b[0], b[1], b[2]);
+    }
+
+    function getShadowFitBox() {
+        return new THREE.Box3().setFromPoints(getShadowFitCorners());
+    }
+
+    function buildSunShadowGizmoVertices() {
+        const size = getShadowFitBox().getSize(new THREE.Vector3()).multiplyScalar(0.5);
+        const x = Math.max(0.001, size.x);
+        const y = Math.max(0.001, size.y);
+        const z = Math.max(0.001, size.z);
+        const vertices = [];
+        const corners = [
+            [-x, -y, -z], [x, -y, -z],
+            [x, y, -z], [-x, y, -z],
+            [-x, -y, z], [x, -y, z],
+            [x, y, z], [-x, y, z]
+        ];
+        [
+            [0, 1], [1, 2], [2, 3], [3, 0],
+            [4, 5], [5, 6], [6, 7], [7, 4],
+            [0, 4], [1, 5], [2, 6], [3, 7]
+        ].forEach(edge => pushSunShadowGizmoLine(vertices, corners[edge[0]], corners[edge[1]]));
+        pushSunShadowGizmoLine(vertices, [-x, 0, 0], [x, 0, 0]);
+        pushSunShadowGizmoLine(vertices, [0, -y, 0], [0, y, 0]);
+        pushSunShadowGizmoLine(vertices, [0, 0, -z], [0, 0, z]);
+        return vertices;
+    }
+
+    function makeSunShadowGizmoHandle(root, name, color, axis, sign) {
+        const material = new THREE.MeshBasicMaterial({
+            color,
+            transparent: true,
+            opacity: 0.95,
+            depthTest: false,
+            depthWrite: false
+        });
+        const handle = new THREE.Mesh(new THREE.SphereGeometry(1, 16, 8), material);
+        handle.name = `lightflow_environment_shadow_${name}`;
+        handle.renderOrder = 1003;
+        handle.userData.lightflowEnvironmentShadowHandle = { name, axis, sign };
+        root.add(handle);
+        return handle;
+    }
+
+    function createSunShadowGizmo() {
+        if (!window.THREE || !window.Canvas?.scene || sunShadowGizmo) return sunShadowGizmo;
+        const root = new THREE.Group();
+        root.name = 'lightflow_environment_shadow_gizmo';
+        root.renderOrder = 1001;
+        root.raycast = () => { };
+
+        const lineMaterial = new THREE.LineBasicMaterial({
+            color: 0xfff3c4,
+            transparent: true,
+            opacity: 0.38,
+            depthTest: false,
+            depthWrite: false
+        });
+        const line = new THREE.LineSegments(new THREE.BufferGeometry(), lineMaterial);
+        line.name = 'lightflow_environment_shadow_area';
+        line.raycast = () => { };
+        root.add(line);
+
+        const handles = {
+            boundPX: makeSunShadowGizmoHandle(root, 'bound_px', 0xb55af8, 'x', 1),
+            boundNX: makeSunShadowGizmoHandle(root, 'bound_nx', 0xb55af8, 'x', -1),
+            boundPY: makeSunShadowGizmoHandle(root, 'bound_py', 0xb55af8, 'y', 1),
+            boundNY: makeSunShadowGizmoHandle(root, 'bound_ny', 0xb55af8, 'y', -1),
+            near: makeSunShadowGizmoHandle(root, 'near', 0xec9218, 'z', 1),
+            far: makeSunShadowGizmoHandle(root, 'far', 0xfa565d, 'z', -1)
+        };
+        Canvas.scene.add(root);
+        registerSunShadowCanvasGizmo(root);
+        sunShadowGizmo = { root, line, lineMaterial, handles, signature: '' };
+        return sunShadowGizmo;
+    }
+
+    function getSunShadowGizmoControlScale(localPosition) {
+        const preview = window.Preview?.selected || window.main_preview;
+        if (!preview || typeof preview.calculateControlScale !== 'function' || !sunShadowGizmo?.root) return 0.45;
+        const worldPosition = localPosition.clone();
+        sunShadowGizmo.root.localToWorld(worldPosition);
+        return Math.max(0.08, preview.calculateControlScale(worldPosition) || 0.45) * 0.52;
+    }
+
+    function updateSunShadowGizmo() {
+        const gizmo = createSunShadowGizmo();
+        if (!gizmo || !sunLight || !sunTarget) return;
+        const shouldShow = !!(
+            settings.show_shadow_gizmo &&
+            settings.enabled &&
+            settings.sun_enabled &&
+            settings.sun_cast_shadows &&
+            settings.shadow_auto_fit &&
+            (!window.Canvas || Canvas.show_gizmos !== false)
+        );
+        gizmo.root.visible = shouldShow;
+        if (!shouldShow) return;
+
+        const fitBox = getShadowFitBox();
+        const center = fitBox.getCenter(new THREE.Vector3());
+        const halfSize = fitBox.getSize(new THREE.Vector3()).multiplyScalar(0.5);
+        gizmo.root.position.copy(center);
+        gizmo.root.quaternion.identity();
+        gizmo.root.scale.setScalar(1);
+        gizmo.lineMaterial.color.copy(sunLight.color);
+
+        const signature = [
+            fitBox.min.x, fitBox.min.y, fitBox.min.z,
+            fitBox.max.x, fitBox.max.y, fitBox.max.z
+        ].join('|');
+        if (gizmo.signature !== signature) {
+            const geometry = new THREE.BufferGeometry();
+            geometry.setAttribute('position', new THREE.Float32BufferAttribute(buildSunShadowGizmoVertices(), 3));
+            gizmo.line.geometry.dispose();
+            gizmo.line.geometry = geometry;
+            gizmo.signature = signature;
+        }
+
+        const positions = {
+            boundPX: new THREE.Vector3(halfSize.x, 0, 0),
+            boundNX: new THREE.Vector3(-halfSize.x, 0, 0),
+            boundPY: new THREE.Vector3(0, halfSize.y, 0),
+            boundNY: new THREE.Vector3(0, -halfSize.y, 0),
+            near: new THREE.Vector3(0, 0, halfSize.z),
+            far: new THREE.Vector3(0, 0, -halfSize.z)
+        };
+        Object.keys(gizmo.handles).forEach(key => {
+            const handle = gizmo.handles[key];
+            handle.position.copy(positions[key]);
+            handle.scale.setScalar(getSunShadowGizmoControlScale(positions[key]));
+        });
+    }
+
+    function disposeSunShadowGizmo() {
+        sunShadowGizmoDrag = null;
+        sunShadowGizmoListeners.splice(0).forEach(listener => listener());
+        if (!sunShadowGizmo) return;
+        unregisterSunShadowCanvasGizmo(sunShadowGizmo.root);
+        sunShadowGizmo.root.parent?.remove?.(sunShadowGizmo.root);
+        sunShadowGizmo.root.traverse(object => {
+            object.geometry?.dispose?.();
+            const materials = Array.isArray(object.material) ? object.material : (object.material ? [object.material] : []);
+            materials.forEach(material => material?.dispose?.());
+        });
+        sunShadowGizmo = null;
+        sunShadowGizmoRaycaster = null;
+        sunShadowGizmoMouse = null;
+        effectiveShadowFrustum = null;
+    }
+
+    function getSunShadowGizmoPreview(event) {
+        const target = event?.target;
+        if (!target) return window.Preview?.selected || window.main_preview || null;
+        const canvas = target.tagName === 'CANVAS'
+            ? target
+            : (typeof target.closest === 'function' ? target.closest('.preview canvas') : null);
+        return (canvas && canvas.preview) || window.Preview?.selected || window.main_preview || null;
+    }
+
+    function setSunShadowGizmoRay(event, preview) {
+        if (!preview?.canvas || !preview.camera) return null;
+        sunShadowGizmoRaycaster = sunShadowGizmoRaycaster || new THREE.Raycaster();
+        sunShadowGizmoMouse = sunShadowGizmoMouse || new THREE.Vector2();
+        const rect = preview.canvas.getBoundingClientRect();
+        sunShadowGizmoMouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+        sunShadowGizmoMouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+        sunShadowGizmoRaycaster.setFromCamera(sunShadowGizmoMouse, preview.camera);
+        return sunShadowGizmoRaycaster.ray;
+    }
+
+    function projectSunShadowGizmoEvent(event, drag) {
+        const ray = setSunShadowGizmoRay(event, drag.preview);
+        if (!ray) return null;
+        const point = new THREE.Vector3();
+        return ray.intersectPlane(drag.plane, point) ? point : null;
+    }
+
+    function stopSunShadowGizmoEvent(event) {
+        event?.preventDefault?.();
+        event?.stopPropagation?.();
+        event?.stopImmediatePropagation?.();
+    }
+
+    function updateSunShadowGizmoDrag(event) {
+        const drag = sunShadowGizmoDrag;
+        if (!drag || !sunShadowGizmo?.root) return;
+        const worldPoint = projectSunShadowGizmoEvent(event, drag);
+        if (!worldPoint) return;
+        const localPoint = drag.viewPosition && drag.inverseViewQuaternion
+            ? worldPoint.clone().sub(drag.viewPosition).applyQuaternion(drag.inverseViewQuaternion)
+            : sunShadowGizmo.root.worldToLocal(worldPoint.clone());
+        const axis = drag.handle.axis;
+        if (!['x', 'y', 'z'].includes(axis)) return;
+        const halfSize = drag.startHalfSize.clone();
+        halfSize[axis] = clamp(Math.abs(localPoint[axis]), 0.001, 100000);
+        const min = drag.startCenter.clone().sub(halfSize);
+        const max = drag.startCenter.clone().add(halfSize);
+        const corners = getBoxWorldCorners(new THREE.Box3(min, max));
+        applySettings({
+            shadow_auto_fit: true,
+            shadow_fit_corners: corners.flatMap(corner => corner.toArray())
+        }, {
+            cause: 'shadow_gizmo',
+            forceShadow: false,
+            syncPanel: false
+        });
+    }
+
+    function installSunShadowGizmoInteraction() {
+        if (typeof document === 'undefined' || sunShadowGizmoListeners.length) return;
+        const onPointerDown = event => {
+            if (event.button !== 0 || !sunShadowGizmo?.root?.visible || window.Canvas?.show_gizmos === false) return;
+            const preview = getSunShadowGizmoPreview(event);
+            if (!preview?.canvas || event.target !== preview.canvas) return;
+            setSunShadowGizmoRay(event, preview);
+            const handles = Object.values(sunShadowGizmo.handles).filter(handle => handle.visible !== false);
+            const hit = sunShadowGizmoRaycaster.intersectObjects(handles, false)[0];
+            const handle = hit?.object?.userData?.lightflowEnvironmentShadowHandle;
+            if (!hit || !handle) return;
+            const normal = new THREE.Vector3(0, 0, -1);
+            preview.camera.getWorldDirection(normal);
+            const fitBox = getShadowFitBox();
+            sunShadowGizmoDrag = {
+                handle,
+                preview,
+                plane: new THREE.Plane().setFromNormalAndCoplanarPoint(normal, hit.point),
+                viewPosition: sunShadowGizmo.root.position.clone(),
+                viewQuaternion: sunShadowGizmo.root.quaternion.clone(),
+                inverseViewQuaternion: sunShadowGizmo.root.quaternion.clone().invert(),
+                startCenter: fitBox.getCenter(new THREE.Vector3()),
+                startHalfSize: fitBox.getSize(new THREE.Vector3()).multiplyScalar(0.5),
+                original: {
+                    shadow_auto_fit: settings.shadow_auto_fit,
+                    shadow_fit_corners: Array.isArray(settings.shadow_fit_corners)
+                        ? settings.shadow_fit_corners.slice()
+                        : null
+                }
+            };
+            stopSunShadowGizmoEvent(event);
+        };
+        const onPointerMove = event => {
+            if (!sunShadowGizmoDrag) return;
+            stopSunShadowGizmoEvent(event);
+            updateSunShadowGizmoDrag(event);
+        };
+        const onPointerUp = event => {
+            if (!sunShadowGizmoDrag) return;
+            stopSunShadowGizmoEvent(event);
+            sunShadowGizmoDrag = null;
+        };
+        const onKeyDown = event => {
+            if (!sunShadowGizmoDrag || event.key !== 'Escape') return;
+            const original = sunShadowGizmoDrag.original;
+            sunShadowGizmoDrag = null;
+            stopSunShadowGizmoEvent(event);
+            applySettings(original, {
+                cause: 'shadow_gizmo_cancel',
+                forceShadow: false,
+                captureShadowFitRegion: false
+            });
+        };
+        document.addEventListener('pointerdown', onPointerDown, true);
+        document.addEventListener('pointermove', onPointerMove, true);
+        document.addEventListener('pointerup', onPointerUp, true);
+        document.addEventListener('keydown', onKeyDown, true);
+        sunShadowGizmoListeners.push(
+            () => document.removeEventListener('pointerdown', onPointerDown, true),
+            () => document.removeEventListener('pointermove', onPointerMove, true),
+            () => document.removeEventListener('pointerup', onPointerUp, true),
+            () => document.removeEventListener('keydown', onKeyDown, true)
+        );
     }
 
     function setColor(target, value) {
@@ -654,12 +1137,11 @@
             sunLight.visible = !!(settings.enabled && settings.sun_enabled && state.sunIntensity > 0.0001);
             sunLight.intensity = state.sunIntensity;
             setColor(sunLight.color, state.sunColor);
-            sunLight.position.fromArray(state.celestialDirection)
-                .multiplyScalar(Math.max(160, settings.shadow_far * 0.38));
-            sunTarget.position.set(0, 0, 0);
+            updateSunShadowPlacement(state.celestialDirection);
             configureSunShadow(!!options.forceShadow);
             sunLight.updateMatrixWorld(true);
             sunTarget.updateMatrixWorld(true);
+            updateSunShadowGizmo();
         }
 
         if (window.ShaderEngine) {
@@ -671,7 +1153,11 @@
             }
         }
         if (typeof window.LightManagerMarkShadowsDirty === 'function') {
-            window.LightManagerMarkShadowsDirty();
+            window.LightManagerMarkShadowsDirty({ scene: !!options.forceShadow });
+        }
+        if (typeof window.LightManagerPrepareRender === 'function') {
+            const preview = window.Preview?.selected || window.main_preview || window.MediaPreview || null;
+            window.LightManagerPrepareRender(preview, { force: !!options.forceShadow });
         }
     }
 
@@ -701,18 +1187,53 @@
         Blockbench.dispatchEvent?.('lightflow_environment_changed', detail);
     }
 
-    function syncToolbar() {
-        timeSlider?.set?.(settings.time);
-        if (animateToggle) {
-            animateToggle.value = settings.animate_time;
-            animateToggle.updateEnabledState?.();
+    function syncEnvironmentPanel(options = {}) {
+        if (!environmentPanel?.form || syncingEnvironmentPanel) return;
+        const controls = environmentPanel.form.form_data;
+        if (!controls) return;
+        syncingEnvironmentPanel = true;
+        try {
+            controls.time?.setValue?.(settings.time);
+            if (options.timeOnly) return;
+            controls.enabled?.setValue?.(settings.enabled);
+            controls.preset?.setValue?.(settings.preset);
+            controls.animate_time?.setValue?.(settings.animate_time);
+            controls.sky_intensity?.setValue?.(settings.sky_intensity);
+            controls.environment_strength?.setValue?.(settings.environment_strength);
+            controls.cloud_mode?.setValue?.(settings.cloud_mode);
+        } finally {
+            syncingEnvironmentPanel = false;
         }
+        environmentPanel.form.update();
     }
 
     function applySettings(next, options = {}) {
-        settings = normalizeSettings(Object.assign({}, settings, next || {}));
+        const incoming = next || {};
+        const frustumKeys = ['shadow_area', 'shadow_near', 'shadow_far'];
+        const hasFrustumEdit = frustumKeys.some(key => Object.prototype.hasOwnProperty.call(incoming, key));
+        const shouldCaptureFitRegion = hasFrustumEdit && (
+            options.captureShadowFitRegion === true ||
+            (
+                options.captureShadowFitRegion !== false &&
+                options.cause !== 'dialog_preview' &&
+                options.cause !== 'dialog_confirm'
+            )
+        );
+        const activeFrustum = getActiveShadowFrustum();
+        const manualFrustum = {
+            area: Object.prototype.hasOwnProperty.call(incoming, 'shadow_area') ? incoming.shadow_area : activeFrustum.area,
+            near: Object.prototype.hasOwnProperty.call(incoming, 'shadow_near') ? incoming.shadow_near : activeFrustum.near,
+            far: Object.prototype.hasOwnProperty.call(incoming, 'shadow_far') ? incoming.shadow_far : activeFrustum.far
+        };
+        const merged = Object.assign({}, settings, incoming);
+        if (shouldCaptureFitRegion) {
+            merged.shadow_area = manualFrustum.area;
+            merged.shadow_near = manualFrustum.near;
+            merged.shadow_far = manualFrustum.far;
+        }
+        settings = normalizeSettings(merged);
+        if (shouldCaptureFitRegion) captureShadowFitRegion(manualFrustum);
         saveSettings();
-        syncToolbar();
         if (options.syncPanel !== false) syncEnvironmentPanel();
         updateScene({ forceShadow: options.forceShadow !== false });
         dispatchChanged(options.cause || 'settings');
@@ -758,8 +1279,77 @@
         };
     }
 
+    function collectEnvironmentSceneFitTargets(fitTool) {
+        const targets = [];
+        const seen = new Set();
+        const roots = Array.isArray(window.Outliner?.root) && Outliner.root.length
+            ? Outliner.root
+            : (Array.isArray(window.Outliner?.elements) ? Outliner.elements : []);
+        roots.forEach(node => fitTool.addTargetNode(node, targets, seen));
+        return targets;
+    }
+
+    function getEnvironmentShadowFitSource() {
+        const fitTool = window.LightManagerFitTool;
+        if (!fitTool) return null;
+
+        const selectedTargets = fitTool.getSelectedTargets();
+        const selectedPoints = fitTool.collectTargetPoints(selectedTargets);
+        if (selectedTargets.length && selectedPoints.length) {
+            return { targets: selectedTargets, points: selectedPoints, mode: 'selection' };
+        }
+
+        const sceneTargets = collectEnvironmentSceneFitTargets(fitTool);
+        const scenePoints = fitTool.collectTargetPoints(sceneTargets);
+        if (!sceneTargets.length || !scenePoints.length) return null;
+        return { targets: sceneTargets, points: scenePoints, mode: 'scene' };
+    }
+
+    function fitEnvironmentShadowRegion() {
+        const source = getEnvironmentShadowFitSource();
+        if (!source) {
+            Blockbench.showQuickMessage(tr(
+                'lightflow_environment.message.fit_no_geometry',
+                'No geometry is available to fit the environment shadow region.'
+            ));
+            return false;
+        }
+
+        const box = window.LightManagerFitTool.getPointsBox(source.points);
+        if (!box || box.isEmpty()) return false;
+        const size = box.getSize(new THREE.Vector3());
+        const margin = Math.max(0.25, Math.max(size.x, size.y, size.z) * 0.015);
+        box.expandByScalar(margin);
+        const min = box.min;
+        const max = box.max;
+        const corners = [
+            [min.x, min.y, min.z], [max.x, min.y, min.z],
+            [max.x, max.y, min.z], [min.x, max.y, min.z],
+            [min.x, min.y, max.z], [max.x, min.y, max.z],
+            [max.x, max.y, max.z], [min.x, max.y, max.z]
+        ];
+        applySettings({
+            shadow_auto_fit: true,
+            shadow_fit_corners: corners.flat()
+        }, {
+            cause: 'fit_shadow_region',
+            forceShadow: false,
+            syncPanel: true
+        });
+
+        const messageKey = source.mode === 'selection'
+            ? 'lightflow_environment.message.fit_selection'
+            : 'lightflow_environment.message.fit_scene';
+        const fallback = source.mode === 'selection'
+            ? 'Environment shadows fitted to the selected geometry.'
+            : 'Environment shadows fitted to all scene geometry.';
+        Blockbench.showQuickMessage(tr(messageKey, fallback));
+        return true;
+    }
+
     function createDialogForm() {
         const textureOptions = getTextureOptions();
+        const shadowFrustum = getActiveShadowFrustum();
         return {
             preset: { type: 'select', label: 'lightflow_environment.field.preset', value: settings.preset,
                 options: { vanilla: 'Minecraft Vanilla', vibrant_visuals: 'Minecraft Vibrant Visuals' } },
@@ -817,11 +1407,19 @@
             cloud_brightness: { type: 'range', label: 'lightflow_environment.field.cloud_brightness', value: settings.cloud_brightness, min: 0, max: 4, step: 0.05, condition: form => !!form.clouds_enabled },
             _shadows: '_',
             sun_cast_shadows: { type: 'checkbox', label: 'lightflow_environment.field.cast_shadows', value: settings.sun_cast_shadows, condition: form => !!form.sun_enabled },
-            shadow_area: { type: 'number', label: 'lightflow_environment.field.shadow_area', value: settings.shadow_area, min: 2, max: 1024, step: 1, condition: form => !!form.sun_cast_shadows },
+            fit_shadow_region: {
+                type: 'buttons',
+                buttons: ['lightflow_environment.action.fit_shadow_region'],
+                click: fitEnvironmentShadowRegion,
+                condition: form => !!form.sun_cast_shadows
+            },
+            shadow_auto_fit: { type: 'checkbox', label: 'lightflow_environment.field.shadow_auto_fit', value: settings.shadow_auto_fit, condition: form => !!form.sun_cast_shadows },
+            show_shadow_gizmo: { type: 'checkbox', label: 'lightflow_environment.field.show_shadow_gizmo', value: settings.show_shadow_gizmo, condition: form => !!form.sun_cast_shadows && !!form.shadow_auto_fit },
+            shadow_area: { type: 'number', label: 'lightflow_environment.field.shadow_area', value: shadowFrustum.area, min: 2, max: 100000, step: 1, condition: form => !!form.sun_cast_shadows && !form.shadow_auto_fit },
             shadow_resolution: { type: 'select', label: 'lightflow_environment.field.shadow_resolution', value: String(settings.shadow_resolution),
                 options: { '256': '256', '512': '512', '1024': '1024', '2048': '2048', '4096': '4096', '8192': '8192' }, condition: form => !!form.sun_cast_shadows },
-            shadow_near: { type: 'number', label: 'lightflow_environment.field.shadow_near', value: settings.shadow_near, min: 0.001, step: 0.1, condition: form => !!form.sun_cast_shadows },
-            shadow_far: { type: 'number', label: 'lightflow_environment.field.shadow_far', value: settings.shadow_far, min: 2, step: 1, condition: form => !!form.sun_cast_shadows },
+            shadow_near: { type: 'number', label: 'lightflow_environment.field.shadow_near', value: shadowFrustum.near, min: 0.001, step: 0.1, condition: form => !!form.sun_cast_shadows && !form.shadow_auto_fit },
+            shadow_far: { type: 'number', label: 'lightflow_environment.field.shadow_far', value: shadowFrustum.far, min: 2, step: 1, condition: form => !!form.sun_cast_shadows && !form.shadow_auto_fit },
             shadow_bias: { type: 'number', label: 'lightflow_environment.field.shadow_bias', value: settings.shadow_bias, min: -0.1, max: 0.1, step: 0.00005, condition: form => !!form.sun_cast_shadows },
             shadow_normal_bias: { type: 'number', label: 'lightflow_environment.field.normal_bias', value: settings.shadow_normal_bias, min: 0, max: 2, step: 0.005, condition: form => !!form.sun_cast_shadows },
             pixelated_shadows: { type: 'checkbox', label: 'lightflow_environment.field.pixelated_shadows', value: settings.pixelated_shadows, condition: form => !!form.sun_cast_shadows },
@@ -832,37 +1430,95 @@
 
     function createPanelForm() {
         return {
-            enabled: { type: 'checkbox', label: 'lightflow_environment.field.enabled', value: settings.enabled },
-            preset: { type: 'select', label: 'lightflow_environment.field.preset', value: settings.preset,
-                options: { vanilla: 'Minecraft Vanilla', vibrant_visuals: 'Minecraft Vibrant Visuals' } },
-            time: { type: 'range', label: 'lightflow_environment.field.time', value: settings.time, min: 0, max: 23999, step: 100 },
-            animate_time: { type: 'checkbox', label: 'lightflow_environment.field.animate', value: settings.animate_time },
-            sky_intensity: { type: 'range', label: 'lightflow_environment.field.sky_intensity', value: settings.sky_intensity, min: 0, max: 4, step: 0.05 },
-            environment_strength: { type: 'range', label: 'lightflow_environment.field.environment', value: settings.environment_strength, min: 0, max: 4, step: 0.05 },
-            cloud_mode: { type: 'select', label: 'lightflow_environment.field.cloud_mode', value: settings.cloud_mode,
-                options: { procedural: 'lightflow_environment.option.cloud_procedural', vanilla: 'lightflow_environment.option.cloud_vanilla', texture: 'lightflow_environment.option.cloud_texture' } },
-            panel_advanced: { type: 'buttons', buttons: ['lightflow_environment.action.open'], click() { openSettingsDialog(); } }
+            enabled: {
+                type: 'action_toggle', value: settings.enabled, description: 'lightflow_environment.field.enabled',
+                icon_on: 'public', icon_off: 'public_off', bg_on: markerColor(0, 'standard', '#58C0FF'),
+                color_on: 'var(--color-ui)', color_off: 'var(--color-subtle_text)', icon_size: '22px'
+            },
+            preset: {
+                type: 'compact_select', label: 'lightflow_environment.field.preset', hide_label: true,
+                description: 'lightflow_environment.field.preset', background: 'transparent', value: settings.preset,
+                options: {
+                    vanilla: { name: 'Minecraft Vanilla', icon: 'landscape', color: markerColor(0, 'pastel', '#A2EBFF') },
+                    vibrant_visuals: { name: 'Minecraft Vibrant Visuals', icon: 'auto_awesome', color: markerColor(1, 'pastel', '#FFF899') }
+                }
+            },
+            animate_time: {
+                type: 'action_toggle', value: settings.animate_time, description: 'lightflow_environment.field.animate',
+                icon_on: 'pause_circle', icon_off: 'play_circle', bg_on: markerColor(6, 'standard', '#00CE71'),
+                color_on: 'var(--color-ui)', color_off: markerColor(6, 'pastel', '#7BFFA3')
+            },
+            panel_advanced: {
+                type: 'action_button', icon: 'tune', description: 'lightflow_environment.action.open',
+                color: markerColor(4, 'pastel', '#C5A6E8'), click: openSettingsDialog
+            },
+            fit_shadow_region: {
+                type: 'action_button', icon: 'center_focus_strong',
+                description: 'lightflow_environment.action.fit_shadow_region.desc',
+                color: markerColor(4, 'pastel', '#C5A6E8'), click: fitEnvironmentShadowRegion
+            },
+            time: {
+                type: 'combo_slider', label: 'lightflow_environment.field.time', icon: 'schedule',
+                color: markerColor(1, 'pastel', '#FFF899'), value: settings.time,
+                resettable: true, reset_value: DEFAULT_SETTINGS.time, min: 0, max: 23999, step: 100
+            },
+            sky_label: {
+                type: 'bar_display', icon: 'wb_twilight', paragraph: false, expand: false,
+                color: 'var(--color-subtle_text)', description: 'lightflow_environment.field.sky_intensity'
+            },
+            sky_intensity: {
+                type: 'combo_slider', label: 'lightflow_environment.field.sky_intensity', icon: 'wb_sunny',
+                background: 'transparent', color: markerColor(2, 'pastel', '#F1BB75'),
+                icon_color: markerColor(2, 'pastel', '#F1BB75'), compact: true, popup_width: '300px',
+                value: settings.sky_intensity, resettable: true, reset_value: DEFAULT_SETTINGS.sky_intensity,
+                min: 0, max: 4, step: 0.05
+            },
+            environment_strength: {
+                type: 'combo_slider', label: 'lightflow_environment.field.environment', icon: 'language',
+                background: 'transparent', color: markerColor(6, 'pastel', '#7BFFA3'),
+                icon_color: markerColor(6, 'pastel', '#7BFFA3'), compact: true, popup_width: '300px',
+                value: settings.environment_strength, resettable: true, reset_value: DEFAULT_SETTINGS.environment_strength,
+                min: 0, max: 4, step: 0.05
+            },
+            cloud_mode: {
+                type: 'compact_select', label: 'lightflow_environment.field.cloud_mode', hide_label: true,
+                description: 'lightflow_environment.field.cloud_mode', background: 'transparent', value: settings.cloud_mode,
+                options: {
+                    procedural: { name: 'lightflow_environment.option.cloud_procedural', icon: 'grain', color: markerColor(9, 'pastel', '#E0E9FB') },
+                    vanilla: { name: 'lightflow_environment.option.cloud_vanilla', icon: 'cloud', color: markerColor(0, 'pastel', '#A2EBFF') },
+                    texture: { name: 'lightflow_environment.option.cloud_texture', icon: 'texture', color: markerColor(8, 'pastel', '#FFA5D5') }
+                }
+            }
         };
     }
 
-    function syncEnvironmentPanel() {
-        if (!environmentPanel?.form || syncingEnvironmentPanel) return;
-        syncingEnvironmentPanel = true;
-        environmentPanel.form.form_config = createPanelForm();
-        environmentPanel.form.buildForm();
-        syncingEnvironmentPanel = false;
-    }
-
     function openSettingsDialog() {
+        const formConfig = createDialogForm();
+        let previousShadowFrustum = {
+            shadow_area: formConfig.shadow_area.value,
+            shadow_near: formConfig.shadow_near.value,
+            shadow_far: formConfig.shadow_far.value
+        };
+        const applyDialogSettings = (form, options) => {
+            const shadowFrustumChanged = ['shadow_area', 'shadow_near', 'shadow_far'].some(key => (
+                Math.abs(finite(form[key], previousShadowFrustum[key]) - finite(previousShadowFrustum[key], 0)) > 1e-6
+            ));
+            previousShadowFrustum = {
+                shadow_area: form.shadow_area,
+                shadow_near: form.shadow_near,
+                shadow_far: form.shadow_far
+            };
+            applySettings(form, { ...options, captureShadowFitRegion: shadowFrustumChanged });
+        };
         new Dialog('lightflow_environment_composer_dialog', {
             title: 'lightflow_environment.dialog.title',
             width: 720,
-            form: createDialogForm(),
+            form: formConfig,
             onFormChange(form) {
-                applySettings(form, { cause: 'dialog_preview', forceShadow: false, syncPanel: false });
+                applyDialogSettings(form, { cause: 'dialog_preview', forceShadow: false, syncPanel: false });
             },
             onConfirm(form) {
-                applySettings(form, { cause: 'dialog_confirm', forceShadow: true, syncPanel: true });
+                applyDialogSettings(form, { cause: 'dialog_confirm', forceShadow: true, syncPanel: true });
             }
         }).show();
     }
@@ -876,67 +1532,60 @@
             condition: () => !!window.Project,
             click: openSettingsDialog
         });
-        timeSlider = new NumSlider('lightflow_environment_time', {
-            name: 'lightflow_environment.field.time',
-            icon: 'schedule',
-            category: 'view',
-            condition: () => !!window.Project,
-            value: settings.time,
-            min: 0, max: 23999, step: 100,
-            onChange() {
-                applySettings({ time: this.value }, { cause: 'time_slider', forceShadow: false });
-            }
-        });
-        animateToggle = new Toggle('lightflow_environment_animate', {
-            name: 'lightflow_environment.field.animate',
-            icon: 'play_circle',
-            category: 'view',
-            condition: () => !!window.Project,
-            value: settings.animate_time,
-            onChange(value) {
-                applySettings({ animate_time: !!value }, { cause: 'animate_toggle', forceShadow: false });
-            }
-        });
-        const toolbar = new Toolbar({
-            id: 'lightflow_environment_toolbar',
-            name: 'lightflow_environment.plugin.title',
-            children: ['lightflow_environment_composer', 'lightflow_environment_time', 'lightflow_environment_animate']
-        });
         environmentPanel = new Panel('lightflow_environment_panel', {
-            name: 'lightflow_environment.plugin.title',
+            name: 'lightflow_environment.panel.title',
             icon: 'wb_twilight',
             growable: true,
             resizable: true,
             expand_button: true,
             condition: { modes: ['render'], project: true },
             default_position: {
-                slot: 'right_bar', float_position: [0, 0], float_size: [340, 460], height: 390,
+                slot: 'right_bar', float_position: [0, 0], float_size: [314, 200], height: 200,
                 folded: false, attached_to: 'outliner', attached_index: 1, sidebar_index: 1
             },
             mode_positions: {
                 render: {
-                    slot: 'right_bar', height: 390, folded: false,
+                    slot: 'right_bar', height: 200, folded: false,
                     attached_to: 'outliner', attached_index: 1, sidebar_index: 1
                 }
             },
             insert_after: 'outliner',
-            toolbars: [toolbar],
             form: createPanelForm()
         });
         environmentPanel.form.on('change', ({ result }) => {
             if (syncingEnvironmentPanel) return;
-            applySettings(result, { cause: 'environment_panel', forceShadow: false, syncPanel: false });
+            const panelResult = {};
+            ['enabled', 'preset', 'time', 'animate_time', 'sky_intensity', 'environment_strength', 'cloud_mode'].forEach(key => {
+                if (result && Object.prototype.hasOwnProperty.call(result, key)) panelResult[key] = result[key];
+            });
+            applySettings(panelResult, { cause: 'environment_panel', forceShadow: false, syncPanel: false });
         });
+        window.applyIndestructibleFormGroups(environmentPanel.form, [
+            {
+                elements: ['enabled', 'preset', '+', 'animate_time', 'fit_shadow_region', 'panel_advanced'], gap: '2px',
+                divider_color: 'var(--color-grid)',
+                flex: { enabled: '0 0 auto', preset: '0 0 auto', animate_time: '0 0 auto', fit_shadow_region: '0 0 auto', panel_advanced: '0 0 auto' }
+            },
+            { elements: ['time'], gap: '2px', flex: { time: '1 1 100%' } },
+            {
+                elements: ['sky_label', 'sky_intensity', 'environment_strength', 'cloud_mode'], gap: '2px',
+                flex: { sky_label: '0 0 auto', sky_intensity: '0 0 auto', environment_strength: '0 0 auto', cloud_mode: '0 0 auto' }
+            }
+        ]);
+        const panelStyles = window.LightManagerUI.addCompactPanelStyles('lightflow_environment_panel');
         MenuBar.menus.view.addAction(settingsAction, '9');
-        deletables.push(settingsAction, timeSlider, animateToggle, toolbar, environmentPanel);
-        syncToolbar();
+        deletables.push(settingsAction, environmentPanel, panelStyles);
+        syncEnvironmentPanel();
     }
 
     function installTranslations() {
         const translations = {
             'lightflow_environment.plugin.title': 'Lightflow Environment',
+            'lightflow_environment.panel.title': 'ENVIRONMENT',
             'lightflow_environment.action.open': 'Environment Composer...',
             'lightflow_environment.action.open.desc': 'Compose a Minecraft sky, time, sun, moon, clouds, ambient response, and directional shadows',
+            'lightflow_environment.action.fit_shadow_region': 'Fit Shadow Region to Selection / Scene',
+            'lightflow_environment.action.fit_shadow_region.desc': 'Fit environment shadows to selected geometry, or to all scene geometry when nothing is selected',
             'lightflow_environment.dialog.title': 'Minecraft Environment Composer',
             'lightflow_environment.field.preset': 'Sky Model',
             'lightflow_environment.field.enabled': 'Render Environment',
@@ -990,6 +1639,8 @@
             'lightflow_environment.field.cloud_contrast': 'Cloud Contrast',
             'lightflow_environment.field.cloud_brightness': 'Cloud Brightness',
             'lightflow_environment.field.cast_shadows': 'Sun Cast Shadows',
+            'lightflow_environment.field.shadow_auto_fit': 'Fixed World Shadow Coverage Box',
+            'lightflow_environment.field.show_shadow_gizmo': 'Show Editable Fixed Shadow Box',
             'lightflow_environment.field.shadow_area': 'Shadow Capture Area',
             'lightflow_environment.field.shadow_resolution': 'Shadow Resolution',
             'lightflow_environment.field.shadow_near': 'Shadow Near Plane',
@@ -998,12 +1649,19 @@
             'lightflow_environment.field.normal_bias': 'Shadow Normal Bias',
             'lightflow_environment.field.pixelated_shadows': 'Vibrant Visuals Pixel Shadows',
             'lightflow_environment.field.pixel_shadow_steps': 'Shadow Tone Steps',
-            'lightflow_environment.field.pixel_shadow_scale': 'Shadow Pixel Size'
+            'lightflow_environment.field.pixel_shadow_scale': 'Shadow Pixel Size',
+            'lightflow_environment.message.light_manager_required': 'Lightflow Environment requires Light Manager.',
+            'lightflow_environment.message.fit_selection': 'Environment shadows fitted to the selected geometry.',
+            'lightflow_environment.message.fit_scene': 'Environment shadows fitted to all scene geometry.',
+            'lightflow_environment.message.fit_no_geometry': 'No geometry is available to fit the environment shadow region.'
         };
         Language.addTranslations('en', translations);
         Language.addTranslations('es', Object.assign({}, translations, {
             'lightflow_environment.plugin.title': 'Entorno Lightflow',
+            'lightflow_environment.panel.title': 'ENTORNO',
             'lightflow_environment.action.open': 'Compositor de entorno...',
+            'lightflow_environment.action.fit_shadow_region': 'Ajustar región de sombras a selección / escena',
+            'lightflow_environment.action.fit_shadow_region.desc': 'Ajusta las sombras a la geometría seleccionada o a toda la escena cuando no hay selección',
             'lightflow_environment.dialog.title': 'Compositor de entorno Minecraft',
             'lightflow_environment.field.preset': 'Modelo de cielo',
             'lightflow_environment.field.enabled': 'Renderizar entorno',
@@ -1043,8 +1701,14 @@
             'lightflow_environment.field.cloud_contrast': 'Contraste de nubes',
             'lightflow_environment.field.cloud_brightness': 'Brillo de nubes',
             'lightflow_environment.field.cast_shadows': 'El sol proyecta sombras',
+            'lightflow_environment.field.shadow_auto_fit': 'Caja fija mundial de cobertura de sombras',
+            'lightflow_environment.field.show_shadow_gizmo': 'Mostrar caja fija de sombras editable',
             'lightflow_environment.field.shadow_area': 'Área de captura de sombras',
-            'lightflow_environment.field.pixelated_shadows': 'Sombras pixeladas Vibrant Visuals'
+            'lightflow_environment.field.pixelated_shadows': 'Sombras pixeladas Vibrant Visuals',
+            'lightflow_environment.message.light_manager_required': 'Lightflow Environment requiere Light Manager.',
+            'lightflow_environment.message.fit_selection': 'Sombras del entorno ajustadas a la geometría seleccionada.',
+            'lightflow_environment.message.fit_scene': 'Sombras del entorno ajustadas a toda la geometría de la escena.',
+            'lightflow_environment.message.fit_no_geometry': 'No hay geometría disponible para ajustar la región de sombras.'
         }));
     }
 
@@ -1062,6 +1726,7 @@
     function loadProjectSettings(project) {
         const activeProject = project || window.Project;
         if (!activeProject) return;
+        effectiveShadowFrustum = null;
         const raw = activeProject[PROJECT_PROPERTY];
         if (typeof raw === 'string' && raw.trim()) {
             try {
@@ -1072,7 +1737,6 @@
         } else {
             settings = loadSettings();
         }
-        syncToolbar();
         syncEnvironmentPanel();
         updateScene({ forceShadow: true });
         dispatchChanged('project_load');
@@ -1090,7 +1754,7 @@
             settings.time = mod(settings.time + deltaSeconds * 24000 / Math.max(settings.day_length_seconds, 1), 24000);
             if (timestamp - lastRenderTime < 33) return;
             lastRenderTime = timestamp;
-            syncToolbar();
+            syncEnvironmentPanel({ timeOnly: true });
             updateScene({ forceShadow: false });
             dispatchChanged('animation');
             requestPreviewRender();
@@ -1099,6 +1763,7 @@
     }
 
     function disposeScene() {
+        disposeSunShadowGizmo();
         if (sunLight) {
             if (window.three_lights?.[sunLight.uuid] === sunLight) delete window.three_lights[sunLight.uuid];
             sunLight.parent?.remove?.(sunLight);
@@ -1136,13 +1801,25 @@
         version: PLUGIN_VERSION,
         min_version: '4.9.0',
         variant: 'both',
+        dependencies: ['light_manager'],
 
-        onload() {
+        async onload() {
+            try {
+                await waitForLightManager();
+            } catch (error) {
+                Blockbench.showToastNotification({
+                    text: tr('lightflow_environment.message.light_manager_required', 'Lightflow Environment requires Light Manager.'),
+                    icon: 'error',
+                    expire: 10000
+                });
+                return;
+            }
             registerProjectProperty();
             installUI();
             createSky();
             createSunLight();
             updateScene({ forceShadow: true });
+            installSunShadowGizmoInteraction();
 
             window.LightflowEnvironment = {
                 get settings() { return Object.assign({}, settings); },
@@ -1168,12 +1845,13 @@
             };
             const textureListeners = ['add_texture', 'remove_texture', 'update_texture']
                 .map(eventName => Blockbench.on(eventName, textureChanged));
+            const viewListener = Blockbench.on('update_view', () => updateSunShadowGizmo());
             const lightManagerListener = () => {
                 ensureSunLightParent();
                 updateScene({ forceShadow: true });
             };
             window.addEventListener('light_manager_initialized', lightManagerListener);
-            deletables.push(selectListener, loadListener, parsedListener, ...textureListeners, {
+            deletables.push(selectListener, loadListener, parsedListener, ...textureListeners, viewListener, {
                 delete() { window.removeEventListener('light_manager_initialized', lightManagerListener); }
             });
             startAnimation();

--- a/lightflow_environment.js
+++ b/lightflow_environment.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_environment';
-    const PLUGIN_VERSION = '1.0.0';
+    const PLUGIN_VERSION = '1.0.1';
     const STORAGE_KEY = 'lightflow_environment.settings';
     const PROJECT_PROPERTY = 'lightflow_environment_settings';
     const TWO_PI = Math.PI * 2;
@@ -245,7 +245,7 @@
         '    vec4 clipPosition = projectionMatrix * rotationOnlyView * vec4(position, 1.0);',
         '    gl_Position = clipPosition.xyww;',
         '}'
-    ].join('\\n');
+    ].join('\n');
 
     const SKY_FRAGMENT = [
         'precision highp float;',
@@ -310,7 +310,7 @@
         '    }',
         '    gl_FragColor=vec4(max(color,vec3(0)),1);',
         '}'
-    ].join('\\n');
+    ].join('\n');
 
     function createSky() {
         if (!window.THREE || !window.Canvas?.scene || skyMesh) return false;

--- a/lightflow_environment.js
+++ b/lightflow_environment.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_environment';
-    const PLUGIN_VERSION = '1.0.1';
+    const PLUGIN_VERSION = '1.1.0';
     const STORAGE_KEY = 'lightflow_environment.settings';
     const PROJECT_PROPERTY = 'lightflow_environment_settings';
     const TWO_PI = Math.PI * 2;
@@ -14,19 +14,42 @@
         animate_time: false,
         day_length_seconds: 120,
         sun_azimuth: 0,
+        palette_mode: 'preset',
+        zenith_color: '#78a7ff',
+        horizon_color: '#b8d2ff',
+        sunrise_zenith_color: '#647db5',
+        sunrise_horizon_color: '#f59a62',
+        night_zenith_color: '#05091d',
+        night_horizon_color: '#151d3d',
+        ground_color: '#536b78',
+        sun_color: '#fff3c4',
+        moon_color: '#dbe4ff',
+        cloud_color: '#f3f5f7',
         sky_intensity: 1,
+        sky_gradient_power: 2.3,
+        star_density: 1,
         environment_strength: 0.75,
         sun_enabled: true,
         sun_intensity: 2.2,
         moon_intensity: 0.28,
         celestial_size: 0.055,
         moon_phase: 0,
+        sun_mode: 'vanilla',
+        moon_mode: 'vanilla',
+        sun_texture_uuid: '',
+        moon_texture_uuid: '',
         stars_enabled: true,
         star_brightness: 0.72,
         clouds_enabled: true,
+        cloud_mode: 'vanilla',
+        cloud_texture_uuid: '',
         cloud_coverage: 0.54,
         cloud_opacity: 0.78,
         cloud_speed: 0.016,
+        cloud_scale: 1,
+        cloud_direction: 0,
+        cloud_contrast: 1,
+        cloud_brightness: 1,
         sun_cast_shadows: true,
         shadow_area: 48,
         shadow_near: 0.1,
@@ -66,6 +89,10 @@
     let settingsAction = null;
     let timeSlider = null;
     let animateToggle = null;
+    let environmentPanel = null;
+    let syncingEnvironmentPanel = false;
+    let vanillaCloudTexture = null;
+    let fallbackTexture = null;
     let projectProperty = null;
     let animationFrame = null;
     let lastFrameTime = 0;
@@ -91,6 +118,11 @@
         return translated === key ? (fallback || key) : translated;
     }
 
+    function normalizeHex(value, fallback) {
+        const match = String(value || '').trim().match(/^#?([0-9a-f]{6})$/i);
+        return match ? '#' + match[1].toLowerCase() : fallback;
+    }
+
     function normalizeSettings(source) {
         const result = Object.assign({}, DEFAULT_SETTINGS, source || {});
         result.enabled = result.enabled !== false;
@@ -99,19 +131,42 @@
         result.animate_time = !!result.animate_time;
         result.day_length_seconds = clamp(finite(result.day_length_seconds, 120), 10, 3600);
         result.sun_azimuth = mod(finite(result.sun_azimuth, 0), 360);
+        result.palette_mode = result.palette_mode === 'custom' ? 'custom' : 'preset';
+        result.zenith_color = normalizeHex(result.zenith_color, DEFAULT_SETTINGS.zenith_color);
+        result.horizon_color = normalizeHex(result.horizon_color, DEFAULT_SETTINGS.horizon_color);
+        result.sunrise_zenith_color = normalizeHex(result.sunrise_zenith_color, DEFAULT_SETTINGS.sunrise_zenith_color);
+        result.sunrise_horizon_color = normalizeHex(result.sunrise_horizon_color, DEFAULT_SETTINGS.sunrise_horizon_color);
+        result.night_zenith_color = normalizeHex(result.night_zenith_color, DEFAULT_SETTINGS.night_zenith_color);
+        result.night_horizon_color = normalizeHex(result.night_horizon_color, DEFAULT_SETTINGS.night_horizon_color);
+        result.ground_color = normalizeHex(result.ground_color, DEFAULT_SETTINGS.ground_color);
+        result.sun_color = normalizeHex(result.sun_color, DEFAULT_SETTINGS.sun_color);
+        result.moon_color = normalizeHex(result.moon_color, DEFAULT_SETTINGS.moon_color);
+        result.cloud_color = normalizeHex(result.cloud_color, DEFAULT_SETTINGS.cloud_color);
         result.sky_intensity = clamp(finite(result.sky_intensity, 1), 0, 4);
+        result.sky_gradient_power = clamp(finite(result.sky_gradient_power, 2.3), 0.5, 8);
+        result.star_density = clamp(finite(result.star_density, 1), 0.1, 4);
         result.environment_strength = clamp(finite(result.environment_strength, 0.75), 0, 4);
         result.sun_enabled = result.sun_enabled !== false;
         result.sun_intensity = clamp(finite(result.sun_intensity, 2.2), 0, 20);
         result.moon_intensity = clamp(finite(result.moon_intensity, 0.28), 0, 5);
         result.celestial_size = clamp(finite(result.celestial_size, 0.055), 0.012, 0.18);
         result.moon_phase = Math.round(clamp(finite(result.moon_phase, 0), 0, 7));
+        result.sun_mode = ['vanilla', 'texture', 'hidden'].includes(result.sun_mode) ? result.sun_mode : 'vanilla';
+        result.moon_mode = ['vanilla', 'texture', 'hidden'].includes(result.moon_mode) ? result.moon_mode : 'vanilla';
+        result.sun_texture_uuid = typeof result.sun_texture_uuid === 'string' ? result.sun_texture_uuid : '';
+        result.moon_texture_uuid = typeof result.moon_texture_uuid === 'string' ? result.moon_texture_uuid : '';
         result.stars_enabled = result.stars_enabled !== false;
         result.star_brightness = clamp(finite(result.star_brightness, 0.72), 0, 3);
         result.clouds_enabled = result.clouds_enabled !== false;
+        result.cloud_mode = ['procedural', 'vanilla', 'texture'].includes(result.cloud_mode) ? result.cloud_mode : 'vanilla';
+        result.cloud_texture_uuid = typeof result.cloud_texture_uuid === 'string' ? result.cloud_texture_uuid : '';
         result.cloud_coverage = clamp(finite(result.cloud_coverage, 0.54), 0, 1);
         result.cloud_opacity = clamp(finite(result.cloud_opacity, 0.78), 0, 1);
         result.cloud_speed = clamp(finite(result.cloud_speed, 0.016), -1, 1);
+        result.cloud_scale = clamp(finite(result.cloud_scale, 1), 0.05, 16);
+        result.cloud_direction = mod(finite(result.cloud_direction, 0), 360);
+        result.cloud_contrast = clamp(finite(result.cloud_contrast, 1), 0.1, 4);
+        result.cloud_brightness = clamp(finite(result.cloud_brightness, 1), 0, 4);
         result.sun_cast_shadows = result.sun_cast_shadows !== false;
         result.shadow_area = clamp(finite(result.shadow_area, 48), 2, 1024);
         result.shadow_near = clamp(finite(result.shadow_near, 0.1), 0.001, 10000);
@@ -174,6 +229,93 @@
         return t * t * (3 - 2 * t);
     }
 
+    function getPalette() {
+        if (settings.palette_mode !== 'custom') return PRESETS[settings.preset] || PRESETS.vanilla;
+        return {
+            name: 'Custom',
+            zenith: settings.zenith_color,
+            horizon: settings.horizon_color,
+            sunrise_zenith: settings.sunrise_zenith_color,
+            sunrise_horizon: settings.sunrise_horizon_color,
+            night_zenith: settings.night_zenith_color,
+            night_horizon: settings.night_horizon_color,
+            ground: settings.ground_color,
+            sun: settings.sun_color,
+            moon: settings.moon_color,
+            cloud: settings.cloud_color,
+            ambient_day: (PRESETS[settings.preset] || PRESETS.vanilla).ambient_day,
+            ambient_night: (PRESETS[settings.preset] || PRESETS.vanilla).ambient_night
+        };
+    }
+
+    function getTextureOptions() {
+        const options = { '': tr('lightflow_environment.option.texture_none', 'Select a project texture') };
+        if (typeof Texture !== 'undefined' && Array.isArray(Texture.all)) {
+            Texture.all.forEach((texture, index) => {
+                if (!texture?.uuid) return;
+                options[texture.uuid] = texture.name || texture.path || `Texture ${index + 1}`;
+            });
+        }
+        return options;
+    }
+
+    function getBlockbenchTextureMap(uuid) {
+        if (!uuid || typeof Texture === 'undefined' || !Array.isArray(Texture.all)) return null;
+        const texture = Texture.all.find(candidate => candidate?.uuid === uuid);
+        if (!texture) return null;
+        const material = texture.getOwnMaterial?.() || texture.getMaterial?.() || texture.material;
+        const map = material?.map || material?.uniforms?.map?.value || texture.texture || texture.three_texture;
+        if (map?.isTexture) return map;
+        const image = texture.canvas || texture.img || texture.image;
+        if (!image || !window.THREE) return null;
+        if (!texture._lightflowEnvironmentTexture) {
+            texture._lightflowEnvironmentTexture = new THREE.Texture(image);
+            texture._lightflowEnvironmentTexture.needsUpdate = true;
+        }
+        return texture._lightflowEnvironmentTexture;
+    }
+
+    function createCanvasTexture(canvas, name) {
+        const texture = THREE.CanvasTexture ? new THREE.CanvasTexture(canvas) : new THREE.Texture(canvas);
+        texture.name = name;
+        texture.minFilter = THREE.NearestFilter;
+        texture.magFilter = THREE.NearestFilter;
+        texture.wrapS = THREE.RepeatWrapping;
+        texture.wrapT = THREE.RepeatWrapping;
+        texture.generateMipmaps = false;
+        texture.needsUpdate = true;
+        return texture;
+    }
+
+    function ensureSkyTextures() {
+        if (!window.THREE || typeof document === 'undefined') return;
+        if (!fallbackTexture) {
+            const canvas = document.createElement('canvas');
+            canvas.width = canvas.height = 1;
+            const context = canvas.getContext('2d');
+            context.fillStyle = '#ffffff';
+            context.fillRect(0, 0, 1, 1);
+            fallbackTexture = createCanvasTexture(canvas, 'Lightflow_Environment_Fallback');
+        }
+        if (!vanillaCloudTexture) {
+            const canvas = document.createElement('canvas');
+            canvas.width = canvas.height = 64;
+            const context = canvas.getContext('2d');
+            context.clearRect(0, 0, 64, 64);
+            for (let y = 0; y < 16; y++) {
+                for (let x = 0; x < 16; x++) {
+                    const seed = Math.sin((x + 19) * 12.9898 + (y + 7) * 78.233) * 43758.5453;
+                    const value = seed - Math.floor(seed);
+                    if (value < 0.48) continue;
+                    const shade = Math.round(214 + value * 41);
+                    context.fillStyle = `rgba(${shade},${shade},${shade},${0.72 + value * 0.28})`;
+                    context.fillRect(x * 4, y * 4, 4, 4);
+                }
+            }
+            vanillaCloudTexture = createCanvasTexture(canvas, 'Lightflow_VanillaStyle_Clouds');
+        }
+    }
+
     function getSunDirection(timeValue = settings.time) {
         const angle = mod(timeValue, 24000) / 24000 * TWO_PI;
         const azimuth = settings.sun_azimuth / 180 * Math.PI;
@@ -186,7 +328,7 @@
     }
 
     function getLightingState() {
-        const preset = PRESETS[settings.preset] || PRESETS.vanilla;
+        const preset = getPalette();
         const sunDirection = getSunDirection();
         const sunHeight = sunDirection[1];
         const daylight = smoothstep(-0.12, 0.16, sunHeight);
@@ -225,8 +367,15 @@
             cloudColor: hexToRgb(preset.cloud),
             cloudCoverage: settings.cloud_coverage,
             cloudOpacity: settings.clouds_enabled ? settings.cloud_opacity : 0,
+            cloudMode: settings.cloud_mode,
+            cloudScale: settings.cloud_scale,
+            cloudDirection: settings.cloud_direction,
+            cloudContrast: settings.cloud_contrast,
+            cloudBrightness: settings.cloud_brightness,
             cloudTime: settings.time / 24000 * 180 +
                 performance.now() * 0.001 * settings.cloud_speed,
+            skyGradientPower: settings.sky_gradient_power,
+            starDensity: settings.star_density,
             vibrant: settings.preset === 'vibrant_visuals',
             ambientColor,
             ambientIntensity,
@@ -267,6 +416,18 @@
         'uniform float uCloudOpacity;',
         'uniform float uCloudTime;',
         'uniform float uVibrant;',
+        'uniform float uSkyGradientPower;',
+        'uniform float uStarDensity;',
+        'uniform int uSunMode;',
+        'uniform int uMoonMode;',
+        'uniform int uCloudMode;',
+        'uniform sampler2D uSunTexture;',
+        'uniform sampler2D uMoonTexture;',
+        'uniform sampler2D uCloudTexture;',
+        'uniform float uCloudScale;',
+        'uniform float uCloudDirection;',
+        'uniform float uCloudContrast;',
+        'uniform float uCloudBrightness;',
         'varying vec3 vSkyDirection;',
         'float hash21(vec2 p) { p = fract(p * vec2(123.34, 456.21)); p += dot(p, p + 45.32); return fract(p.x * p.y); }',
         'float valueNoise(vec2 p) {',
@@ -288,24 +449,40 @@
         '}',
         'void main() {',
         '    vec3 d=normalize(vSkyDirection); float up=d.y;',
-        '    float h=pow(1.0-clamp(abs(up),0.0,1.0),mix(2.3,3.4,uVibrant));',
+        '    float h=pow(1.0-clamp(abs(up),0.0,1.0),max(.1,uSkyGradientPower+uVibrant*1.1));',
         '    vec3 color=up>=0.0?mix(uZenith,uHorizon,h):mix(uGround,uHorizon,exp(up*7.0));',
-        '    float sun=squareDisc(celestialCoordinates(d,uSunDirection),uCelestialSize);',
+        '    vec2 sunCoord=celestialCoordinates(d,uSunDirection);',
+        '    vec2 sunUv=sunCoord/max(uCelestialSize*2.0,.001)+.5;',
+        '    float sunInside=step(0.0,sunUv.x)*step(sunUv.x,1.0)*step(0.0,sunUv.y)*step(sunUv.y,1.0);',
+        '    vec4 sunTex=texture2D(uSunTexture,clamp(sunUv,0.0,1.0));',
+        '    float sunTexMask=sunTex.a<.999?sunTex.a:max(sunTex.r,max(sunTex.g,sunTex.b));',
+        '    float sun=uSunMode==0?squareDisc(sunCoord,uCelestialSize):(uSunMode==1?sunInside*sunTexMask:0.0);',
         '    vec2 moonUv=celestialCoordinates(d,-uSunDirection)/max(uCelestialSize,.001);',
-        '    float moonSquare=squareDisc(moonUv*uCelestialSize,uCelestialSize);',
+        '    vec2 moonTexUv=moonUv*.5+.5;',
+        '    float moonInside=step(0.0,moonTexUv.x)*step(moonTexUv.x,1.0)*step(0.0,moonTexUv.y)*step(moonTexUv.y,1.0);',
+        '    vec4 moonTex=texture2D(uMoonTexture,clamp(moonTexUv,0.0,1.0));',
+        '    float moonTexMask=moonTex.a<.999?moonTex.a:max(moonTex.r,max(moonTex.g,moonTex.b));',
+        '    float moonSquare=uMoonMode==0?squareDisc(moonUv*uCelestialSize,uCelestialSize):(uMoonMode==1?moonInside*moonTexMask:0.0);',
         '    float phaseShift=(uMoonPhase-3.5)/4.0;',
         '    float moon=moonSquare*smoothstep(-.12,.12,.78-abs(moonUv.x+phaseShift));',
-        '    color=mix(color,uSunColor,sun*uDaylight); color=mix(color,uMoonColor,moon*uNight);',
+        '    vec3 sunDisplay=uSunMode==1?sunTex.rgb*uSunColor:uSunColor;',
+        '    vec3 moonDisplay=uMoonMode==1?moonTex.rgb*uMoonColor:uMoonColor;',
+        '    color=mix(color,sunDisplay,sun*uDaylight); color=mix(color,moonDisplay,moon*uNight);',
         '    if(uStars>0.0&&up>.02){',
         '        vec2 sph=vec2(atan(d.z,d.x)/(2.0*PI),asin(d.y)/PI); vec2 cell=floor(sph*vec2(420,220));',
-        '        float star=step(.9915,hash21(cell))*(.45+.55*hash21(cell+9.7));',
+        '        float star=step(1.0-.0085*clamp(uStarDensity,.1,4.0),hash21(cell))*(.45+.55*hash21(cell+9.7));',
         '        color+=vec3(star*smoothstep(.02,.24,up)*uNight*uStars);',
         '    }',
         '    if(uCloudOpacity>0.0&&up>.025){',
-        '        vec2 uv=d.xz/max(up,.035)*7.5+vec2(uCloudTime,uCloudTime*.37);',
-        '        float cloud=smoothstep(uCloudCoverage-.08,uCloudCoverage+.08,blockClouds(uv));',
+        '        float cs=cos(uCloudDirection), sn=sin(uCloudDirection);',
+        '        vec2 drift=vec2(cs,sn)*uCloudTime;',
+        '        vec2 uv=(d.xz/max(up,.035)*7.5+drift)*max(uCloudScale,.01);',
+        '        float cloudSource=blockClouds(uv);',
+        '        if(uCloudMode>0){vec4 cloudTex=texture2D(uCloudTexture,fract(uv*.035)); cloudSource=cloudTex.a<.999?cloudTex.a:dot(cloudTex.rgb,vec3(.299,.587,.114));}',
+        '        cloudSource=clamp((cloudSource-.5)*uCloudContrast+.5,0.0,1.0);',
+        '        float cloud=smoothstep(uCloudCoverage-.08,uCloudCoverage+.08,cloudSource);',
         '        cloud*=smoothstep(.025,.13,up)*uCloudOpacity;',
-        '        vec3 lit=mix(uCloudColor*.24,uCloudColor,.18+.82*uDaylight);',
+        '        vec3 lit=mix(uCloudColor*.24,uCloudColor,.18+.82*uDaylight)*uCloudBrightness;',
         '        lit=mix(lit,vec3(1.0,.42,.22),uTwilight*.34*(1.0-uVibrant)); color=mix(color,lit,cloud);',
         '    }',
         '    gl_FragColor=vec4(max(color,vec3(0)),1);',
@@ -314,6 +491,7 @@
 
     function createSky() {
         if (!window.THREE || !window.Canvas?.scene || skyMesh) return false;
+        ensureSkyTextures();
         skyMaterial = new THREE.ShaderMaterial({
             name: 'Lightflow_Minecraft_Sky',
             uniforms: {
@@ -330,7 +508,17 @@
                 uStars: { value: settings.star_brightness },
                 uCloudCoverage: { value: settings.cloud_coverage },
                 uCloudOpacity: { value: settings.cloud_opacity },
-                uCloudTime: { value: 0 }, uVibrant: { value: 0 }
+                uCloudTime: { value: 0 }, uVibrant: { value: 0 },
+                uSkyGradientPower: { value: settings.sky_gradient_power },
+                uStarDensity: { value: settings.star_density },
+                uSunMode: { value: 0 }, uMoonMode: { value: 0 }, uCloudMode: { value: 1 },
+                uSunTexture: { value: fallbackTexture },
+                uMoonTexture: { value: fallbackTexture },
+                uCloudTexture: { value: vanillaCloudTexture || fallbackTexture },
+                uCloudScale: { value: settings.cloud_scale },
+                uCloudDirection: { value: settings.cloud_direction / 180 * Math.PI },
+                uCloudContrast: { value: settings.cloud_contrast },
+                uCloudBrightness: { value: settings.cloud_brightness }
             },
             vertexShader: SKY_VERTEX,
             fragmentShader: SKY_FRAGMENT,
@@ -414,8 +602,9 @@
         createSky();
         createSunLight();
         ensureSunLightParent();
+        ensureSkyTextures();
         const state = getLightingState();
-        const preset = PRESETS[settings.preset] || PRESETS.vanilla;
+        const preset = getPalette();
 
         if (skyMesh) skyMesh.visible = !!settings.enabled;
         if (skyMaterial) {
@@ -437,6 +626,27 @@
             skyMaterial.uniforms.uCloudTime.value = settings.time / 24000 * 180 +
                 performance.now() * 0.001 * settings.cloud_speed;
             skyMaterial.uniforms.uVibrant.value = settings.preset === 'vibrant_visuals' ? 1 : 0;
+            skyMaterial.uniforms.uSkyGradientPower.value = settings.sky_gradient_power;
+            skyMaterial.uniforms.uStarDensity.value = settings.star_density;
+            const sunTexture = getBlockbenchTextureMap(settings.sun_texture_uuid);
+            const moonTexture = getBlockbenchTextureMap(settings.moon_texture_uuid);
+            const customCloudTexture = getBlockbenchTextureMap(settings.cloud_texture_uuid);
+            skyMaterial.uniforms.uSunMode.value = settings.sun_mode === 'hidden'
+                ? 2
+                : (settings.sun_mode === 'texture' && sunTexture ? 1 : 0);
+            skyMaterial.uniforms.uMoonMode.value = settings.moon_mode === 'hidden'
+                ? 2
+                : (settings.moon_mode === 'texture' && moonTexture ? 1 : 0);
+            skyMaterial.uniforms.uCloudMode.value = settings.cloud_mode === 'procedural' ? 0 : 1;
+            skyMaterial.uniforms.uSunTexture.value = sunTexture || fallbackTexture;
+            skyMaterial.uniforms.uMoonTexture.value = moonTexture || fallbackTexture;
+            skyMaterial.uniforms.uCloudTexture.value = settings.cloud_mode === 'texture' && customCloudTexture
+                ? customCloudTexture
+                : (vanillaCloudTexture || fallbackTexture);
+            skyMaterial.uniforms.uCloudScale.value = settings.cloud_scale;
+            skyMaterial.uniforms.uCloudDirection.value = settings.cloud_direction / 180 * Math.PI;
+            skyMaterial.uniforms.uCloudContrast.value = settings.cloud_contrast;
+            skyMaterial.uniforms.uCloudBrightness.value = settings.cloud_brightness;
         }
 
         if (sunLight) {
@@ -491,6 +701,7 @@
         settings = normalizeSettings(Object.assign({}, settings, next || {}));
         saveSettings();
         syncToolbar();
+        if (options.syncPanel !== false) syncEnvironmentPanel();
         updateScene({ forceShadow: options.forceShadow !== false });
         dispatchChanged(options.cause || 'settings');
         if (options.render !== false) requestPreviewRender();
@@ -502,6 +713,7 @@
         const vibrant = preset === 'vibrant_visuals';
         return applySettings({
             preset,
+            palette_mode: 'preset',
             sky_intensity: vibrant ? 1.08 : 1,
             environment_strength: vibrant ? 0.92 : 0.75,
             sun_intensity: vibrant ? 2.8 : 2.2,
@@ -510,7 +722,10 @@
             pixel_shadow_steps: vibrant ? 4 : settings.pixel_shadow_steps,
             pixel_shadow_scale: vibrant ? 2 : settings.pixel_shadow_scale,
             cloud_coverage: vibrant ? 0.5 : 0.54,
-            cloud_opacity: vibrant ? 0.86 : 0.78
+            cloud_opacity: vibrant ? 0.86 : 0.78,
+            cloud_mode: 'vanilla',
+            sun_mode: 'vanilla',
+            moon_mode: 'vanilla'
         }, { cause: options.cause || 'preset', forceShadow: true });
     }
 
@@ -532,6 +747,7 @@
     }
 
     function createDialogForm() {
+        const textureOptions = getTextureOptions();
         return {
             preset: { type: 'select', label: 'lightflow_environment.field.preset', value: settings.preset,
                 options: { vanilla: 'Minecraft Vanilla', vibrant_visuals: 'Minecraft Vibrant Visuals' } },
@@ -541,21 +757,52 @@
             animate_time: { type: 'checkbox', label: 'lightflow_environment.field.animate', value: settings.animate_time },
             day_length_seconds: { type: 'number', label: 'lightflow_environment.field.day_length', value: settings.day_length_seconds, min: 10, max: 3600, step: 10, condition: form => !!form.animate_time },
             sun_azimuth: { type: 'range', label: 'lightflow_environment.field.azimuth', value: settings.sun_azimuth, min: 0, max: 360, step: 1 },
-            _lighting: '_',
+            _sky_colors: '_',
+            palette_mode: { type: 'select', label: 'lightflow_environment.field.palette_mode', value: settings.palette_mode,
+                options: { preset: 'lightflow_environment.option.palette_preset', custom: 'lightflow_environment.option.palette_custom' } },
+            zenith_color: { type: 'color', label: 'lightflow_environment.field.zenith_color', value: settings.zenith_color, condition: form => form.palette_mode === 'custom' },
+            horizon_color: { type: 'color', label: 'lightflow_environment.field.horizon_color', value: settings.horizon_color, condition: form => form.palette_mode === 'custom' },
+            sunrise_zenith_color: { type: 'color', label: 'lightflow_environment.field.sunrise_zenith_color', value: settings.sunrise_zenith_color, condition: form => form.palette_mode === 'custom' },
+            sunrise_horizon_color: { type: 'color', label: 'lightflow_environment.field.sunrise_horizon_color', value: settings.sunrise_horizon_color, condition: form => form.palette_mode === 'custom' },
+            night_zenith_color: { type: 'color', label: 'lightflow_environment.field.night_zenith_color', value: settings.night_zenith_color, condition: form => form.palette_mode === 'custom' },
+            night_horizon_color: { type: 'color', label: 'lightflow_environment.field.night_horizon_color', value: settings.night_horizon_color, condition: form => form.palette_mode === 'custom' },
+            ground_color: { type: 'color', label: 'lightflow_environment.field.ground_color', value: settings.ground_color, condition: form => form.palette_mode === 'custom' },
+            sun_color: { type: 'color', label: 'lightflow_environment.field.sun_color', value: settings.sun_color, condition: form => form.palette_mode === 'custom' },
+            moon_color: { type: 'color', label: 'lightflow_environment.field.moon_color', value: settings.moon_color, condition: form => form.palette_mode === 'custom' },
+            cloud_color: { type: 'color', label: 'lightflow_environment.field.cloud_color', value: settings.cloud_color, condition: form => form.palette_mode === 'custom' },
             sky_intensity: { type: 'range', label: 'lightflow_environment.field.sky_intensity', value: settings.sky_intensity, min: 0, max: 4, step: 0.05 },
+            sky_gradient_power: { type: 'range', label: 'lightflow_environment.field.gradient_power', value: settings.sky_gradient_power, min: 0.5, max: 8, step: 0.05 },
             environment_strength: { type: 'range', label: 'lightflow_environment.field.environment', value: settings.environment_strength, min: 0, max: 4, step: 0.05 },
+            _celestial: '_',
             sun_enabled: { type: 'checkbox', label: 'lightflow_environment.field.sun_enabled', value: settings.sun_enabled },
             sun_intensity: { type: 'range', label: 'lightflow_environment.field.sun_intensity', value: settings.sun_intensity, min: 0, max: 10, step: 0.05, condition: form => !!form.sun_enabled },
             moon_intensity: { type: 'range', label: 'lightflow_environment.field.moon_intensity', value: settings.moon_intensity, min: 0, max: 2, step: 0.02, condition: form => !!form.sun_enabled },
             celestial_size: { type: 'range', label: 'lightflow_environment.field.celestial_size', value: settings.celestial_size, min: 0.012, max: 0.18, step: 0.002 },
             moon_phase: { type: 'range', label: 'lightflow_environment.field.moon_phase', value: settings.moon_phase, min: 0, max: 7, step: 1 },
+            sun_mode: { type: 'select', label: 'lightflow_environment.field.sun_mode', value: settings.sun_mode,
+                options: { vanilla: 'lightflow_environment.option.celestial_vanilla', texture: 'lightflow_environment.option.celestial_texture', hidden: 'lightflow_environment.option.hidden' } },
+            sun_texture_uuid: { type: 'select', label: 'lightflow_environment.field.sun_texture', value: settings.sun_texture_uuid,
+                options: textureOptions, condition: form => form.sun_mode === 'texture' },
+            moon_mode: { type: 'select', label: 'lightflow_environment.field.moon_mode', value: settings.moon_mode,
+                options: { vanilla: 'lightflow_environment.option.celestial_vanilla', texture: 'lightflow_environment.option.celestial_texture', hidden: 'lightflow_environment.option.hidden' } },
+            moon_texture_uuid: { type: 'select', label: 'lightflow_environment.field.moon_texture', value: settings.moon_texture_uuid,
+                options: textureOptions, condition: form => form.moon_mode === 'texture' },
             _sky: '_',
             stars_enabled: { type: 'checkbox', label: 'lightflow_environment.field.stars', value: settings.stars_enabled },
             star_brightness: { type: 'range', label: 'lightflow_environment.field.star_brightness', value: settings.star_brightness, min: 0, max: 3, step: 0.05, condition: form => !!form.stars_enabled },
+            star_density: { type: 'range', label: 'lightflow_environment.field.star_density', value: settings.star_density, min: 0.1, max: 4, step: 0.05, condition: form => !!form.stars_enabled },
             clouds_enabled: { type: 'checkbox', label: 'lightflow_environment.field.clouds', value: settings.clouds_enabled },
+            cloud_mode: { type: 'select', label: 'lightflow_environment.field.cloud_mode', value: settings.cloud_mode,
+                options: { procedural: 'lightflow_environment.option.cloud_procedural', vanilla: 'lightflow_environment.option.cloud_vanilla', texture: 'lightflow_environment.option.cloud_texture' }, condition: form => !!form.clouds_enabled },
+            cloud_texture_uuid: { type: 'select', label: 'lightflow_environment.field.cloud_texture', value: settings.cloud_texture_uuid,
+                options: textureOptions, condition: form => !!form.clouds_enabled && form.cloud_mode === 'texture' },
             cloud_coverage: { type: 'range', label: 'lightflow_environment.field.cloud_coverage', value: settings.cloud_coverage, min: 0, max: 1, step: 0.01, condition: form => !!form.clouds_enabled },
             cloud_opacity: { type: 'range', label: 'lightflow_environment.field.cloud_opacity', value: settings.cloud_opacity, min: 0, max: 1, step: 0.01, condition: form => !!form.clouds_enabled },
             cloud_speed: { type: 'range', label: 'lightflow_environment.field.cloud_speed', value: settings.cloud_speed, min: -0.2, max: 0.2, step: 0.002, condition: form => !!form.clouds_enabled },
+            cloud_scale: { type: 'range', label: 'lightflow_environment.field.cloud_scale', value: settings.cloud_scale, min: 0.05, max: 16, step: 0.05, condition: form => !!form.clouds_enabled },
+            cloud_direction: { type: 'range', label: 'lightflow_environment.field.cloud_direction', value: settings.cloud_direction, min: 0, max: 360, step: 1, condition: form => !!form.clouds_enabled },
+            cloud_contrast: { type: 'range', label: 'lightflow_environment.field.cloud_contrast', value: settings.cloud_contrast, min: 0.1, max: 4, step: 0.05, condition: form => !!form.clouds_enabled },
+            cloud_brightness: { type: 'range', label: 'lightflow_environment.field.cloud_brightness', value: settings.cloud_brightness, min: 0, max: 4, step: 0.05, condition: form => !!form.clouds_enabled },
             _shadows: '_',
             sun_cast_shadows: { type: 'checkbox', label: 'lightflow_environment.field.cast_shadows', value: settings.sun_cast_shadows, condition: form => !!form.sun_enabled },
             shadow_area: { type: 'number', label: 'lightflow_environment.field.shadow_area', value: settings.shadow_area, min: 2, max: 1024, step: 1, condition: form => !!form.sun_cast_shadows },
@@ -571,16 +818,39 @@
         };
     }
 
+    function createPanelForm() {
+        return {
+            enabled: { type: 'checkbox', label: 'lightflow_environment.field.enabled', value: settings.enabled },
+            preset: { type: 'select', label: 'lightflow_environment.field.preset', value: settings.preset,
+                options: { vanilla: 'Minecraft Vanilla', vibrant_visuals: 'Minecraft Vibrant Visuals' } },
+            time: { type: 'range', label: 'lightflow_environment.field.time', value: settings.time, min: 0, max: 23999, step: 100 },
+            animate_time: { type: 'checkbox', label: 'lightflow_environment.field.animate', value: settings.animate_time },
+            sky_intensity: { type: 'range', label: 'lightflow_environment.field.sky_intensity', value: settings.sky_intensity, min: 0, max: 4, step: 0.05 },
+            environment_strength: { type: 'range', label: 'lightflow_environment.field.environment', value: settings.environment_strength, min: 0, max: 4, step: 0.05 },
+            cloud_mode: { type: 'select', label: 'lightflow_environment.field.cloud_mode', value: settings.cloud_mode,
+                options: { procedural: 'lightflow_environment.option.cloud_procedural', vanilla: 'lightflow_environment.option.cloud_vanilla', texture: 'lightflow_environment.option.cloud_texture' } },
+            panel_advanced: { type: 'buttons', buttons: ['lightflow_environment.action.open'], click() { openSettingsDialog(); } }
+        };
+    }
+
+    function syncEnvironmentPanel() {
+        if (!environmentPanel?.form || syncingEnvironmentPanel) return;
+        syncingEnvironmentPanel = true;
+        environmentPanel.form.form_config = createPanelForm();
+        environmentPanel.form.buildForm();
+        syncingEnvironmentPanel = false;
+    }
+
     function openSettingsDialog() {
         new Dialog('lightflow_environment_composer_dialog', {
             title: 'lightflow_environment.dialog.title',
             width: 720,
             form: createDialogForm(),
             onFormChange(form) {
-                applySettings(form, { cause: 'dialog_preview', forceShadow: false });
+                applySettings(form, { cause: 'dialog_preview', forceShadow: false, syncPanel: false });
             },
             onConfirm(form) {
-                applySettings(form, { cause: 'dialog_confirm', forceShadow: true });
+                applySettings(form, { cause: 'dialog_confirm', forceShadow: true, syncPanel: true });
             }
         }).show();
     }
@@ -602,7 +872,7 @@
             value: settings.time,
             min: 0, max: 23999, step: 100,
             onChange() {
-                applySettings({ time: this.value }, { cause: 'time_slider', forceShadow: true });
+                applySettings({ time: this.value }, { cause: 'time_slider', forceShadow: false });
             }
         });
         animateToggle = new Toggle('lightflow_environment_animate', {
@@ -620,15 +890,33 @@
             name: 'lightflow_environment.plugin.title',
             children: ['lightflow_environment_composer', 'lightflow_environment_time', 'lightflow_environment_animate']
         });
-        const panel = new Panel('lightflow_environment_panel', {
+        environmentPanel = new Panel('lightflow_environment_panel', {
             name: 'lightflow_environment.plugin.title',
             icon: 'wb_twilight',
-            condition: () => !!window.Project,
-            default_position: { slot: 'right_bar', height: 58, folded: false },
-            toolbars: [toolbar]
+            growable: true,
+            resizable: true,
+            expand_button: true,
+            condition: { modes: ['render'], project: true },
+            default_position: {
+                slot: 'right_bar', float_position: [0, 0], float_size: [340, 460], height: 390,
+                folded: false, attached_to: 'outliner', attached_index: 1, sidebar_index: 1
+            },
+            mode_positions: {
+                render: {
+                    slot: 'right_bar', height: 390, folded: false,
+                    attached_to: 'outliner', attached_index: 1, sidebar_index: 1
+                }
+            },
+            insert_after: 'outliner',
+            toolbars: [toolbar],
+            form: createPanelForm()
+        });
+        environmentPanel.form.on('change', ({ result }) => {
+            if (syncingEnvironmentPanel) return;
+            applySettings(result, { cause: 'environment_panel', forceShadow: false, syncPanel: false });
         });
         MenuBar.menus.view.addAction(settingsAction, '9');
-        deletables.push(settingsAction, timeSlider, animateToggle, toolbar, panel);
+        deletables.push(settingsAction, timeSlider, animateToggle, toolbar, environmentPanel);
         syncToolbar();
     }
 
@@ -644,19 +932,51 @@
             'lightflow_environment.field.animate': 'Animate Day Cycle',
             'lightflow_environment.field.day_length': 'Full Day Length (seconds)',
             'lightflow_environment.field.azimuth': 'Sun Path Rotation',
+            'lightflow_environment.field.palette_mode': 'Sky Color Source',
+            'lightflow_environment.option.palette_preset': 'Use Preset Palette',
+            'lightflow_environment.option.palette_custom': 'Custom Palette',
+            'lightflow_environment.field.zenith_color': 'Day Zenith',
+            'lightflow_environment.field.horizon_color': 'Day Horizon',
+            'lightflow_environment.field.sunrise_zenith_color': 'Sunrise Zenith',
+            'lightflow_environment.field.sunrise_horizon_color': 'Sunrise Horizon',
+            'lightflow_environment.field.night_zenith_color': 'Night Zenith',
+            'lightflow_environment.field.night_horizon_color': 'Night Horizon',
+            'lightflow_environment.field.ground_color': 'Lower Sky / Ground',
+            'lightflow_environment.field.sun_color': 'Sun Color',
+            'lightflow_environment.field.moon_color': 'Moon Color',
+            'lightflow_environment.field.cloud_color': 'Cloud Color',
             'lightflow_environment.field.sky_intensity': 'Sky Brightness',
+            'lightflow_environment.field.gradient_power': 'Sky Gradient Shape',
             'lightflow_environment.field.environment': 'Environment Influence',
             'lightflow_environment.field.sun_enabled': 'Sun / Moon Light',
             'lightflow_environment.field.sun_intensity': 'Sun Intensity',
             'lightflow_environment.field.moon_intensity': 'Moon Intensity',
             'lightflow_environment.field.celestial_size': 'Sun / Moon Size',
             'lightflow_environment.field.moon_phase': 'Moon Phase',
+            'lightflow_environment.field.sun_mode': 'Sun Appearance',
+            'lightflow_environment.field.moon_mode': 'Moon Appearance',
+            'lightflow_environment.field.sun_texture': 'Sun Project Texture',
+            'lightflow_environment.field.moon_texture': 'Moon Project Texture',
+            'lightflow_environment.option.celestial_vanilla': 'Vanilla-style Square',
+            'lightflow_environment.option.celestial_texture': 'Project Texture',
+            'lightflow_environment.option.hidden': 'Hidden',
+            'lightflow_environment.option.texture_none': 'Select a project texture',
             'lightflow_environment.field.stars': 'Stars',
             'lightflow_environment.field.star_brightness': 'Star Brightness',
+            'lightflow_environment.field.star_density': 'Star Density',
             'lightflow_environment.field.clouds': 'Minecraft Clouds',
+            'lightflow_environment.field.cloud_mode': 'Cloud Source',
+            'lightflow_environment.field.cloud_texture': 'Cloud Project Texture',
+            'lightflow_environment.option.cloud_procedural': 'Procedural Blocks',
+            'lightflow_environment.option.cloud_vanilla': 'Generated Vanilla-style Texture',
+            'lightflow_environment.option.cloud_texture': 'Project Texture',
             'lightflow_environment.field.cloud_coverage': 'Cloud Coverage',
             'lightflow_environment.field.cloud_opacity': 'Cloud Opacity',
             'lightflow_environment.field.cloud_speed': 'Cloud Speed',
+            'lightflow_environment.field.cloud_scale': 'Cloud Scale',
+            'lightflow_environment.field.cloud_direction': 'Cloud Direction',
+            'lightflow_environment.field.cloud_contrast': 'Cloud Contrast',
+            'lightflow_environment.field.cloud_brightness': 'Cloud Brightness',
             'lightflow_environment.field.cast_shadows': 'Sun Cast Shadows',
             'lightflow_environment.field.shadow_area': 'Shadow Capture Area',
             'lightflow_environment.field.shadow_resolution': 'Shadow Resolution',
@@ -677,7 +997,39 @@
             'lightflow_environment.field.enabled': 'Renderizar entorno',
             'lightflow_environment.field.time': 'Hora de Minecraft',
             'lightflow_environment.field.animate': 'Animar ciclo del día',
+            'lightflow_environment.field.palette_mode': 'Origen de colores del cielo',
+            'lightflow_environment.option.palette_preset': 'Usar paleta del preset',
+            'lightflow_environment.option.palette_custom': 'Paleta personalizada',
+            'lightflow_environment.field.zenith_color': 'Cénit diurno',
+            'lightflow_environment.field.horizon_color': 'Horizonte diurno',
+            'lightflow_environment.field.sunrise_zenith_color': 'Cénit del amanecer',
+            'lightflow_environment.field.sunrise_horizon_color': 'Horizonte del amanecer',
+            'lightflow_environment.field.night_zenith_color': 'Cénit nocturno',
+            'lightflow_environment.field.night_horizon_color': 'Horizonte nocturno',
+            'lightflow_environment.field.ground_color': 'Cielo inferior / suelo',
+            'lightflow_environment.field.sun_color': 'Color del sol',
+            'lightflow_environment.field.moon_color': 'Color de la luna',
+            'lightflow_environment.field.cloud_color': 'Color de las nubes',
+            'lightflow_environment.field.gradient_power': 'Forma del gradiente del cielo',
             'lightflow_environment.field.environment': 'Influencia del entorno',
+            'lightflow_environment.field.sun_mode': 'Apariencia del sol',
+            'lightflow_environment.field.moon_mode': 'Apariencia de la luna',
+            'lightflow_environment.field.sun_texture': 'Textura del proyecto para el sol',
+            'lightflow_environment.field.moon_texture': 'Textura del proyecto para la luna',
+            'lightflow_environment.option.celestial_vanilla': 'Cuadrado estilo Vanilla',
+            'lightflow_environment.option.celestial_texture': 'Textura del proyecto',
+            'lightflow_environment.option.hidden': 'Oculto',
+            'lightflow_environment.option.texture_none': 'Selecciona una textura del proyecto',
+            'lightflow_environment.field.star_density': 'Densidad de estrellas',
+            'lightflow_environment.field.cloud_mode': 'Origen de las nubes',
+            'lightflow_environment.field.cloud_texture': 'Textura del proyecto para nubes',
+            'lightflow_environment.option.cloud_procedural': 'Bloques procedurales',
+            'lightflow_environment.option.cloud_vanilla': 'Textura estilo Vanilla generada',
+            'lightflow_environment.option.cloud_texture': 'Textura del proyecto',
+            'lightflow_environment.field.cloud_scale': 'Escala de nubes',
+            'lightflow_environment.field.cloud_direction': 'Dirección de nubes',
+            'lightflow_environment.field.cloud_contrast': 'Contraste de nubes',
+            'lightflow_environment.field.cloud_brightness': 'Brillo de nubes',
             'lightflow_environment.field.cast_shadows': 'El sol proyecta sombras',
             'lightflow_environment.field.shadow_area': 'Área de captura de sombras',
             'lightflow_environment.field.pixelated_shadows': 'Sombras pixeladas Vibrant Visuals'
@@ -709,6 +1061,7 @@
             settings = loadSettings();
         }
         syncToolbar();
+        syncEnvironmentPanel();
         updateScene({ forceShadow: true });
         dispatchChanged('project_load');
         requestPreviewRender();
@@ -726,7 +1079,7 @@
             if (timestamp - lastRenderTime < 33) return;
             lastRenderTime = timestamp;
             syncToolbar();
-            updateScene({ forceShadow: true });
+            updateScene({ forceShadow: false });
             dispatchChanged('animation');
             requestPreviewRender();
         };
@@ -743,10 +1096,20 @@
         skyMesh?.parent?.remove?.(skyMesh);
         skyMesh?.geometry?.dispose?.();
         skyMaterial?.dispose?.();
+        vanillaCloudTexture?.dispose?.();
+        fallbackTexture?.dispose?.();
+        if (typeof Texture !== 'undefined' && Array.isArray(Texture.all)) {
+            Texture.all.forEach(texture => {
+                texture?._lightflowEnvironmentTexture?.dispose?.();
+                if (texture) delete texture._lightflowEnvironmentTexture;
+            });
+        }
         sunLight = null;
         sunTarget = null;
         skyMesh = null;
         skyMaterial = null;
+        vanillaCloudTexture = null;
+        fallbackTexture = null;
         delete window.LightflowEnvironmentSunLight;
     }
 
@@ -786,12 +1149,19 @@
             const selectListener = Blockbench.on('select_project', event => loadProjectSettings(event?.project));
             const loadListener = Blockbench.on('load_project', event => loadProjectSettings(event?.project));
             const parsedListener = window.Codecs?.project?.on?.('parsed', () => loadProjectSettings(window.Project));
+            const textureChanged = () => {
+                syncEnvironmentPanel();
+                updateScene({ forceShadow: false });
+                requestPreviewRender();
+            };
+            const textureListeners = ['add_texture', 'remove_texture', 'update_texture']
+                .map(eventName => Blockbench.on(eventName, textureChanged));
             const lightManagerListener = () => {
                 ensureSunLightParent();
                 updateScene({ forceShadow: true });
             };
             window.addEventListener('light_manager_initialized', lightManagerListener);
-            deletables.push(selectListener, loadListener, parsedListener, {
+            deletables.push(selectListener, loadListener, parsedListener, ...textureListeners, {
                 delete() { window.removeEventListener('light_manager_initialized', lightManagerListener); }
             });
             startAnimation();

--- a/lightflow_environment.js
+++ b/lightflow_environment.js
@@ -1,0 +1,812 @@
+(function () {
+    'use strict';
+
+    const PLUGIN_ID = 'lightflow_environment';
+    const PLUGIN_VERSION = '1.0.0';
+    const STORAGE_KEY = 'lightflow_environment.settings';
+    const PROJECT_PROPERTY = 'lightflow_environment_settings';
+    const TWO_PI = Math.PI * 2;
+
+    const DEFAULT_SETTINGS = {
+        enabled: true,
+        preset: 'vanilla',
+        time: 6000,
+        animate_time: false,
+        day_length_seconds: 120,
+        sun_azimuth: 0,
+        sky_intensity: 1,
+        environment_strength: 0.75,
+        sun_enabled: true,
+        sun_intensity: 2.2,
+        moon_intensity: 0.28,
+        celestial_size: 0.055,
+        moon_phase: 0,
+        stars_enabled: true,
+        star_brightness: 0.72,
+        clouds_enabled: true,
+        cloud_coverage: 0.54,
+        cloud_opacity: 0.78,
+        cloud_speed: 0.016,
+        sun_cast_shadows: true,
+        shadow_area: 48,
+        shadow_near: 0.1,
+        shadow_far: 480,
+        shadow_resolution: 2048,
+        shadow_bias: -0.00035,
+        shadow_normal_bias: 0.025,
+        pixelated_shadows: false,
+        pixel_shadow_steps: 4,
+        pixel_shadow_scale: 2
+    };
+
+    const PRESETS = {
+        vanilla: {
+            name: 'Minecraft Vanilla',
+            zenith: '#78a7ff', horizon: '#b8d2ff',
+            sunrise_zenith: '#647db5', sunrise_horizon: '#f59a62',
+            night_zenith: '#05091d', night_horizon: '#151d3d',
+            ground: '#536b78', sun: '#fff3c4', moon: '#dbe4ff', cloud: '#f3f5f7',
+            ambient_day: 0.78, ambient_night: 0.17
+        },
+        vibrant_visuals: {
+            name: 'Minecraft Vibrant Visuals',
+            zenith: '#3184ff', horizon: '#a6dcff',
+            sunrise_zenith: '#6b69bd', sunrise_horizon: '#ff874d',
+            night_zenith: '#030824', night_horizon: '#1f2b5b',
+            ground: '#416579', sun: '#fff1b0', moon: '#cbdcff', cloud: '#fff7ec',
+            ambient_day: 0.92, ambient_night: 0.21
+        }
+    };
+
+    let settings = loadSettings();
+    let skyMesh = null;
+    let skyMaterial = null;
+    let sunLight = null;
+    let sunTarget = null;
+    let settingsAction = null;
+    let timeSlider = null;
+    let animateToggle = null;
+    let projectProperty = null;
+    let animationFrame = null;
+    let lastFrameTime = 0;
+    let lastRenderTime = 0;
+    const deletables = [];
+
+    function clamp(value, min, max) {
+        return Math.max(min, Math.min(max, Number(value)));
+    }
+
+    function finite(value, fallback) {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : fallback;
+    }
+
+    function mod(value, divisor) {
+        return ((value % divisor) + divisor) % divisor;
+    }
+
+    function tr(key, fallback) {
+        if (typeof tl !== 'function') return fallback || key;
+        const translated = tl(key);
+        return translated === key ? (fallback || key) : translated;
+    }
+
+    function normalizeSettings(source) {
+        const result = Object.assign({}, DEFAULT_SETTINGS, source || {});
+        result.enabled = result.enabled !== false;
+        result.preset = PRESETS[result.preset] ? result.preset : 'vanilla';
+        result.time = mod(finite(result.time, 6000), 24000);
+        result.animate_time = !!result.animate_time;
+        result.day_length_seconds = clamp(finite(result.day_length_seconds, 120), 10, 3600);
+        result.sun_azimuth = mod(finite(result.sun_azimuth, 0), 360);
+        result.sky_intensity = clamp(finite(result.sky_intensity, 1), 0, 4);
+        result.environment_strength = clamp(finite(result.environment_strength, 0.75), 0, 4);
+        result.sun_enabled = result.sun_enabled !== false;
+        result.sun_intensity = clamp(finite(result.sun_intensity, 2.2), 0, 20);
+        result.moon_intensity = clamp(finite(result.moon_intensity, 0.28), 0, 5);
+        result.celestial_size = clamp(finite(result.celestial_size, 0.055), 0.012, 0.18);
+        result.moon_phase = Math.round(clamp(finite(result.moon_phase, 0), 0, 7));
+        result.stars_enabled = result.stars_enabled !== false;
+        result.star_brightness = clamp(finite(result.star_brightness, 0.72), 0, 3);
+        result.clouds_enabled = result.clouds_enabled !== false;
+        result.cloud_coverage = clamp(finite(result.cloud_coverage, 0.54), 0, 1);
+        result.cloud_opacity = clamp(finite(result.cloud_opacity, 0.78), 0, 1);
+        result.cloud_speed = clamp(finite(result.cloud_speed, 0.016), -1, 1);
+        result.sun_cast_shadows = result.sun_cast_shadows !== false;
+        result.shadow_area = clamp(finite(result.shadow_area, 48), 2, 1024);
+        result.shadow_near = clamp(finite(result.shadow_near, 0.1), 0.001, 10000);
+        result.shadow_far = Math.max(result.shadow_near + 1, clamp(finite(result.shadow_far, 480), 2, 10000));
+        result.shadow_resolution = [256, 512, 1024, 2048, 4096, 8192].includes(Number(result.shadow_resolution))
+            ? Number(result.shadow_resolution) : 2048;
+        result.shadow_bias = clamp(finite(result.shadow_bias, -0.00035), -0.1, 0.1);
+        result.shadow_normal_bias = clamp(finite(result.shadow_normal_bias, 0.025), 0, 2);
+        result.pixelated_shadows = !!result.pixelated_shadows;
+        result.pixel_shadow_steps = Math.round(clamp(finite(result.pixel_shadow_steps, 4), 2, 16));
+        result.pixel_shadow_scale = Math.round(clamp(finite(result.pixel_shadow_scale, 2), 1, 16));
+        return result;
+    }
+
+    function loadSettings() {
+        try {
+            return normalizeSettings(Object.assign(
+                {},
+                DEFAULT_SETTINGS,
+                JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+            ));
+        } catch (error) {
+            return Object.assign({}, DEFAULT_SETTINGS);
+        }
+    }
+
+    function saveSettings() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+        } catch (error) {
+            // Local storage is optional.
+        }
+        if (typeof Project !== 'undefined' && Project) {
+            Project[PROJECT_PROPERTY] = JSON.stringify(settings);
+            if (typeof Project.saved === 'boolean') Project.saved = false;
+        }
+    }
+
+    function hexToRgb(hex) {
+        const match = String(hex || '').match(/^#?([0-9a-f]{6})$/i);
+        const value = match ? parseInt(match[1], 16) : 0xffffff;
+        return [((value >> 16) & 255) / 255, ((value >> 8) & 255) / 255, (value & 255) / 255];
+    }
+
+    function mixColor(a, b, amount) {
+        const t = clamp(amount, 0, 1);
+        return [
+            a[0] + (b[0] - a[0]) * t,
+            a[1] + (b[1] - a[1]) * t,
+            a[2] + (b[2] - a[2]) * t
+        ];
+    }
+
+    function multiplyColor(color, scalar) {
+        return color.map(channel => Math.max(0, channel * scalar));
+    }
+
+    function smoothstep(edge0, edge1, value) {
+        const t = clamp((value - edge0) / Math.max(edge1 - edge0, 0.000001), 0, 1);
+        return t * t * (3 - 2 * t);
+    }
+
+    function getSunDirection(timeValue = settings.time) {
+        const angle = mod(timeValue, 24000) / 24000 * TWO_PI;
+        const azimuth = settings.sun_azimuth / 180 * Math.PI;
+        const horizontal = Math.cos(angle);
+        return [
+            horizontal * Math.cos(azimuth),
+            Math.sin(angle),
+            horizontal * Math.sin(azimuth)
+        ];
+    }
+
+    function getLightingState() {
+        const preset = PRESETS[settings.preset] || PRESETS.vanilla;
+        const sunDirection = getSunDirection();
+        const sunHeight = sunDirection[1];
+        const daylight = smoothstep(-0.12, 0.16, sunHeight);
+        const night = 1 - smoothstep(-0.28, 0.04, sunHeight);
+        const twilight = clamp(1 - Math.abs(sunHeight) / 0.28, 0, 1) * (1 - night * 0.35);
+
+        let zenith = mixColor(hexToRgb(preset.night_zenith), hexToRgb(preset.zenith), daylight);
+        let horizon = mixColor(hexToRgb(preset.night_horizon), hexToRgb(preset.horizon), daylight);
+        zenith = mixColor(zenith, hexToRgb(preset.sunrise_zenith), twilight * 0.72);
+        horizon = mixColor(horizon, hexToRgb(preset.sunrise_horizon), twilight);
+        const ground = mixColor(hexToRgb('#070910'), hexToRgb(preset.ground), daylight);
+        const ambientColor = mixColor(zenith, horizon, 0.58);
+        const ambientIntensity = (preset.ambient_night +
+            (preset.ambient_day - preset.ambient_night) * daylight) * settings.environment_strength;
+        const celestialDirection = sunHeight >= -0.04 ? sunDirection : sunDirection.map(value => -value);
+        const sunColor = sunHeight >= -0.04 ? hexToRgb(preset.sun) : hexToRgb(preset.moon);
+        const sunIntensity = settings.sun_enabled
+            ? (sunHeight >= -0.04 ? settings.sun_intensity * daylight : settings.moon_intensity * night)
+            : 0;
+
+        return {
+            enabled: !!settings.enabled,
+            preset: settings.preset,
+            time: settings.time,
+            daylight,
+            night,
+            twilight,
+            sunDirection,
+            celestialDirection,
+            sunColor,
+            sunIntensity,
+            celestialSize: settings.celestial_size,
+            zenithColor: multiplyColor(zenith, settings.sky_intensity),
+            horizonColor: multiplyColor(horizon, settings.sky_intensity),
+            groundColor: multiplyColor(ground, settings.sky_intensity),
+            cloudColor: hexToRgb(preset.cloud),
+            cloudCoverage: settings.cloud_coverage,
+            cloudOpacity: settings.clouds_enabled ? settings.cloud_opacity : 0,
+            cloudTime: settings.time / 24000 * 180 +
+                performance.now() * 0.001 * settings.cloud_speed,
+            vibrant: settings.preset === 'vibrant_visuals',
+            ambientColor,
+            ambientIntensity,
+            environmentIntensity: settings.environment_strength,
+            pixelatedShadows: settings.pixelated_shadows,
+            pixelShadowSteps: settings.pixel_shadow_steps,
+            pixelShadowScale: settings.pixel_shadow_scale
+        };
+    }
+
+    const SKY_VERTEX = [
+        'varying vec3 vSkyDirection;',
+        'void main() {',
+        '    vSkyDirection = normalize(position);',
+        '    mat4 rotationOnlyView = mat4(mat3(modelViewMatrix));',
+        '    vec4 clipPosition = projectionMatrix * rotationOnlyView * vec4(position, 1.0);',
+        '    gl_Position = clipPosition.xyww;',
+        '}'
+    ].join('\\n');
+
+    const SKY_FRAGMENT = [
+        'precision highp float;',
+        '#define PI 3.141592653589793',
+        'uniform vec3 uZenith;',
+        'uniform vec3 uHorizon;',
+        'uniform vec3 uGround;',
+        'uniform vec3 uSunDirection;',
+        'uniform vec3 uSunColor;',
+        'uniform vec3 uMoonColor;',
+        'uniform vec3 uCloudColor;',
+        'uniform float uDaylight;',
+        'uniform float uNight;',
+        'uniform float uTwilight;',
+        'uniform float uCelestialSize;',
+        'uniform float uMoonPhase;',
+        'uniform float uStars;',
+        'uniform float uCloudCoverage;',
+        'uniform float uCloudOpacity;',
+        'uniform float uCloudTime;',
+        'uniform float uVibrant;',
+        'varying vec3 vSkyDirection;',
+        'float hash21(vec2 p) { p = fract(p * vec2(123.34, 456.21)); p += dot(p, p + 45.32); return fract(p.x * p.y); }',
+        'float valueNoise(vec2 p) {',
+        '    vec2 i = floor(p); vec2 f = fract(p); f = f*f*(3.0-2.0*f);',
+        '    return mix(mix(hash21(i), hash21(i+vec2(1,0)), f.x), mix(hash21(i+vec2(0,1)), hash21(i+vec2(1,1)), f.x), f.y);',
+        '}',
+        'float blockClouds(vec2 p) {',
+        '    p = floor(p * 3.0) / 3.0;',
+        '    return valueNoise(p*.18)*.58 + valueNoise(p*.43+17.0)*.28 + valueNoise(p*.91+31.0)*.14;',
+        '}',
+        'vec2 celestialCoordinates(vec3 d, vec3 c) {',
+        '    vec3 ref = abs(c.y) > .96 ? vec3(1,0,0) : vec3(0,1,0);',
+        '    vec3 t = normalize(cross(ref,c)); vec3 b = normalize(cross(c,t));',
+        '    float f = max(dot(d,c), .0001); return vec2(dot(d,t),dot(d,b))/f;',
+        '}',
+        'float squareDisc(vec2 p, float r) {',
+        '    float d=max(abs(p.x),abs(p.y)); float a=max(fwidth(d),.0002);',
+        '    return 1.0-smoothstep(r-a,r+a,d);',
+        '}',
+        'void main() {',
+        '    vec3 d=normalize(vSkyDirection); float up=d.y;',
+        '    float h=pow(1.0-clamp(abs(up),0.0,1.0),mix(2.3,3.4,uVibrant));',
+        '    vec3 color=up>=0.0?mix(uZenith,uHorizon,h):mix(uGround,uHorizon,exp(up*7.0));',
+        '    float sun=squareDisc(celestialCoordinates(d,uSunDirection),uCelestialSize);',
+        '    vec2 moonUv=celestialCoordinates(d,-uSunDirection)/max(uCelestialSize,.001);',
+        '    float moonSquare=squareDisc(moonUv*uCelestialSize,uCelestialSize);',
+        '    float phaseShift=(uMoonPhase-3.5)/4.0;',
+        '    float moon=moonSquare*smoothstep(-.12,.12,.78-abs(moonUv.x+phaseShift));',
+        '    color=mix(color,uSunColor,sun*uDaylight); color=mix(color,uMoonColor,moon*uNight);',
+        '    if(uStars>0.0&&up>.02){',
+        '        vec2 sph=vec2(atan(d.z,d.x)/(2.0*PI),asin(d.y)/PI); vec2 cell=floor(sph*vec2(420,220));',
+        '        float star=step(.9915,hash21(cell))*(.45+.55*hash21(cell+9.7));',
+        '        color+=vec3(star*smoothstep(.02,.24,up)*uNight*uStars);',
+        '    }',
+        '    if(uCloudOpacity>0.0&&up>.025){',
+        '        vec2 uv=d.xz/max(up,.035)*7.5+vec2(uCloudTime,uCloudTime*.37);',
+        '        float cloud=smoothstep(uCloudCoverage-.08,uCloudCoverage+.08,blockClouds(uv));',
+        '        cloud*=smoothstep(.025,.13,up)*uCloudOpacity;',
+        '        vec3 lit=mix(uCloudColor*.24,uCloudColor,.18+.82*uDaylight);',
+        '        lit=mix(lit,vec3(1.0,.42,.22),uTwilight*.34*(1.0-uVibrant)); color=mix(color,lit,cloud);',
+        '    }',
+        '    gl_FragColor=vec4(max(color,vec3(0)),1);',
+        '}'
+    ].join('\\n');
+
+    function createSky() {
+        if (!window.THREE || !window.Canvas?.scene || skyMesh) return false;
+        skyMaterial = new THREE.ShaderMaterial({
+            name: 'Lightflow_Minecraft_Sky',
+            uniforms: {
+                uZenith: { value: new THREE.Color(0x78a7ff) },
+                uHorizon: { value: new THREE.Color(0xb8d2ff) },
+                uGround: { value: new THREE.Color(0x536b78) },
+                uSunDirection: { value: new THREE.Vector3(0, 1, 0) },
+                uSunColor: { value: new THREE.Color(0xfff3c4) },
+                uMoonColor: { value: new THREE.Color(0xdbe4ff) },
+                uCloudColor: { value: new THREE.Color(0xf3f5f7) },
+                uDaylight: { value: 1 }, uNight: { value: 0 }, uTwilight: { value: 0 },
+                uCelestialSize: { value: settings.celestial_size },
+                uMoonPhase: { value: settings.moon_phase },
+                uStars: { value: settings.star_brightness },
+                uCloudCoverage: { value: settings.cloud_coverage },
+                uCloudOpacity: { value: settings.cloud_opacity },
+                uCloudTime: { value: 0 }, uVibrant: { value: 0 }
+            },
+            vertexShader: SKY_VERTEX,
+            fragmentShader: SKY_FRAGMENT,
+            side: THREE.BackSide,
+            depthWrite: false,
+            depthTest: false,
+            fog: false,
+            transparent: false,
+            toneMapped: false
+        });
+        skyMesh = new THREE.Mesh(new THREE.SphereGeometry(1, 48, 24), skyMaterial);
+        skyMesh.name = 'Lightflow Environment Sky';
+        skyMesh.frustumCulled = false;
+        skyMesh.renderOrder = -100000;
+        skyMesh.userData.lightflowEnvironment = true;
+        Canvas.scene.add(skyMesh);
+        return true;
+    }
+
+    function ensureSunLightParent() {
+        if (!sunLight || !sunTarget || !window.Canvas?.scene) return;
+        const preferredParent = window.three_lights_group || Canvas.scene;
+        if (sunLight.parent !== preferredParent) preferredParent.add(sunLight);
+        if (sunTarget.parent !== preferredParent) preferredParent.add(sunTarget);
+        window.three_lights = window.three_lights || {};
+        window.three_lights[sunLight.uuid] = sunLight;
+    }
+
+    function createSunLight() {
+        if (!window.THREE || !window.Canvas?.scene || sunLight) return false;
+        sunLight = new THREE.DirectionalLight(0xfff3c4, 1);
+        sunLight.name = 'Lightflow Environment Sun';
+        sunLight.userData.lightflowEnvironment = true;
+        sunLight.userData.lightflowEnvironmentVirtual = true;
+        sunTarget = new THREE.Object3D();
+        sunTarget.name = 'Lightflow Environment Sun Target';
+        sunLight.target = sunTarget;
+        ensureSunLightParent();
+        configureSunShadow(true);
+        window.LightflowEnvironmentSunLight = sunLight;
+        return true;
+    }
+
+    function configureSunShadow(force) {
+        if (!sunLight?.shadow) return;
+        const renderer = window.Preview?.selected?.renderer || window.main_preview?.renderer;
+        let maxTextureSize = 4096;
+        try {
+            const gl = renderer?.getContext?.();
+            if (gl) maxTextureSize = Number(gl.getParameter(gl.MAX_TEXTURE_SIZE)) || maxTextureSize;
+        } catch (error) {
+            // Use the conservative fallback.
+        }
+        const resolution = Math.min(settings.shadow_resolution, maxTextureSize);
+        const area = settings.shadow_area;
+        const shadow = sunLight.shadow;
+        const recreate = force || shadow.mapSize.width !== resolution || shadow.camera.left !== -area;
+        sunLight.castShadow = !!settings.sun_cast_shadows;
+        shadow.mapSize.set(resolution, resolution);
+        Object.assign(shadow.camera, {
+            left: -area, right: area, top: area, bottom: -area,
+            near: settings.shadow_near, far: settings.shadow_far
+        });
+        shadow.bias = settings.shadow_bias;
+        shadow.normalBias = settings.shadow_normal_bias;
+        shadow.radius = settings.pixelated_shadows ? 0 : 1;
+        shadow.camera.updateProjectionMatrix?.();
+        if (recreate && shadow.map) {
+            shadow.map.dispose?.();
+            shadow.map = null;
+        }
+        shadow.needsUpdate = true;
+    }
+
+    function setColor(target, value) {
+        target?.setRGB?.(value[0], value[1], value[2]);
+    }
+
+    function updateScene(options = {}) {
+        if (!window.THREE || !window.Canvas?.scene) return;
+        createSky();
+        createSunLight();
+        ensureSunLightParent();
+        const state = getLightingState();
+        const preset = PRESETS[settings.preset] || PRESETS.vanilla;
+
+        if (skyMesh) skyMesh.visible = !!settings.enabled;
+        if (skyMaterial) {
+            setColor(skyMaterial.uniforms.uZenith.value, state.zenithColor);
+            setColor(skyMaterial.uniforms.uHorizon.value, state.horizonColor);
+            setColor(skyMaterial.uniforms.uGround.value, state.groundColor);
+            skyMaterial.uniforms.uSunDirection.value.fromArray(state.sunDirection);
+            setColor(skyMaterial.uniforms.uSunColor.value, hexToRgb(preset.sun));
+            setColor(skyMaterial.uniforms.uMoonColor.value, hexToRgb(preset.moon));
+            setColor(skyMaterial.uniforms.uCloudColor.value, hexToRgb(preset.cloud));
+            skyMaterial.uniforms.uDaylight.value = state.daylight;
+            skyMaterial.uniforms.uNight.value = state.night;
+            skyMaterial.uniforms.uTwilight.value = state.twilight;
+            skyMaterial.uniforms.uCelestialSize.value = settings.celestial_size;
+            skyMaterial.uniforms.uMoonPhase.value = settings.moon_phase;
+            skyMaterial.uniforms.uStars.value = settings.stars_enabled ? settings.star_brightness : 0;
+            skyMaterial.uniforms.uCloudCoverage.value = settings.cloud_coverage;
+            skyMaterial.uniforms.uCloudOpacity.value = settings.clouds_enabled ? settings.cloud_opacity : 0;
+            skyMaterial.uniforms.uCloudTime.value = settings.time / 24000 * 180 +
+                performance.now() * 0.001 * settings.cloud_speed;
+            skyMaterial.uniforms.uVibrant.value = settings.preset === 'vibrant_visuals' ? 1 : 0;
+        }
+
+        if (sunLight) {
+            sunLight.visible = !!(settings.enabled && settings.sun_enabled && state.sunIntensity > 0.0001);
+            sunLight.intensity = state.sunIntensity;
+            setColor(sunLight.color, state.sunColor);
+            sunLight.position.fromArray(state.celestialDirection)
+                .multiplyScalar(Math.max(160, settings.shadow_far * 0.38));
+            sunTarget.position.set(0, 0, 0);
+            configureSunShadow(!!options.forceShadow);
+            sunLight.updateMatrixWorld(true);
+            sunTarget.updateMatrixWorld(true);
+        }
+
+        if (window.ShaderEngine) {
+            window.ShaderEngine.environmentState = state;
+            window.ShaderEngine.updateLightUniforms?.();
+        }
+        if (typeof window.LightManagerMarkShadowsDirty === 'function') {
+            window.LightManagerMarkShadowsDirty();
+        }
+    }
+
+    function requestPreviewRender() {
+        if (window.LightManagerStudioRenderSession) return;
+        const previews = new Set();
+        if (window.Preview?.selected) previews.add(Preview.selected);
+        if (Array.isArray(window.Preview?.all)) Preview.all.forEach(preview => previews.add(preview));
+        [window.main_preview, window.MediaPreview].forEach(preview => { if (preview) previews.add(preview); });
+        previews.forEach(preview => preview?.render?.());
+    }
+
+    function dispatchChanged(cause) {
+        const detail = { cause: cause || 'settings', settings: Object.assign({}, settings), state: getLightingState() };
+        try {
+            window.dispatchEvent(new CustomEvent('lightflow_environment_changed', { detail }));
+        } catch (error) {
+            // CustomEvent is unavailable in headless validation.
+        }
+        Blockbench.dispatchEvent?.('lightflow_environment_changed', detail);
+    }
+
+    function syncToolbar() {
+        timeSlider?.set?.(settings.time);
+        if (animateToggle) {
+            animateToggle.value = settings.animate_time;
+            animateToggle.updateEnabledState?.();
+        }
+    }
+
+    function applySettings(next, options = {}) {
+        settings = normalizeSettings(Object.assign({}, settings, next || {}));
+        saveSettings();
+        syncToolbar();
+        updateScene({ forceShadow: options.forceShadow !== false });
+        dispatchChanged(options.cause || 'settings');
+        if (options.render !== false) requestPreviewRender();
+        return Object.assign({}, settings);
+    }
+
+    function applyPreset(presetId, options = {}) {
+        const preset = PRESETS[presetId] ? presetId : 'vanilla';
+        const vibrant = preset === 'vibrant_visuals';
+        return applySettings({
+            preset,
+            sky_intensity: vibrant ? 1.08 : 1,
+            environment_strength: vibrant ? 0.92 : 0.75,
+            sun_intensity: vibrant ? 2.8 : 2.2,
+            shadow_resolution: vibrant ? 2048 : settings.shadow_resolution,
+            pixelated_shadows: vibrant,
+            pixel_shadow_steps: vibrant ? 4 : settings.pixel_shadow_steps,
+            pixel_shadow_scale: vibrant ? 2 : settings.pixel_shadow_scale,
+            cloud_coverage: vibrant ? 0.5 : 0.54,
+            cloud_opacity: vibrant ? 0.86 : 0.78
+        }, { cause: options.cause || 'preset', forceShadow: true });
+    }
+
+    function getVirtualLight() {
+        const state = getLightingState();
+        if (!sunLight || !state.enabled || !settings.sun_enabled || state.sunIntensity <= 0.0001) return null;
+        return {
+            uuid: sunLight.uuid,
+            light_type: 'directional',
+            visibility: true,
+            has_shadow: !!settings.sun_cast_shadows,
+            render_intensity: state.sunIntensity,
+            intensity: state.sunIntensity,
+            render_color: state.sunColor.map(channel => Math.round(clamp(channel, 0, 1) * 255)),
+            color: state.sunColor.map(channel => Math.round(clamp(channel, 0, 1) * 255)),
+            threeLight: sunLight,
+            mesh: sunLight
+        };
+    }
+
+    function createDialogForm() {
+        return {
+            preset: { type: 'select', label: 'lightflow_environment.field.preset', value: settings.preset,
+                options: { vanilla: 'Minecraft Vanilla', vibrant_visuals: 'Minecraft Vibrant Visuals' } },
+            enabled: { type: 'checkbox', label: 'lightflow_environment.field.enabled', value: settings.enabled },
+            _time: '_',
+            time: { type: 'range', label: 'lightflow_environment.field.time', value: settings.time, min: 0, max: 23999, step: 100 },
+            animate_time: { type: 'checkbox', label: 'lightflow_environment.field.animate', value: settings.animate_time },
+            day_length_seconds: { type: 'number', label: 'lightflow_environment.field.day_length', value: settings.day_length_seconds, min: 10, max: 3600, step: 10, condition: form => !!form.animate_time },
+            sun_azimuth: { type: 'range', label: 'lightflow_environment.field.azimuth', value: settings.sun_azimuth, min: 0, max: 360, step: 1 },
+            _lighting: '_',
+            sky_intensity: { type: 'range', label: 'lightflow_environment.field.sky_intensity', value: settings.sky_intensity, min: 0, max: 4, step: 0.05 },
+            environment_strength: { type: 'range', label: 'lightflow_environment.field.environment', value: settings.environment_strength, min: 0, max: 4, step: 0.05 },
+            sun_enabled: { type: 'checkbox', label: 'lightflow_environment.field.sun_enabled', value: settings.sun_enabled },
+            sun_intensity: { type: 'range', label: 'lightflow_environment.field.sun_intensity', value: settings.sun_intensity, min: 0, max: 10, step: 0.05, condition: form => !!form.sun_enabled },
+            moon_intensity: { type: 'range', label: 'lightflow_environment.field.moon_intensity', value: settings.moon_intensity, min: 0, max: 2, step: 0.02, condition: form => !!form.sun_enabled },
+            celestial_size: { type: 'range', label: 'lightflow_environment.field.celestial_size', value: settings.celestial_size, min: 0.012, max: 0.18, step: 0.002 },
+            moon_phase: { type: 'range', label: 'lightflow_environment.field.moon_phase', value: settings.moon_phase, min: 0, max: 7, step: 1 },
+            _sky: '_',
+            stars_enabled: { type: 'checkbox', label: 'lightflow_environment.field.stars', value: settings.stars_enabled },
+            star_brightness: { type: 'range', label: 'lightflow_environment.field.star_brightness', value: settings.star_brightness, min: 0, max: 3, step: 0.05, condition: form => !!form.stars_enabled },
+            clouds_enabled: { type: 'checkbox', label: 'lightflow_environment.field.clouds', value: settings.clouds_enabled },
+            cloud_coverage: { type: 'range', label: 'lightflow_environment.field.cloud_coverage', value: settings.cloud_coverage, min: 0, max: 1, step: 0.01, condition: form => !!form.clouds_enabled },
+            cloud_opacity: { type: 'range', label: 'lightflow_environment.field.cloud_opacity', value: settings.cloud_opacity, min: 0, max: 1, step: 0.01, condition: form => !!form.clouds_enabled },
+            cloud_speed: { type: 'range', label: 'lightflow_environment.field.cloud_speed', value: settings.cloud_speed, min: -0.2, max: 0.2, step: 0.002, condition: form => !!form.clouds_enabled },
+            _shadows: '_',
+            sun_cast_shadows: { type: 'checkbox', label: 'lightflow_environment.field.cast_shadows', value: settings.sun_cast_shadows, condition: form => !!form.sun_enabled },
+            shadow_area: { type: 'number', label: 'lightflow_environment.field.shadow_area', value: settings.shadow_area, min: 2, max: 1024, step: 1, condition: form => !!form.sun_cast_shadows },
+            shadow_resolution: { type: 'select', label: 'lightflow_environment.field.shadow_resolution', value: String(settings.shadow_resolution),
+                options: { '256': '256', '512': '512', '1024': '1024', '2048': '2048', '4096': '4096', '8192': '8192' }, condition: form => !!form.sun_cast_shadows },
+            shadow_near: { type: 'number', label: 'lightflow_environment.field.shadow_near', value: settings.shadow_near, min: 0.001, step: 0.1, condition: form => !!form.sun_cast_shadows },
+            shadow_far: { type: 'number', label: 'lightflow_environment.field.shadow_far', value: settings.shadow_far, min: 2, step: 1, condition: form => !!form.sun_cast_shadows },
+            shadow_bias: { type: 'number', label: 'lightflow_environment.field.shadow_bias', value: settings.shadow_bias, min: -0.1, max: 0.1, step: 0.00005, condition: form => !!form.sun_cast_shadows },
+            shadow_normal_bias: { type: 'number', label: 'lightflow_environment.field.normal_bias', value: settings.shadow_normal_bias, min: 0, max: 2, step: 0.005, condition: form => !!form.sun_cast_shadows },
+            pixelated_shadows: { type: 'checkbox', label: 'lightflow_environment.field.pixelated_shadows', value: settings.pixelated_shadows, condition: form => !!form.sun_cast_shadows },
+            pixel_shadow_steps: { type: 'range', label: 'lightflow_environment.field.pixel_shadow_steps', value: settings.pixel_shadow_steps, min: 2, max: 16, step: 1, condition: form => !!form.pixelated_shadows },
+            pixel_shadow_scale: { type: 'range', label: 'lightflow_environment.field.pixel_shadow_scale', value: settings.pixel_shadow_scale, min: 1, max: 16, step: 1, condition: form => !!form.pixelated_shadows }
+        };
+    }
+
+    function openSettingsDialog() {
+        new Dialog('lightflow_environment_composer_dialog', {
+            title: 'lightflow_environment.dialog.title',
+            width: 720,
+            form: createDialogForm(),
+            onFormChange(form) {
+                applySettings(form, { cause: 'dialog_preview', forceShadow: false });
+            },
+            onConfirm(form) {
+                applySettings(form, { cause: 'dialog_confirm', forceShadow: true });
+            }
+        }).show();
+    }
+
+    function installUI() {
+        settingsAction = new Action('lightflow_environment_composer', {
+            name: 'lightflow_environment.action.open',
+            description: 'lightflow_environment.action.open.desc',
+            icon: 'wb_twilight',
+            category: 'view',
+            condition: () => !!window.Project,
+            click: openSettingsDialog
+        });
+        timeSlider = new NumSlider('lightflow_environment_time', {
+            name: 'lightflow_environment.field.time',
+            icon: 'schedule',
+            category: 'view',
+            condition: () => !!window.Project,
+            value: settings.time,
+            min: 0, max: 23999, step: 100,
+            onChange() {
+                applySettings({ time: this.value }, { cause: 'time_slider', forceShadow: true });
+            }
+        });
+        animateToggle = new Toggle('lightflow_environment_animate', {
+            name: 'lightflow_environment.field.animate',
+            icon: 'play_circle',
+            category: 'view',
+            condition: () => !!window.Project,
+            value: settings.animate_time,
+            onChange(value) {
+                applySettings({ animate_time: !!value }, { cause: 'animate_toggle', forceShadow: false });
+            }
+        });
+        const toolbar = new Toolbar({
+            id: 'lightflow_environment_toolbar',
+            name: 'lightflow_environment.plugin.title',
+            children: ['lightflow_environment_composer', 'lightflow_environment_time', 'lightflow_environment_animate']
+        });
+        const panel = new Panel('lightflow_environment_panel', {
+            name: 'lightflow_environment.plugin.title',
+            icon: 'wb_twilight',
+            condition: () => !!window.Project,
+            default_position: { slot: 'right_bar', height: 58, folded: false },
+            toolbars: [toolbar]
+        });
+        MenuBar.menus.view.addAction(settingsAction, '9');
+        deletables.push(settingsAction, timeSlider, animateToggle, toolbar, panel);
+        syncToolbar();
+    }
+
+    function installTranslations() {
+        const translations = {
+            'lightflow_environment.plugin.title': 'Lightflow Environment',
+            'lightflow_environment.action.open': 'Environment Composer...',
+            'lightflow_environment.action.open.desc': 'Compose a Minecraft sky, time, sun, moon, clouds, ambient response, and directional shadows',
+            'lightflow_environment.dialog.title': 'Minecraft Environment Composer',
+            'lightflow_environment.field.preset': 'Sky Model',
+            'lightflow_environment.field.enabled': 'Render Environment',
+            'lightflow_environment.field.time': 'Minecraft Time',
+            'lightflow_environment.field.animate': 'Animate Day Cycle',
+            'lightflow_environment.field.day_length': 'Full Day Length (seconds)',
+            'lightflow_environment.field.azimuth': 'Sun Path Rotation',
+            'lightflow_environment.field.sky_intensity': 'Sky Brightness',
+            'lightflow_environment.field.environment': 'Environment Influence',
+            'lightflow_environment.field.sun_enabled': 'Sun / Moon Light',
+            'lightflow_environment.field.sun_intensity': 'Sun Intensity',
+            'lightflow_environment.field.moon_intensity': 'Moon Intensity',
+            'lightflow_environment.field.celestial_size': 'Sun / Moon Size',
+            'lightflow_environment.field.moon_phase': 'Moon Phase',
+            'lightflow_environment.field.stars': 'Stars',
+            'lightflow_environment.field.star_brightness': 'Star Brightness',
+            'lightflow_environment.field.clouds': 'Minecraft Clouds',
+            'lightflow_environment.field.cloud_coverage': 'Cloud Coverage',
+            'lightflow_environment.field.cloud_opacity': 'Cloud Opacity',
+            'lightflow_environment.field.cloud_speed': 'Cloud Speed',
+            'lightflow_environment.field.cast_shadows': 'Sun Cast Shadows',
+            'lightflow_environment.field.shadow_area': 'Shadow Capture Area',
+            'lightflow_environment.field.shadow_resolution': 'Shadow Resolution',
+            'lightflow_environment.field.shadow_near': 'Shadow Near Plane',
+            'lightflow_environment.field.shadow_far': 'Shadow Far Plane',
+            'lightflow_environment.field.shadow_bias': 'Shadow Bias',
+            'lightflow_environment.field.normal_bias': 'Shadow Normal Bias',
+            'lightflow_environment.field.pixelated_shadows': 'Vibrant Visuals Pixel Shadows',
+            'lightflow_environment.field.pixel_shadow_steps': 'Shadow Tone Steps',
+            'lightflow_environment.field.pixel_shadow_scale': 'Shadow Pixel Size'
+        };
+        Language.addTranslations('en', translations);
+        Language.addTranslations('es', Object.assign({}, translations, {
+            'lightflow_environment.plugin.title': 'Entorno Lightflow',
+            'lightflow_environment.action.open': 'Compositor de entorno...',
+            'lightflow_environment.dialog.title': 'Compositor de entorno Minecraft',
+            'lightflow_environment.field.preset': 'Modelo de cielo',
+            'lightflow_environment.field.enabled': 'Renderizar entorno',
+            'lightflow_environment.field.time': 'Hora de Minecraft',
+            'lightflow_environment.field.animate': 'Animar ciclo del día',
+            'lightflow_environment.field.environment': 'Influencia del entorno',
+            'lightflow_environment.field.cast_shadows': 'El sol proyecta sombras',
+            'lightflow_environment.field.shadow_area': 'Área de captura de sombras',
+            'lightflow_environment.field.pixelated_shadows': 'Sombras pixeladas Vibrant Visuals'
+        }));
+    }
+
+    function registerProjectProperty() {
+        if (projectProperty || typeof Property === 'undefined') return projectProperty;
+        const projectClass = typeof ModelProject !== 'undefined'
+            ? ModelProject
+            : (window.Project?.constructor && Project.constructor !== Object ? Project.constructor : null);
+        if (!projectClass) return null;
+        projectProperty = new Property(projectClass, 'string', PROJECT_PROPERTY, { default: '', exposed: true });
+        deletables.push(projectProperty);
+        return projectProperty;
+    }
+
+    function loadProjectSettings(project) {
+        const activeProject = project || window.Project;
+        if (!activeProject) return;
+        const raw = activeProject[PROJECT_PROPERTY];
+        if (typeof raw === 'string' && raw.trim()) {
+            try {
+                settings = normalizeSettings(Object.assign({}, DEFAULT_SETTINGS, JSON.parse(raw)));
+            } catch (error) {
+                settings = loadSettings();
+            }
+        } else {
+            settings = loadSettings();
+        }
+        syncToolbar();
+        updateScene({ forceShadow: true });
+        dispatchChanged('project_load');
+        requestPreviewRender();
+    }
+
+    function startAnimation() {
+        const tick = timestamp => {
+            animationFrame = requestAnimationFrame(tick);
+            if (!lastFrameTime) lastFrameTime = timestamp;
+            const deltaSeconds = Math.min(0.1, Math.max(0, (timestamp - lastFrameTime) / 1000));
+            lastFrameTime = timestamp;
+            ensureSunLightParent();
+            if (!settings.animate_time || !settings.enabled || window.LightManagerStudioRenderSession) return;
+            settings.time = mod(settings.time + deltaSeconds * 24000 / Math.max(settings.day_length_seconds, 1), 24000);
+            if (timestamp - lastRenderTime < 33) return;
+            lastRenderTime = timestamp;
+            syncToolbar();
+            updateScene({ forceShadow: true });
+            dispatchChanged('animation');
+            requestPreviewRender();
+        };
+        animationFrame = requestAnimationFrame(tick);
+    }
+
+    function disposeScene() {
+        if (sunLight) {
+            if (window.three_lights?.[sunLight.uuid] === sunLight) delete window.three_lights[sunLight.uuid];
+            sunLight.parent?.remove?.(sunLight);
+            sunLight.shadow?.map?.dispose?.();
+        }
+        sunTarget?.parent?.remove?.(sunTarget);
+        skyMesh?.parent?.remove?.(skyMesh);
+        skyMesh?.geometry?.dispose?.();
+        skyMaterial?.dispose?.();
+        sunLight = null;
+        sunTarget = null;
+        skyMesh = null;
+        skyMaterial = null;
+        delete window.LightflowEnvironmentSunLight;
+    }
+
+    installTranslations();
+
+    Plugin.register(PLUGIN_ID, {
+        title: 'Lightflow Environment',
+        icon: 'wb_twilight',
+        author: 'MidFord327',
+        description: 'Procedural Minecraft Vanilla and Vibrant Visuals skies with time, sun/moon lighting, ambient material response, reflections, clouds, and directional shadows.',
+        tags: ['Lightflow', 'Environment', 'Minecraft', 'Sky', 'Lighting', 'Vibrant Visuals'],
+        version: PLUGIN_VERSION,
+        min_version: '4.9.0',
+        variant: 'both',
+
+        onload() {
+            registerProjectProperty();
+            installUI();
+            createSky();
+            createSunLight();
+            updateScene({ forceShadow: true });
+
+            window.LightflowEnvironment = {
+                get settings() { return Object.assign({}, settings); },
+                setSettings: applySettings,
+                applyPreset,
+                open: openSettingsDialog,
+                getLightingState,
+                getVirtualLight,
+                getDirectionalLight: () => sunLight,
+                refresh() {
+                    updateScene({ forceShadow: true });
+                    requestPreviewRender();
+                }
+            };
+
+            const selectListener = Blockbench.on('select_project', event => loadProjectSettings(event?.project));
+            const loadListener = Blockbench.on('load_project', event => loadProjectSettings(event?.project));
+            const parsedListener = window.Codecs?.project?.on?.('parsed', () => loadProjectSettings(window.Project));
+            const lightManagerListener = () => {
+                ensureSunLightParent();
+                updateScene({ forceShadow: true });
+            };
+            window.addEventListener('light_manager_initialized', lightManagerListener);
+            deletables.push(selectListener, loadListener, parsedListener, {
+                delete() { window.removeEventListener('light_manager_initialized', lightManagerListener); }
+            });
+            startAnimation();
+            dispatchChanged('load');
+            requestPreviewRender();
+        },
+
+        onunload() {
+            if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+            animationFrame = null;
+            disposeScene();
+            deletables.splice(0).reverse().forEach(item => item?.delete?.());
+            delete window.LightflowEnvironment;
+            window.ShaderEngine?.updateLightUniforms?.();
+            requestPreviewRender();
+        }
+    });
+})();

--- a/lightflow_environment.js
+++ b/lightflow_environment.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_environment';
-    const PLUGIN_VERSION = '1.1.0';
+    const PLUGIN_VERSION = '1.2.0';
     const STORAGE_KEY = 'lightflow_environment.settings';
     const PROJECT_PROPERTY = 'lightflow_environment_settings';
     const TWO_PI = Math.PI * 2;
@@ -95,6 +95,7 @@
     let fallbackTexture = null;
     let projectProperty = null;
     let animationFrame = null;
+    let previewRenderFrame = null;
     let lastFrameTime = 0;
     let lastRenderTime = 0;
     const deletables = [];
@@ -663,7 +664,11 @@
 
         if (window.ShaderEngine) {
             window.ShaderEngine.environmentState = state;
-            window.ShaderEngine.updateLightUniforms?.();
+            if (typeof window.ShaderEngine.requestLightUniformUpdate === 'function') {
+                window.ShaderEngine.requestLightUniformUpdate('environment_update', { render: false });
+            } else {
+                window.ShaderEngine.updateLightUniforms?.('environment_update', { render: false });
+            }
         }
         if (typeof window.LightManagerMarkShadowsDirty === 'function') {
             window.LightManagerMarkShadowsDirty();
@@ -672,11 +677,18 @@
 
     function requestPreviewRender() {
         if (window.LightManagerStudioRenderSession) return;
-        const previews = new Set();
-        if (window.Preview?.selected) previews.add(Preview.selected);
-        if (Array.isArray(window.Preview?.all)) Preview.all.forEach(preview => previews.add(preview));
-        [window.main_preview, window.MediaPreview].forEach(preview => { if (preview) previews.add(preview); });
-        previews.forEach(preview => preview?.render?.());
+        if (previewRenderFrame !== null) return;
+        const render = () => {
+            previewRenderFrame = null;
+            if (window.LightManagerStudioRenderSession) return;
+            const preview = window.Preview?.selected || window.main_preview || window.MediaPreview;
+            preview?.render?.();
+        };
+        if (typeof requestAnimationFrame === 'function') previewRenderFrame = requestAnimationFrame(render);
+        else {
+            previewRenderFrame = 'microtask';
+            queueMicrotask(render);
+        }
     }
 
     function dispatchChanged(cause) {
@@ -1172,6 +1184,8 @@
         onunload() {
             if (animationFrame !== null) cancelAnimationFrame(animationFrame);
             animationFrame = null;
+            if (typeof previewRenderFrame === 'number') cancelAnimationFrame(previewRenderFrame);
+            previewRenderFrame = null;
             disposeScene();
             deletables.splice(0).reverse().forEach(item => item?.delete?.());
             delete window.LightflowEnvironment;

--- a/lightflow_environment.js
+++ b/lightflow_environment.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const PLUGIN_ID = 'lightflow_environment';
-    const PLUGIN_VERSION = '1.2.0';
+    const PLUGIN_VERSION = '1.3.0';
     const STORAGE_KEY = 'lightflow_environment.settings';
     const PROJECT_PROPERTY = 'lightflow_environment_settings';
     const TWO_PI = Math.PI * 2;
@@ -105,6 +105,12 @@
     let previewRenderFrame = null;
     let lastFrameTime = 0;
     let lastRenderTime = 0;
+    let environmentRevision = 0;
+    let environmentProject = null;
+    let lastSunShadowConfig = '';
+    let lastSunShadowDirection = null;
+    let lastSunShadowRefresh = 0;
+    let lastSunShadowGizmoSignature = '';
     const deletables = [];
 
     function clamp(value, min, max) {
@@ -128,30 +134,6 @@
 
     function markerColor(index, tone = 'pastel', fallback = 'var(--color-accent)') {
         return window.LightManagerUI?.markerColor?.(index, tone, fallback) || fallback;
-    }
-
-    function waitForLightManager(timeout = 5000) {
-        return new Promise((resolve, reject) => {
-            if (window.LIGHT_MANAGER_LOADED && window.LightManagerUI && typeof window.applyIndestructibleFormGroups === 'function') {
-                resolve(window.LightManagerUI);
-                return;
-            }
-            let finished = false;
-            const timer = setTimeout(() => {
-                if (finished) return;
-                finished = true;
-                window.removeEventListener('light_manager_initialized', onReady);
-                reject(new Error('Lightflow Environment requires Light Manager.'));
-            }, timeout);
-            function onReady() {
-                if (finished || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') return;
-                finished = true;
-                clearTimeout(timer);
-                window.removeEventListener('light_manager_initialized', onReady);
-                resolve(window.LightManagerUI);
-            }
-            window.addEventListener('light_manager_initialized', onReady);
-        });
     }
 
     function normalizeHex(value, fallback) {
@@ -757,8 +739,8 @@
         settings.shadow_fit_corners = corners.flatMap(corner => corner.toArray());
     }
 
-    function configureSunShadow(force) {
-        if (!sunLight?.shadow) return;
+    function configureSunShadow(force, options = {}) {
+        if (!sunLight?.shadow) return false;
         const renderer = window.Preview?.selected?.renderer || window.main_preview?.renderer;
         let maxTextureSize = 4096;
         try {
@@ -771,22 +753,67 @@
         const frustum = getActiveShadowFrustum();
         const area = frustum.area;
         const shadow = sunLight.shadow;
-        const recreate = force || shadow.mapSize.width !== resolution || shadow.mapSize.height !== resolution;
-        sunLight.castShadow = !!settings.sun_cast_shadows;
-        shadow.mapSize.set(resolution, resolution);
-        Object.assign(shadow.camera, {
+        const state = options.state || getLightingState();
+        // Keep shadow-light topology stable while Environment/Sun is toggled.
+        // Manual shadow invalidation means an intensity-zero light does not
+        // keep paying for shadow passes, while Three can reuse its programs.
+        const castsShadow = !!settings.sun_cast_shadows;
+        const radius = settings.pixelated_shadows ? 0 : 1;
+        const configSignature = [
+            castsShadow ? 1 : 0,
+            resolution,
+            area,
+            frustum.near,
+            frustum.far,
+            settings.shadow_bias,
+            settings.shadow_normal_bias,
+            radius
+        ].map(value => Number(value).toFixed(5)).join('|');
+        const configChanged = configSignature !== lastSunShadowConfig;
+        const resolutionChanged = shadow.mapSize.width !== resolution || shadow.mapSize.height !== resolution;
+        let cameraChanged = false;
+
+        if (sunLight.castShadow !== castsShadow) sunLight.castShadow = castsShadow;
+        if (resolutionChanged) {
+            shadow.mapSize.set(resolution, resolution);
+            if (shadow.map?.setSize) {
+                shadow.map.setSize(resolution, resolution);
+            } else if (shadow.map) {
+                shadow.map.dispose?.();
+                shadow.map = null;
+            }
+        }
+        const cameraValues = {
             left: -area, right: area, top: area, bottom: -area,
             near: frustum.near, far: frustum.far
+        };
+        Object.entries(cameraValues).forEach(([key, value]) => {
+            if (shadow.camera[key] === value) return;
+            shadow.camera[key] = value;
+            cameraChanged = true;
         });
-        shadow.bias = settings.shadow_bias;
-        shadow.normalBias = settings.shadow_normal_bias;
-        shadow.radius = settings.pixelated_shadows ? 0 : 1;
-        shadow.camera.updateProjectionMatrix?.();
-        if (recreate && shadow.map) {
-            shadow.map.dispose?.();
-            shadow.map = null;
+        if (shadow.bias !== settings.shadow_bias) shadow.bias = settings.shadow_bias;
+        if (shadow.normalBias !== settings.shadow_normal_bias) shadow.normalBias = settings.shadow_normal_bias;
+        if (shadow.radius !== radius) shadow.radius = radius;
+        if (cameraChanged) shadow.camera.updateProjectionMatrix?.();
+
+        const direction = sunLight.position.clone().sub(sunTarget?.position || new THREE.Vector3()).normalize();
+        const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+        const directionAngle = lastSunShadowDirection
+            ? Math.acos(clamp(lastSunShadowDirection.dot(direction), -1, 1))
+            : Infinity;
+        const animatedDirectionDue = options.animation === true
+            ? (directionAngle >= THREE.MathUtils.degToRad(0.35) || now - lastSunShadowRefresh >= 100)
+            : directionAngle > 0.000001;
+        const changed = !!(force || configChanged || resolutionChanged || cameraChanged || animatedDirectionDue);
+        lastSunShadowConfig = configSignature;
+        if (changed) {
+            if (!lastSunShadowDirection) lastSunShadowDirection = new THREE.Vector3();
+            lastSunShadowDirection.copy(direction);
+            lastSunShadowRefresh = now;
+            shadow.needsUpdate = true;
         }
-        shadow.needsUpdate = true;
+        return changed;
     }
 
     function registerSunShadowCanvasGizmo(object) {
@@ -1133,15 +1160,39 @@
             skyMaterial.uniforms.uCloudBrightness.value = settings.cloud_brightness;
         }
 
+        let shadowChanged = false;
         if (sunLight) {
-            sunLight.visible = !!(settings.enabled && settings.sun_enabled && state.sunIntensity > 0.0001);
-            sunLight.intensity = state.sunIntensity;
+            const activeSun = !!(settings.enabled && settings.sun_enabled && state.sunIntensity > 0.0001);
+            // Keep the directional light in Three's light list. Toggling
+            // Object3D.visible changes NUM_DIR_LIGHTS and recompiles every
+            // material; intensity zero is visually identical without the
+            // shader-program hitch.
+            sunLight.visible = true;
+            sunLight.intensity = activeSun ? state.sunIntensity : 0;
             setColor(sunLight.color, state.sunColor);
             updateSunShadowPlacement(state.celestialDirection);
-            configureSunShadow(!!options.forceShadow);
+            shadowChanged = configureSunShadow(!!options.forceShadow, {
+                animation: !!options.animation,
+                state
+            });
             sunLight.updateMatrixWorld(true);
             sunTarget.updateMatrixWorld(true);
-            updateSunShadowGizmo();
+            const frustum = getActiveShadowFrustum();
+            const gizmoSignature = [
+                settings.show_shadow_gizmo ? 1 : 0,
+                settings.enabled ? 1 : 0,
+                settings.sun_enabled ? 1 : 0,
+                settings.sun_cast_shadows ? 1 : 0,
+                settings.shadow_auto_fit ? 1 : 0,
+                frustum.area,
+                frustum.near,
+                frustum.far,
+                Array.isArray(settings.shadow_fit_corners) ? settings.shadow_fit_corners.join(',') : ''
+            ].join('|');
+            if (gizmoSignature !== lastSunShadowGizmoSignature) {
+                lastSunShadowGizmoSignature = gizmoSignature;
+                updateSunShadowGizmo();
+            }
         }
 
         if (window.ShaderEngine) {
@@ -1152,10 +1203,10 @@
                 window.ShaderEngine.updateLightUniforms?.('environment_update', { render: false });
             }
         }
-        if (typeof window.LightManagerMarkShadowsDirty === 'function') {
+        if (shadowChanged && typeof window.LightManagerMarkShadowsDirty === 'function') {
             window.LightManagerMarkShadowsDirty({ scene: !!options.forceShadow });
         }
-        if (typeof window.LightManagerPrepareRender === 'function') {
+        if (shadowChanged && typeof window.LightManagerPrepareRender === 'function') {
             const preview = window.Preview?.selected || window.main_preview || window.MediaPreview || null;
             window.LightManagerPrepareRender(preview, { force: !!options.forceShadow });
         }
@@ -1164,9 +1215,16 @@
     function requestPreviewRender() {
         if (window.LightManagerStudioRenderSession) return;
         if (previewRenderFrame !== null) return;
+        const revision = environmentRevision;
+        const project = window.Project || null;
         const render = () => {
             previewRenderFrame = null;
             if (window.LightManagerStudioRenderSession) return;
+            if (
+                revision !== environmentRevision ||
+                project !== environmentProject ||
+                project !== (window.Project || null)
+            ) return;
             const preview = window.Preview?.selected || window.main_preview || window.MediaPreview;
             preview?.render?.();
         };
@@ -1235,7 +1293,10 @@
         if (shouldCaptureFitRegion) captureShadowFitRegion(manualFrustum);
         saveSettings();
         if (options.syncPanel !== false) syncEnvironmentPanel();
-        updateScene({ forceShadow: options.forceShadow !== false });
+        updateScene({
+            forceShadow: options.forceShadow === true,
+            animation: !!options.animation
+        });
         dispatchChanged(options.cause || 'settings');
         if (options.render !== false) requestPreviewRender();
         return Object.assign({}, settings);
@@ -1723,10 +1784,36 @@
         return projectProperty;
     }
 
-    function loadProjectSettings(project) {
-        const activeProject = project || window.Project;
-        if (!activeProject) return;
+    function beginEnvironmentProject(project) {
+        environmentRevision += 1;
+        environmentProject = project || null;
+        if (typeof previewRenderFrame === 'number' && typeof cancelAnimationFrame === 'function') {
+            cancelAnimationFrame(previewRenderFrame);
+        }
+        previewRenderFrame = null;
+        lastSunShadowConfig = '';
+        lastSunShadowDirection = null;
+        lastSunShadowRefresh = 0;
+        lastSunShadowGizmoSignature = '';
+    }
+
+    function loadProjectSettings(project, model) {
+        const activeProject = project || null;
+        beginEnvironmentProject(activeProject);
+        if (!activeProject) {
+            if (skyMesh) skyMesh.visible = false;
+            if (sunLight) {
+                sunLight.intensity = 0;
+            }
+            return;
+        }
         effectiveShadowFrustum = null;
+        if (
+            (!activeProject[PROJECT_PROPERTY] || !String(activeProject[PROJECT_PROPERTY]).trim()) &&
+            typeof model?.[PROJECT_PROPERTY] === 'string'
+        ) {
+            activeProject[PROJECT_PROPERTY] = model[PROJECT_PROPERTY];
+        }
         const raw = activeProject[PROJECT_PROPERTY];
         if (typeof raw === 'string' && raw.trim()) {
             try {
@@ -1738,7 +1825,7 @@
             settings = loadSettings();
         }
         syncEnvironmentPanel();
-        updateScene({ forceShadow: true });
+        updateScene({ forceShadow: true, animation: false });
         dispatchChanged('project_load');
         requestPreviewRender();
     }
@@ -1755,7 +1842,7 @@
             if (timestamp - lastRenderTime < 33) return;
             lastRenderTime = timestamp;
             syncEnvironmentPanel({ timeOnly: true });
-            updateScene({ forceShadow: false });
+            updateScene({ forceShadow: false, animation: true });
             dispatchChanged('animation');
             requestPreviewRender();
         };
@@ -1803,10 +1890,8 @@
         variant: 'both',
         dependencies: ['light_manager'],
 
-        async onload() {
-            try {
-                await waitForLightManager();
-            } catch (error) {
+        onload() {
+            if (!window.LIGHT_MANAGER_LOADED || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') {
                 Blockbench.showToastNotification({
                     text: tr('lightflow_environment.message.light_manager_required', 'Lightflow Environment requires Light Manager.'),
                     icon: 'error',
@@ -1818,7 +1903,6 @@
             installUI();
             createSky();
             createSunLight();
-            updateScene({ forceShadow: true });
             installSunShadowGizmoInteraction();
 
             window.LightflowEnvironment = {
@@ -1835,9 +1919,25 @@
                 }
             };
 
-            const selectListener = Blockbench.on('select_project', event => loadProjectSettings(event?.project));
-            const loadListener = Blockbench.on('load_project', event => loadProjectSettings(event?.project));
-            const parsedListener = window.Codecs?.project?.on?.('parsed', () => loadProjectSettings(window.Project));
+            const lifecycleHydrator = window.LightflowLifecycle?.registerHydrator?.(
+                'lightflow_environment',
+                ({ project, model, isCurrent, deferred }) => {
+                    if (deferred) {
+                        beginEnvironmentProject(project);
+                        return;
+                    }
+                    if (project && !isCurrent()) return;
+                    loadProjectSettings(project, model);
+                }
+            );
+            if (lifecycleHydrator) {
+                deletables.push(lifecycleHydrator);
+            } else {
+                loadProjectSettings(window.Project || null, null);
+                const selectListener = Blockbench.on('select_project', event => loadProjectSettings(event?.project || window.Project, null));
+                const parsedListener = window.Codecs?.project?.on?.('parsed', () => loadProjectSettings(window.Project || null, null));
+                deletables.push(selectListener, parsedListener);
+            }
             const textureChanged = () => {
                 syncEnvironmentPanel();
                 updateScene({ forceShadow: false });
@@ -1851,15 +1951,14 @@
                 updateScene({ forceShadow: true });
             };
             window.addEventListener('light_manager_initialized', lightManagerListener);
-            deletables.push(selectListener, loadListener, parsedListener, ...textureListeners, viewListener, {
+            deletables.push(...textureListeners, viewListener, {
                 delete() { window.removeEventListener('light_manager_initialized', lightManagerListener); }
             });
             startAnimation();
-            dispatchChanged('load');
-            requestPreviewRender();
         },
 
         onunload() {
+            beginEnvironmentProject(null);
             if (animationFrame !== null) cancelAnimationFrame(animationFrame);
             animationFrame = null;
             if (typeof previewRenderFrame === 'number') cancelAnimationFrame(previewRenderFrame);
@@ -1868,7 +1967,6 @@
             deletables.splice(0).reverse().forEach(item => item?.delete?.());
             delete window.LightflowEnvironment;
             window.ShaderEngine?.updateLightUniforms?.();
-            requestPreviewRender();
         }
     });
 })();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Validation harness for the Lightflow Blockbench plugin suite",
   "scripts": {
-    "check": "node --check light_manager.js && node --check shader_architect.js && node --check lightflow_atmosphere.js && node --check studio_render.js",
+    "check": "node --check light_manager.js && node --check shader_architect.js && node --check lightflow_atmosphere.js && node --check lightflow_environment.js && node --check studio_render.js",
     "test": "node --test tests/release_candidate.test.js",
     "validate": "npm run check && npm test"
   },

--- a/shader_architect.js
+++ b/shader_architect.js
@@ -14371,6 +14371,11 @@ ${lumaForgeLightflowHelpers}`
         pendingPreviewRenderFrame: null,
         pendingPreviewRenderLightOnly: false,
         currentPreviewRenderLightOnly: false,
+        projectRevision: 0,
+        activeProject: typeof Project !== 'undefined' ? Project : null,
+        pendingSceneUpdateRevision: null,
+        pendingLightUniformRevision: null,
+        pendingPreviewRenderRevision: null,
         lightUniformMaterialCache: null,
         lightUniformMaterialCacheDirty: true,
         animationUniformTargets: null,
@@ -14771,7 +14776,21 @@ ${lumaForgeLightflowHelpers}`
         },
 
         isSceneUpdateReady() {
-            return !!Project?.parsed && !Blockbench.hasFlag('switching_project');
+            return !!(
+                Project?.parsed &&
+                this.activeProject === Project &&
+                !Blockbench.hasFlag('switching_project')
+            );
+        },
+
+        beginProjectLifecycle(project) {
+            this.projectRevision += 1;
+            this.activeProject = project || null;
+            this.cancelPendingSceneUpdate();
+            this.cancelPendingLightUniformUpdate();
+            this.cancelPendingPreviewRender();
+            this.invalidateLightUniformMaterialCache();
+            this.animationUniformTargetCacheDirty = true;
         },
 
         pickSceneUpdateCause(causes = []) {
@@ -14809,8 +14828,19 @@ ${lumaForgeLightflowHelpers}`
 
             if (this.pendingSceneUpdateFrame !== null) return;
 
+            const scheduledRevision = this.projectRevision;
+            const scheduledProject = this.activeProject;
+            this.pendingSceneUpdateRevision = scheduledRevision;
+
             const flush = () => {
+                if (
+                    scheduledRevision !== this.projectRevision ||
+                    scheduledProject !== this.activeProject ||
+                    scheduledProject !== (window.Project || null) ||
+                    this.pendingSceneUpdateRevision !== scheduledRevision
+                ) return;
                 this.pendingSceneUpdateFrame = null;
+                this.pendingSceneUpdateRevision = null;
                 this.flushPendingSceneUpdate();
             };
 
@@ -14872,6 +14902,7 @@ ${lumaForgeLightflowHelpers}`
                 cancelAnimationFrame(this.pendingSceneUpdateFrame);
             }
             this.pendingSceneUpdateFrame = null;
+            this.pendingSceneUpdateRevision = null;
             if (this.pendingSceneUpdateCauses) {
                 this.pendingSceneUpdateCauses.clear();
             }
@@ -14887,10 +14918,21 @@ ${lumaForgeLightflowHelpers}`
 
             if (this.pendingLightUniformFrame !== null) return;
 
+            const scheduledRevision = this.projectRevision;
+            const scheduledProject = this.activeProject;
+            this.pendingLightUniformRevision = scheduledRevision;
+
             const flush = () => {
+                if (
+                    scheduledRevision !== this.projectRevision ||
+                    scheduledProject !== this.activeProject ||
+                    scheduledProject !== (window.Project || null) ||
+                    this.pendingLightUniformRevision !== scheduledRevision
+                ) return;
                 const pendingCause = this.pendingLightUniformCause || 'light_update';
                 const shouldRender = this.pendingLightUniformRender;
                 this.pendingLightUniformFrame = null;
+                this.pendingLightUniformRevision = null;
                 this.pendingLightUniformCause = null;
                 this.pendingLightUniformRender = false;
                 this.updateLightUniforms(pendingCause, { render: shouldRender });
@@ -14919,6 +14961,7 @@ ${lumaForgeLightflowHelpers}`
             }
 
             this.pendingLightUniformFrame = null;
+            this.pendingLightUniformRevision = null;
             this.pendingLightUniformCause = null;
             this.pendingLightUniformRender = false;
         },
@@ -14933,10 +14976,20 @@ ${lumaForgeLightflowHelpers}`
             }
 
             this.pendingPreviewRenderLightOnly = lightOnly;
+            const scheduledRevision = this.projectRevision;
+            const scheduledProject = this.activeProject;
+            this.pendingPreviewRenderRevision = scheduledRevision;
 
             const flush = () => {
+                if (
+                    scheduledRevision !== this.projectRevision ||
+                    scheduledProject !== this.activeProject ||
+                    scheduledProject !== (window.Project || null) ||
+                    this.pendingPreviewRenderRevision !== scheduledRevision
+                ) return;
                 const renderLightOnly = this.pendingPreviewRenderLightOnly;
                 this.pendingPreviewRenderFrame = null;
+                this.pendingPreviewRenderRevision = null;
                 this.pendingPreviewRenderLightOnly = false;
 
                 /*
@@ -14985,6 +15038,7 @@ ${lumaForgeLightflowHelpers}`
             }
 
             this.pendingPreviewRenderFrame = null;
+            this.pendingPreviewRenderRevision = null;
             this.pendingPreviewRenderLightOnly = false;
             this.currentPreviewRenderLightOnly = false;
         },
@@ -19328,39 +19382,6 @@ ${stochasticAlpha
     // =========================================================================
     // 6. PLUGIN INITIALIZATION & MENUS
     // =========================================================================
-    function waitForPluginLightManager(timeout = 5000) {
-        return new Promise((resolve, reject) => {
-
-            // Use the existing ready flag when Light Manager has already loaded.
-            if (window.LIGHT_MANAGER_LOADED && window.LightManagerUI && typeof window.applyIndestructibleFormGroups === 'function') {
-                resolve(window.LightManagerUI);
-                return;
-            }
-
-            let finished = false;
-
-            const timer = setTimeout(() => {
-                if (finished) return;
-                finished = true;
-
-                window.removeEventListener('light_manager_initialized', onReady);
-
-                reject(new Error(`Light Manager is not available after waiting for ${timeout}ms. Shader Architect requires Light Manager to function properly. Please ensure Light Manager is installed and enabled.`));
-            }, timeout);
-
-            function onReady(event) {
-                if (finished) return;
-                if (!window.LIGHT_MANAGER_LOADED || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') return;
-                finished = true;
-
-                clearTimeout(timer);
-                resolve(window.LightManagerUI);
-            }
-
-            window.addEventListener('light_manager_initialized', onReady, { once: true });
-        });
-    }
-
     /**
      * Wraps an existing function to dispatch a Blockbench event before or after its execution.
      * The wrapped function perfectly preserves the original arguments, 'this' context, and return value.
@@ -19472,6 +19493,53 @@ ${stochasticAlpha
         });
     }
 
+    function hydrateShaderArchitectProject(context = {}) {
+        const project = context.project || null;
+        ShaderEngine.beginProjectLifecycle(project);
+        if (context.deferred) return;
+        if (!project) return;
+        if (typeof context.isCurrent === 'function' && !context.isCurrent()) return;
+
+        const model = context.model;
+        if (
+            !project[PROJECT_MATERIAL_INSTANCES_PROP] &&
+            typeof model?.[PROJECT_MATERIAL_INSTANCES_PROP] === 'string'
+        ) {
+            project[PROJECT_MATERIAL_INSTANCES_PROP] = model[PROJECT_MATERIAL_INSTANCES_PROP];
+        }
+
+        if (Array.isArray(model?.elements)) {
+            const rawByUuid = new Map(
+                model.elements
+                    .filter(element => element?.uuid)
+                    .map(element => [element.uuid, element])
+            );
+            const assignmentProperties = [
+                'sa_material_id',
+                'sa_material_instance_id',
+                CUBE_MATERIAL_INSTANCES_FALLBACK_PROP,
+                FACE_MATERIAL_INSTANCES_PROP
+            ];
+            getAllShaderElements().forEach(element => {
+                const raw = rawByUuid.get(element?.uuid);
+                if (!raw) return;
+                assignmentProperties.forEach(property => {
+                    if (element[property]) return;
+                    if (!Object.prototype.hasOwnProperty.call(raw, property)) return;
+                    element[property] = raw[property];
+                });
+            });
+        }
+
+        if (context.reason === 'new_project') {
+            MaterialManager.materialInstancePersistenceWarningShown = false;
+        }
+        project.parsed = true;
+        MaterialManager.syncMaterialInstancesFromProject(project);
+        invalidateTextureAlphaProfiles();
+        ShaderEngine.requestSceneUpdate('project_update');
+    }
+
     function registerNativeMethodEvent(owner, methodName, eventName, options = {}) {
         if (!owner) return;
 
@@ -19498,17 +19566,14 @@ ${stochasticAlpha
         author: 'MidFord327',
         description: 'Build advanced Blockbench materials with real-time Lightflow presets, editable GLSL, material instances, and deep Light Manager integration. Requires Light Manager for lights and shadows.',
         tags: ['Lightflow', 'Shaders', 'Materials', 'Rendering', 'GLSL', 'Lighting'],
-        version: '2.8.0',
+        version: '2.9.0',
         min_version: '4.9.0',
         variant: 'both',
         dependencies: ['light_manager'],
 
-        onload: async function () {
+        onload: function () {
 
-            try {
-                await waitForPluginLightManager();
-            }
-            catch (e) {
+            if (!window.LIGHT_MANAGER_LOADED || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') {
                 Blockbench.showToastNotification({
                     text: tl('shader_architect.message.light_manager_required'),
                     icon: 'error',
@@ -21374,16 +21439,11 @@ ${stochasticAlpha
                     deletables.push(Blockbench.on(eventName, applyAddedElement));
                 });
 
-                const updateProjectEvent = (project) => {
-                    if (!project) project = MaterialManager.getActiveProject();
-                    if (!project) return;
-                    Project.parsed = true;
-                    MaterialManager.syncMaterialInstancesFromProject(project);
-                    ShaderEngine.requestSceneUpdate('project_update');
-                };
-
                 let onParseProjectEvent = Codecs.project.on('parse', () => {
                     Project.parsed = false;
+                    ShaderEngine.cancelPendingSceneUpdate();
+                    ShaderEngine.cancelPendingLightUniformUpdate();
+                    ShaderEngine.cancelPendingPreviewRender();
                     const projectInstancesProp = MaterialManager.registerProjectMaterialInstanceProperty();
                     if (projectInstancesProp && !deletables.includes(projectInstancesProp)) {
                         deletables.push(projectInstancesProp);
@@ -21392,30 +21452,22 @@ ${stochasticAlpha
 
                 deletables.push(onParseProjectEvent);
 
-                let loadProjectEvent = Codecs.project.on('parsed', () => {
-                    Project.parsed = true;
-                    updateProjectEvent();
-                });
-
-                deletables.push(loadProjectEvent);
-
-                let selectProjectEvent = Blockbench.on('select_project', (args) => {
-                    updateProjectEvent(args.project);
-                });
-
-                deletables.push(selectProjectEvent);
-
-                let loadGenericProjectEvent = Blockbench.on('load_project', (args) => {
-                    const project = args && args.project || MaterialManager.getActiveProject();
-                    updateProjectEvent(project);
-                });
-                deletables.push(loadGenericProjectEvent);
-
-                let newProjectEvent = Blockbench.on('new_project', () => {
-                    MaterialManager.materialInstancePersistenceWarningShown = false;
-                    updateProjectEvent(MaterialManager.getActiveProject());
-                });
-                deletables.push(newProjectEvent);
+                const projectHydrator = window.LightflowLifecycle?.registerHydrator?.(
+                    'shader_architect',
+                    hydrateShaderArchitectProject
+                );
+                if (projectHydrator) {
+                    deletables.push(projectHydrator);
+                } else {
+                    hydrateShaderArchitectProject({ project: MaterialManager.getActiveProject() });
+                    const loadProjectEvent = Codecs.project.on('parsed', () => {
+                        hydrateShaderArchitectProject({ project: MaterialManager.getActiveProject(), reason: 'parsed' });
+                    });
+                    const selectProjectEvent = Blockbench.on('select_project', args => {
+                        hydrateShaderArchitectProject({ project: args?.project || MaterialManager.getActiveProject(), reason: 'select_project' });
+                    });
+                    deletables.push(loadProjectEvent, selectProjectEvent);
+                }
 
                 let updateSelectionEvent = Blockbench.on('update_selection', () => {
                     if (!Project.parsed) return;
@@ -21435,6 +21487,7 @@ ${stochasticAlpha
         },
 
         onunload() {
+            ShaderEngine.beginProjectLifecycle(null);
             ShaderEngine.stopAnimationLoop();
             ShaderEngine.disposeMaterialPool();
             MinecraftPromotionalSilhouetteManager.dispose();

--- a/shader_architect.js
+++ b/shader_architect.js
@@ -13879,6 +13879,7 @@ ${lumaForgeLightflowHelpers}`
         pendingSceneUpdateCauses: null,
         pendingLightUniformFrame: null,
         pendingLightUniformCause: null,
+        pendingLightUniformRender: false,
         pendingPreviewRenderFrame: null,
         pendingPreviewRenderLightOnly: false,
         currentPreviewRenderLightOnly: false,
@@ -13888,6 +13889,7 @@ ${lumaForgeLightflowHelpers}`
         animationUniformTargetCacheDirty: true,
         sharedFrameUniforms: null,
         sharedLightUniforms: null,
+        lightUniformScratch: null,
         materialPool: new Map(),
         materialPoolObjectIds: new WeakMap(),
         nextMaterialPoolObjectId: 1,
@@ -13921,7 +13923,8 @@ ${lumaForgeLightflowHelpers}`
                 'max_light_number', 'uLightPos', 'uLightDir', 'uLightColor',
                 'uLightIntensity', 'uLightDistance', 'uLightConeAngle',
                 'uLightType', 'uLightPenumbra', 'uLightCastShadow',
-                'uLightShadowIndex'
+                'uLightShadowIndex', 'uSAEnvironmentEnabled',
+                'uSAEnvironmentAmbient', 'uSAEnvironmentStrength'
             ].forEach(name => {
                 const uniform = material.uniforms[name];
                 if (!uniform) return;
@@ -14390,23 +14393,29 @@ ${lumaForgeLightflowHelpers}`
             this.pendingSceneUpdatePartial = false;
         },
 
-        requestLightUniformUpdate(cause = 'light_update') {
+        requestLightUniformUpdate(cause = 'light_update', options = {}) {
             this.pendingLightUniformCause = cause;
+            this.pendingLightUniformRender = this.pendingLightUniformRender || options.render !== false;
 
             if (this.pendingLightUniformFrame !== null) return;
 
             const flush = () => {
                 const pendingCause = this.pendingLightUniformCause || 'light_update';
+                const shouldRender = this.pendingLightUniformRender;
                 this.pendingLightUniformFrame = null;
                 this.pendingLightUniformCause = null;
-                this.updateLightUniforms(pendingCause);
+                this.pendingLightUniformRender = false;
+                this.updateLightUniforms(pendingCause, { render: shouldRender });
             };
 
-            if (typeof requestAnimationFrame === 'function') {
-                this.pendingLightUniformFrame = requestAnimationFrame(flush);
-            } else if (typeof queueMicrotask === 'function') {
+            // Light Manager already batches slider traffic to one animation
+            // frame. A microtask merges all callbacks from that update while
+            // keeping the resulting uniforms available to the next paint.
+            if (typeof queueMicrotask === 'function') {
                 this.pendingLightUniformFrame = 'microtask';
                 queueMicrotask(flush);
+            } else if (typeof requestAnimationFrame === 'function') {
+                this.pendingLightUniformFrame = requestAnimationFrame(flush);
             } else {
                 this.pendingLightUniformFrame = 'promise';
                 Promise.resolve().then(flush);
@@ -14423,6 +14432,7 @@ ${lumaForgeLightflowHelpers}`
 
             this.pendingLightUniformFrame = null;
             this.pendingLightUniformCause = null;
+            this.pendingLightUniformRender = false;
         },
 
         requestPreviewRender(options = {}) {
@@ -14441,8 +14451,6 @@ ${lumaForgeLightflowHelpers}`
                 this.pendingPreviewRenderFrame = null;
                 this.pendingPreviewRenderLightOnly = false;
 
-                if (!window.Preview || !Array.isArray(Preview.all)) return;
-
                 /*
                  * Studio Render owns the offscreen preview and renders every
                  * tile itself. A queued Shader Architect preview refresh must
@@ -14458,11 +14466,12 @@ ${lumaForgeLightflowHelpers}`
 
                 this.currentPreviewRenderLightOnly = renderLightOnly;
                 try {
-                    Preview.all.forEach(preview => {
-                        if (preview && typeof preview.render === 'function') {
-                            preview.render();
-                        }
-                    });
+                    const preview =
+                        (window.Preview && Preview.selected) ||
+                        window.main_preview ||
+                        window.MediaPreview ||
+                        null;
+                    preview?.render?.();
                 } finally {
                     this.currentPreviewRenderLightOnly = false;
                 }
@@ -16483,7 +16492,48 @@ ${stochasticAlpha
             return materials;
         },
 
-        updateLightUniforms() {
+        getLightUniformScratch(maxLights) {
+            const size = Math.max(1, maxLights | 0);
+            if (!this.lightUniformScratch || this.lightUniformScratch.size !== size) {
+                const vectors = fallback => Array.from({ length: size }, () => new THREE.Vector3(...fallback));
+                this.lightUniformScratch = {
+                    size,
+                    posArray: vectors([0, 0, 0]),
+                    dirArray: vectors([0, -1, 0]),
+                    colArray: vectors([0, 0, 0]),
+                    intArray: new Array(size).fill(0),
+                    distanceArray: new Array(size).fill(0),
+                    coneAngleArray: new Array(size).fill(0),
+                    penumbraArray: new Array(size).fill(0),
+                    lightTypeArray: new Array(size).fill(0),
+                    castShadowArray: new Array(size).fill(0),
+                    shadowIndexArray: new Array(size).fill(-1),
+                    lightPosition: new THREE.Vector3(),
+                    targetPosition: new THREE.Vector3(),
+                    quaternion: new THREE.Quaternion(),
+                    shadowIndexByThreeUuid: new Map(),
+                    updatedUniformGroups: new Set()
+                };
+            }
+            const scratch = this.lightUniformScratch;
+            for (let index = 0; index < size; index++) {
+                scratch.posArray[index].set(0, 0, 0);
+                scratch.dirArray[index].set(0, -1, 0);
+                scratch.colArray[index].set(0, 0, 0);
+                scratch.intArray[index] = 0;
+                scratch.distanceArray[index] = 0;
+                scratch.coneAngleArray[index] = 0;
+                scratch.penumbraArray[index] = 0;
+                scratch.lightTypeArray[index] = 0;
+                scratch.castShadowArray[index] = 0;
+                scratch.shadowIndexArray[index] = -1;
+            }
+            scratch.shadowIndexByThreeUuid.clear();
+            scratch.updatedUniformGroups.clear();
+            return scratch;
+        },
+
+        updateLightUniforms(cause = 'light_update', options = {}) {
             this.cancelPendingLightUniformUpdate();
 
             const lights = (window.LightElement && Array.isArray(window.LightElement.all))
@@ -16496,38 +16546,20 @@ ${stochasticAlpha
             }
 
             const MAX_LIGHTS = 16;
+            const scratch = this.getLightUniformScratch(MAX_LIGHTS);
+            const {
+                posArray, dirArray, colArray, intArray, distanceArray,
+                coneAngleArray, penumbraArray, lightTypeArray,
+                castShadowArray, shadowIndexArray
+            } = scratch;
 
-            const posArray = [];
-            const dirArray = [];
-            const colArray = [];
-            const intArray = [];
-            const distanceArray = [];
-            const coneAngleArray = [];
-            const penumbraArray = [];
-            const lightTypeArray = [];
-            const castShadowArray = [];
-            const shadowIndexArray = [];
-
-            if (!this._preparingLightUniformRender && typeof window.LightManagerPrepareRender === 'function') {
-                this._preparingLightUniformRender = true;
-                try {
-                    const preview =
-                        window.LightManagerStudioRenderPreview ||
-                        (typeof Preview !== 'undefined' && Preview.selected) ||
-                        window.main_preview ||
-                        window.MediaPreview ||
-                        window.Screencam?.NoAAPreview ||
-                        null;
-                    window.LightManagerPrepareRender(preview, {
-                        shadows: true,
-                        scene: true,
-                        gizmos: false,
-                        studio: !!window.LightManagerStudioRenderActive
-                    });
-                } finally {
-                    this._preparingLightUniformRender = false;
-                }
-            }
+            /*
+             * Do not call LightManagerPrepareRender from this uniform-only
+             * path. Light Manager invokes us after synchronizing its THREE
+             * lights, and each actual renderer prepares its own shadows. The
+             * old call performed a full shadow/scene preparation for every
+             * slider step and then requested another preview render.
+             */
 
             const threeLights = window.three_lights || {};
             const threeLightsGroup = window.three_lights_group || null;
@@ -16559,9 +16591,9 @@ ${stochasticAlpha
                 return 0;
             };
 
-            const getLightColor = (element, threeLight) => {
+            const getLightColor = (element, threeLight, target) => {
                 if (threeLight && threeLight.color) {
-                    return new THREE.Vector3(
+                    return target.set(
                         threeLight.color.r,
                         threeLight.color.g,
                         threeLight.color.b
@@ -16570,7 +16602,7 @@ ${stochasticAlpha
 
                 const color = element.render_color || element.color || [255, 255, 255];
 
-                return new THREE.Vector3(
+                return target.set(
                     Math.max(0, Math.min(1, Number(color[0] ?? 255) / 255)),
                     Math.max(0, Math.min(1, Number(color[1] ?? 255) / 255)),
                     Math.max(0, Math.min(1, Number(color[2] ?? 255) / 255))
@@ -16583,20 +16615,17 @@ ${stochasticAlpha
                 return isUsableThreeLight(threeLight) ? threeLight : null;
             };
 
-            const getWorldDirectionFromThreeLight = (threeLight, fallbackMesh) => {
-                const direction = new THREE.Vector3(0, 0, -1);
+            const getWorldDirectionFromThreeLight = (threeLight, fallbackMesh, direction) => {
+                direction.set(0, 0, -1);
 
                 if (threeLight && threeLight.target) {
-                    const lightPos = new THREE.Vector3();
-                    const targetPos = new THREE.Vector3();
-
                     threeLight.updateMatrixWorld(true);
                     threeLight.target.updateMatrixWorld(true);
 
-                    threeLight.getWorldPosition(lightPos);
-                    threeLight.target.getWorldPosition(targetPos);
+                    threeLight.getWorldPosition(scratch.lightPosition);
+                    threeLight.target.getWorldPosition(scratch.targetPosition);
 
-                    direction.copy(targetPos).sub(lightPos);
+                    direction.copy(scratch.targetPosition).sub(scratch.lightPosition);
 
                     if (direction.lengthSq() > 1e-8) {
                         return direction.normalize();
@@ -16604,17 +16633,16 @@ ${stochasticAlpha
                 }
 
                 if (fallbackMesh) {
-                    const quat = new THREE.Quaternion();
                     fallbackMesh.updateMatrixWorld(true);
-                    fallbackMesh.getWorldQuaternion(quat);
-                    direction.applyQuaternion(quat);
+                    fallbackMesh.getWorldQuaternion(scratch.quaternion);
+                    direction.applyQuaternion(scratch.quaternion);
 
                     if (direction.lengthSq() > 1e-8) {
                         return direction.normalize();
                     }
                 }
 
-                return new THREE.Vector3(0, -1, 0);
+                return direction.set(0, -1, 0);
             };
 
             /*
@@ -16622,7 +16650,7 @@ ${stochasticAlpha
                 Three.js does not use the LightElement.all index.
                 Use the actual THREE light order from the scene/group.
             */
-            const shadowIndexByThreeUuid = new Map();
+            const shadowIndexByThreeUuid = scratch.shadowIndexByThreeUuid;
 
             let directionalShadowIndex = 0;
             let spotShadowIndex = 0;
@@ -16666,7 +16694,7 @@ ${stochasticAlpha
                 const threeLight = getThreeLightForElement(element);
                 const typeId = getLightTypeIdFromElement(element);
 
-                const worldPos = new THREE.Vector3();
+                const worldPos = posArray[activeLightCount];
 
                 if (threeLight) {
                     threeLight.updateMatrixWorld(true);
@@ -16676,7 +16704,11 @@ ${stochasticAlpha
                     element.mesh.getWorldPosition(worldPos);
                 }
 
-                const worldDir = getWorldDirectionFromThreeLight(threeLight, element.mesh);
+                getWorldDirectionFromThreeLight(
+                    threeLight,
+                    element.mesh,
+                    dirArray[activeLightCount]
+                );
 
                 const castsShadow =
                     !!threeLight &&
@@ -16689,52 +16721,37 @@ ${stochasticAlpha
                     ? shadowIndexByThreeUuid.get(threeLight.uuid)
                     : -1;
 
-                posArray.push(worldPos);
-                dirArray.push(worldDir);
-                lightTypeArray.push(typeId);
-                colArray.push(getLightColor(element, threeLight));
+                lightTypeArray[activeLightCount] = typeId;
+                getLightColor(element, threeLight, colArray[activeLightCount]);
 
-                intArray.push(
+                intArray[activeLightCount] =
                     element.render_intensity !== undefined
                         ? Math.max(0, Number(element.render_intensity) || 0)
                         : Math.max(0, Number(element.intensity) || 0)
-                );
+                ;
 
-                distanceArray.push(
+                distanceArray[activeLightCount] =
                     element.distance !== undefined
                         ? Math.max(0, Number(element.distance) || 0)
                         : 0.0
-                );
+                ;
 
-                coneAngleArray.push(
+                coneAngleArray[activeLightCount] =
                     THREE.MathUtils.degToRad(
                         Math.max(0.001, Math.min(89.9, Number(element.angle) || 45))
                     )
-                );
+                ;
 
-                penumbraArray.push(
+                penumbraArray[activeLightCount] =
                     element.penumbra !== undefined
                         ? Math.max(0, Math.min(1, Number(element.penumbra) || 0))
                         : 0.0
-                );
+                ;
 
-                castShadowArray.push(castsShadow ? 1 : 0);
-                shadowIndexArray.push(shadowIndex);
+                castShadowArray[activeLightCount] = castsShadow ? 1 : 0;
+                shadowIndexArray[activeLightCount] = shadowIndex;
 
                 activeLightCount++;
-            }
-
-            for (let i = activeLightCount; i < MAX_LIGHTS; i++) {
-                posArray.push(new THREE.Vector3(0, 0, 0));
-                dirArray.push(new THREE.Vector3(0, -1, 0));
-                colArray.push(new THREE.Vector3(0, 0, 0));
-                intArray.push(0.0);
-                distanceArray.push(0.0);
-                coneAngleArray.push(0.0);
-                penumbraArray.push(0.0);
-                lightTypeArray.push(0);
-                castShadowArray.push(0);
-                shadowIndexArray.push(-1);
             }
 
             const ensureUniform = (mat, name, valueFactory) => {
@@ -16789,7 +16806,7 @@ ${stochasticAlpha
                 return uniform;
             };
 
-            const updatedUniformGroups = new Set();
+            const updatedUniformGroups = scratch.updatedUniformGroups;
             const environmentState = window.LightflowEnvironment?.getLightingState?.();
             this.getLightUniformMaterials().forEach(mat => {
                 if (!mat || !mat.uniforms) return;
@@ -16869,7 +16886,9 @@ ${stochasticAlpha
                 }
             });
 
-            this.requestPreviewRender({ lightOnly: true });
+            if (options.render !== false) {
+                this.requestPreviewRender({ lightOnly: true, cause });
+            }
         }
     };
 
@@ -18934,7 +18953,7 @@ ${stochasticAlpha
             UpdateShaderArchitectLights: window.UpdateShaderArchitectLights,
             on_light_element_updated: window.on_light_element_updated
         };
-        const updateShaderLights = () => ShaderEngine.updateLightUniforms('light_element_update');
+        const updateShaderLights = () => ShaderEngine.requestLightUniformUpdate('light_element_update');
 
         window.updateLights = updateShaderLights;
         window.UpdateShaderArchitectLights = updateShaderLights;
@@ -18975,7 +18994,7 @@ ${stochasticAlpha
         author: 'MidFord327',
         description: 'Build advanced Blockbench materials with real-time Lightflow presets, editable GLSL, material instances, and deep Light Manager integration. Requires Light Manager for lights and shadows.',
         tags: ['Lightflow', 'Shaders', 'Materials', 'Rendering', 'GLSL', 'Lighting'],
-        version: '2.7.1',
+        version: '2.8.0',
         min_version: '4.9.0',
         variant: 'both',
 
@@ -20856,13 +20875,24 @@ ${stochasticAlpha
                     const controller = ElementType.preview_controller;
                     if (!controller || typeof controller.on !== 'function') return;
                     ['update_uv', 'update_faces', 'update_geometry'].forEach(eventName => {
-                        const previewEvent = controller.on(eventName, () => {
+                        const previewEvent = controller.on(eventName, (event) => {
                             if (!Project.parsed || Blockbench.hasFlag('switching_project')) return;
                             if (eventName === 'update_uv' && window.TextureAnimator && window.TextureAnimator.isPlaying) {
                                 ShaderEngine.requestPreviewRender({ cause: 'texture_animation_frame' });
                                 return;
                             }
-                            ShaderEngine.requestSceneUpdate(`${ElementType.name || 'element'}_${eventName}`);
+                            const changedElement = event?.element || event?.object || event?.cube || null;
+                            const changedElements = changedElement
+                                ? [changedElement]
+                                : getSelectedShaderElements();
+                            if (changedElements.length) {
+                                ShaderEngine.requestSceneUpdate(
+                                    `${ElementType.name || 'element'}_${eventName}`,
+                                    { partial: true, cubes: changedElements }
+                                );
+                            } else {
+                                ShaderEngine.requestSceneUpdate(`${ElementType.name || 'element'}_${eventName}`);
+                            }
                         });
                         if (previewEvent) deletables.push(previewEvent);
                     });
@@ -20881,11 +20911,6 @@ ${stochasticAlpha
                 ['add_cube', 'add_mesh', 'add_texture_mesh'].forEach(eventName => {
                     deletables.push(Blockbench.on(eventName, applyAddedElement));
                 });
-
-                let transformEvent = Blockbench.on('update_transform', () => {
-                    ShaderEngine.requestLightUniformUpdate('update_transform');
-                });
-                deletables.push(transformEvent);
 
                 const updateProjectEvent = (project) => {
                     if (!project) project = MaterialManager.getActiveProject();

--- a/shader_architect.js
+++ b/shader_architect.js
@@ -668,6 +668,7 @@
 
         "shader_architect.preset.classic": "Classic Shader",
         "shader_architect.preset.pbr_metallic_roughness": "Lightflow Principled PBR",
+        "shader_architect.preset.vibrant_visuals_pbr": "Vibrant Visuals PBR",
         "shader_architect.preset.lightflow": "Lightflow",
         "shader_architect.preset.shaded_lightflow": "Lightflow (Legacy)",
         "shader_architect.preset.pixelated_shaded_lightflow": "Pixelated Lightflow",
@@ -1027,6 +1028,12 @@
         "shader_architect.uniform.shadowPixelResolution.desc": "Size of the pixelated shadow grid",
         "shader_architect.uniform.shadowThreshold": "Cutoff",
         "shader_architect.uniform.shadowThreshold.desc": "Shadow threshold for the pixelated shadow mask",
+        "shader_architect.uniform.PIXELATED_SHADOWS": "Pixelated Shadows",
+        "shader_architect.uniform.PIXELATED_SHADOWS.desc": "Switch the Vibrant Visuals-style stepped shadow response without changing material",
+        "shader_architect.uniform.uPixelatedShadows": "Pixelated Shadows",
+        "shader_architect.uniform.uPixelatedShadows.desc": "Quantize PBR shadow visibility into stable screen-space pixel cells",
+        "shader_architect.uniform.uPixelShadowSteps": "Shadow Tone Steps",
+        "shader_architect.uniform.uPixelShadowScale": "Shadow Pixel Size",
         "shader_architect.uniform.shadowFilterScale": "Filter Scale",
         "shader_architect.uniform.shadowFilterScale.desc": "Multiplies the light shadow softness used by pixelated shadows",
         "shader_architect.uniform.shadowFeather": "Feather",
@@ -1185,6 +1192,7 @@
 
         "shader_architect.preset.classic": "Shader Clásico",
         "shader_architect.preset.pbr_metallic_roughness": "PBR Principled Lightflow",
+        "shader_architect.preset.vibrant_visuals_pbr": "PBR Vibrant Visuals",
         "shader_architect.preset.lightflow": "Lightflow",
         "shader_architect.preset.shaded_lightflow": "Lightflow (Compatibilidad)",
         "shader_architect.preset.pixelated_shaded_lightflow": "Lightflow Pixelado",
@@ -2094,7 +2102,23 @@ uniform float uSA_SSRCameraNear;
 uniform float uSA_SSRCameraFar;
 uniform int uSA_SSRCameraIsPerspective;
 uniform mat4 uSA_SSRCameraProjectionMatrix;
+uniform mat4 uSA_SSRViewToWorld;
 uniform float uSA_SSRTime;
+uniform int uSA_EnvironmentEnabled;
+uniform vec3 uSA_EnvironmentZenith;
+uniform vec3 uSA_EnvironmentHorizon;
+uniform vec3 uSA_EnvironmentGround;
+uniform vec3 uSA_EnvironmentCelestialDirection;
+uniform vec3 uSA_EnvironmentCelestialColor;
+uniform float uSA_EnvironmentCelestialSize;
+uniform vec3 uSA_EnvironmentCloudColor;
+uniform float uSA_EnvironmentCloudCoverage;
+uniform float uSA_EnvironmentCloudOpacity;
+uniform float uSA_EnvironmentCloudTime;
+uniform float uSA_EnvironmentDaylight;
+uniform float uSA_EnvironmentTwilight;
+uniform float uSA_EnvironmentVibrant;
+uniform float uSA_EnvironmentIntensity;
 
 uniform bool uSSREnabled;
 uniform float uSSRIntensity;
@@ -2149,11 +2173,95 @@ vec3 saSSRSampleScene(vec2 uv, float roughness) {
     return color;
 }
 
+float saSSREnvironmentHash(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+float saSSREnvironmentNoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(saSSREnvironmentHash(i), saSSREnvironmentHash(i + vec2(1.0, 0.0)), f.x),
+        mix(saSSREnvironmentHash(i + vec2(0.0, 1.0)), saSSREnvironmentHash(i + vec2(1.0)), f.x),
+        f.y
+    );
+}
+
+float saSSREnvironmentClouds(vec2 p) {
+    p = floor(p * 3.0) / 3.0;
+    return saSSREnvironmentNoise(p * 0.18) * 0.58 +
+        saSSREnvironmentNoise(p * 0.43 + 17.0) * 0.28 +
+        saSSREnvironmentNoise(p * 0.91 + 31.0) * 0.14;
+}
+
+float saSSREnvironmentCelestial(vec3 direction, vec3 center, float size) {
+    vec3 reference = abs(center.y) > 0.96 ? vec3(1.0, 0.0, 0.0) : vec3(0.0, 1.0, 0.0);
+    vec3 tangent = normalize(cross(reference, center));
+    vec3 bitangent = normalize(cross(center, tangent));
+    float facing = max(dot(direction, center), 0.0001);
+    vec2 coordinates = vec2(dot(direction, tangent), dot(direction, bitangent)) / facing;
+    float distanceToSquare = max(abs(coordinates.x), abs(coordinates.y));
+    return 1.0 - smoothstep(size * 0.88, size * 1.08, distanceToSquare);
+}
+
+vec3 saSSRSampleEnvironment(vec3 viewRay, float roughness, out float visibility) {
+    if (uSA_EnvironmentEnabled != 1 || uSA_EnvironmentIntensity <= 0.0) {
+        visibility = 0.0;
+        return vec3(0.0);
+    }
+
+    vec3 worldRay = normalize((uSA_SSRViewToWorld * vec4(viewRay, 0.0)).xyz);
+    float horizon = pow(1.0 - clamp(abs(worldRay.y), 0.0, 1.0), 2.6);
+    vec3 upper = mix(uSA_EnvironmentZenith, uSA_EnvironmentHorizon, horizon);
+    vec3 lower = mix(uSA_EnvironmentGround, uSA_EnvironmentHorizon, exp(worldRay.y * 6.0));
+    vec3 environment = worldRay.y >= 0.0 ? upper : lower;
+
+    vec3 celestialDirection = normalize(uSA_EnvironmentCelestialDirection);
+    float celestial = saSSREnvironmentCelestial(
+        worldRay,
+        celestialDirection,
+        max(uSA_EnvironmentCelestialSize, 0.001)
+    );
+    environment = mix(environment, uSA_EnvironmentCelestialColor, celestial);
+
+    if (uSA_EnvironmentCloudOpacity > 0.0 && worldRay.y > 0.025) {
+        vec2 cloudUv = worldRay.xz / max(worldRay.y, 0.035) * 7.5 +
+            vec2(uSA_EnvironmentCloudTime, uSA_EnvironmentCloudTime * 0.37);
+        float clouds = smoothstep(
+            uSA_EnvironmentCloudCoverage - 0.08,
+            uSA_EnvironmentCloudCoverage + 0.08,
+            saSSREnvironmentClouds(cloudUv)
+        );
+        clouds *= smoothstep(0.025, 0.13, worldRay.y) * uSA_EnvironmentCloudOpacity;
+        vec3 cloudLight = mix(
+            uSA_EnvironmentCloudColor * 0.24,
+            uSA_EnvironmentCloudColor,
+            0.18 + 0.82 * uSA_EnvironmentDaylight
+        );
+        cloudLight = mix(
+            cloudLight,
+            vec3(1.0, 0.42, 0.22),
+            uSA_EnvironmentTwilight * 0.34 * (1.0 - uSA_EnvironmentVibrant)
+        );
+        environment = mix(environment, cloudLight, clouds);
+    }
+
+    // Rough materials see a broader, quieter environment lobe.
+    environment = mix(environment, uSA_EnvironmentHorizon, clamp(roughness, 0.0, 1.0) * 0.38);
+    visibility = 1.0;
+    return max(environment, vec3(0.0)) * uSA_EnvironmentIntensity;
+}
+
 vec3 saSSRFallbackReflection(vec4 clipPosition, vec3 rayDir, float roughness, out float hitFade) {
     vec2 screenUv = (clipPosition.xy / max(clipPosition.w, 0.0001)) * 0.5 + 0.5;
     vec2 uv = screenUv + rayDir.xy * clamp(uSSRDistortion, 0.0, 0.5) / max(0.35, abs(rayDir.z));
     hitFade = saSSRScreenEdgeFade(uv);
-    if (saSSROutsideScreen(uv)) hitFade = 0.0;
+    if (saSSROutsideScreen(uv)) {
+        return saSSRSampleEnvironment(rayDir, roughness, hitFade);
+    }
     return saSSRSampleScene(uv, roughness);
 }
 
@@ -2208,7 +2316,9 @@ vec3 saSSRRaymarch(vec3 viewPosition, vec3 rayDir, vec4 clipPosition, float roug
         }
     }
 
-    if (hitFade <= 0.0 || saSSROutsideScreen(hitUv)) return vec3(0.0);
+    if (hitFade <= 0.0 || saSSROutsideScreen(hitUv)) {
+        return saSSRSampleEnvironment(rayDir, roughness, hitFade);
+    }
     return saSSRSampleScene(hitUv, roughness);
 }
 
@@ -4810,6 +4920,9 @@ uniform int uLightShadowIndex[16];
 
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
+uniform int uSAEnvironmentEnabled;
+uniform vec3 uSAEnvironmentAmbient;
+uniform float uSAEnvironmentStrength;
 
 uniform float uExposure;
 uniform float uUseToneMapping;
@@ -4824,6 +4937,9 @@ uniform float uAODirectInfluence;
 
 uniform float uShadowStrength;
 uniform float uShadowFloor;
+uniform bool uPixelatedShadows;
+uniform float uPixelShadowSteps;
+uniform float uPixelShadowScale;
 
 varying vec2 vUv;
 varying vec2 v_uvSize;
@@ -5398,6 +5514,12 @@ void main() {
         vec3 L = getLightDirection(i, vWorldPos);
         float attenuation = getLightAttenuation(i, vWorldPos, L);
         float shadow = getCustomLightShadow(i);
+        if (uPixelatedShadows) {
+            float levels = max(2.0, uPixelShadowSteps);
+            vec2 pixelCell = floor(gl_FragCoord.xy / max(uPixelShadowScale, 1.0));
+            float dither = fract(dot(pixelCell, vec2(0.75487766, 0.56984029))) - 0.5;
+            shadow = floor(clamp(shadow + dither / levels, 0.0, 1.0) * levels + 0.5) / levels;
+        }
         vec3 incidentRadiance = getLightRadiance(i, attenuation);
         vec3 radiance = incidentRadiance * shadow;
 
@@ -5493,6 +5615,10 @@ void main() {
     float specAO = mix(1.0, ambientOcclusion, clamp(uAODirectInfluence * 0.35, 0.0, 1.0));
 
     vec3 ambientLight = max(uAmbientColor, vec3(0.0)) * max(uAmbient, 0.0);
+    if (uSAEnvironmentEnabled == 1) {
+        ambientLight += max(uSAEnvironmentAmbient, vec3(0.0)) *
+            max(uSAEnvironmentStrength, 0.0);
+    }
 
     vec3 F_ambient = F_SchlickRoughness(F0, NdotV, roughness);
     vec3 ambientDiffuse = ambientLight * baseColor * (1.0 - metallic) * ambientOcclusion;
@@ -5662,6 +5788,9 @@ void main() {
                     // Ambient
                     "uAmbient": { type: "float", value: 0.3, expose: true, min: 0.0, max: 1.0, step: 0.05, allow_higher: true, allow_lower: false },
                     "uAmbientColor": { type: "vec3", value: new THREE.Vector3(1, 1, 1), hexValue: "#ffffff", expose: true, is_color: true },
+                    "uSAEnvironmentEnabled": { type: "int", value: 0, expose: false },
+                    "uSAEnvironmentAmbient": { type: "vec3", value: new THREE.Vector3(1, 1, 1), expose: false },
+                    "uSAEnvironmentStrength": { type: "float", value: 0.0, expose: false },
 
                     // Normal correction
                     "uWorldNormalMatrix": { type: "mat3", value: new THREE.Matrix3(), expose: false },
@@ -5683,6 +5812,9 @@ void main() {
                     // Shadows
                     "uShadowStrength": { type: "float", value: 1.0, expose: true, min: 0.0, max: 1.0, step: 0.05, allow_higher: false, allow_lower: false },
                     "uShadowFloor": { type: "float", value: 0.0, expose: true, min: 0.0, max: 1.0, step: 0.05, allow_higher: false, allow_lower: false },
+                    "uPixelatedShadows": { type: "bool", value: false, expose: true },
+                    "uPixelShadowSteps": { type: "float", value: 4.0, expose: true, min: 2.0, max: 16.0, step: 1.0, allow_higher: false, allow_lower: false },
+                    "uPixelShadowScale": { type: "float", value: 2.0, expose: true, min: 1.0, max: 16.0, step: 1.0, allow_higher: false, allow_lower: false },
 
                     // Blockbench-style controls
                     "SHADE": { type: "bool", value: true, expose: true },
@@ -5695,6 +5827,42 @@ void main() {
                     quality: 0.72,
                     renderScale: 0.85
                 })),
+                supportsScreenSpaceReflections: true,
+                enableShadows: true
+            });
+
+            const vibrantVisualsUniforms = {};
+            Object.keys(pbr_metallic_roughness.uniforms).forEach(key => {
+                vibrantVisualsUniforms[key] = cloneUniformDefinition(
+                    pbr_metallic_roughness.uniforms[key]
+                );
+            });
+            const setVibrantDefault = (name, value) => {
+                if (vibrantVisualsUniforms[name]) vibrantVisualsUniforms[name].value = value;
+            };
+            setVibrantDefault('uRoughness', 0.62);
+            setVibrantDefault('uEnvSpecularStrength', 0.72);
+            setVibrantDefault('uSpecularIntensity', 0.9);
+            setVibrantDefault('uAmbient', 0.16);
+            setVibrantDefault('uUseToneMapping', 1.0);
+            setVibrantDefault('uExposure', 1.08);
+            setVibrantDefault('uSSREnabled', true);
+            setVibrantDefault('uSSRIntensity', 0.48);
+            setVibrantDefault('uSSRRoughness', 0.22);
+            setVibrantDefault('uSSRQuality', 0.72);
+            setVibrantDefault('uSSRRenderScale', 0.85);
+            setVibrantDefault('uPixelatedShadows', true);
+            setVibrantDefault('uPixelShadowSteps', 4.0);
+            setVibrantDefault('uPixelShadowScale', 2.0);
+
+            const vibrant_visuals_pbr = new FancyShaderMaterial({
+                id: 'vibrant_visuals_pbr',
+                name: tl('shader_architect.preset.vibrant_visuals_pbr'),
+                icon: 'landscape_2',
+                isCustom: false,
+                vertex: pbr_metallic_roughness.vertex,
+                fragment: pbr_metallic_roughness.fragment,
+                uniforms: vibrantVisualsUniforms,
                 supportsScreenSpaceReflections: true,
                 enableShadows: true
             });
@@ -5813,6 +5981,21 @@ void main() {
                         hexValue: "#ffffff",
                         expose: true,
                         is_color: true
+                    },
+                    "uSAEnvironmentEnabled": {
+                        type: "int",
+                        value: 0,
+                        expose: false
+                    },
+                    "uSAEnvironmentAmbient": {
+                        type: "vec3",
+                        value: new THREE.Vector3(1, 1, 1),
+                        expose: false
+                    },
+                    "uSAEnvironmentStrength": {
+                        type: "float",
+                        value: 0.0,
+                        expose: false
                     },
                     // Light arrays
                     "uLightPos": {
@@ -6150,6 +6333,9 @@ uniform int max_light_number;
 
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
+uniform int uSAEnvironmentEnabled;
+uniform vec3 uSAEnvironmentAmbient;
+uniform float uSAEnvironmentStrength;
 
 uniform float uExposure;
 uniform int uToneMapping;
@@ -6413,6 +6599,10 @@ void main() {
     float ambientOcclusion = 1.0;
 
     vec3 ambientLight = max(uAmbientColor, vec3(0.0)) * max(uAmbient, 0.0);
+    if (uSAEnvironmentEnabled == 1) {
+        ambientLight += max(uSAEnvironmentAmbient, vec3(0.0)) *
+            max(uSAEnvironmentStrength, 0.0);
+    }
     ambientLight *= ambientOcclusion;
 
     float directAO = mix(1.0, ambientOcclusion, clamp(uAODirectInfluence, 0.0, 1.0));
@@ -6593,6 +6783,9 @@ uniform int uLightShadowIndex[16];
 
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
+uniform int uSAEnvironmentEnabled;
+uniform vec3 uSAEnvironmentAmbient;
+uniform float uSAEnvironmentStrength;
 
 uniform float uExposure;
 uniform int uToneMapping;
@@ -6973,6 +7166,10 @@ void main() {
     float ambientOcclusion = 1.0;
 
     vec3 ambientLight = max(uAmbientColor, vec3(0.0)) * max(uAmbient, 0.0);
+    if (uSAEnvironmentEnabled == 1) {
+        ambientLight += max(uSAEnvironmentAmbient, vec3(0.0)) *
+            max(uSAEnvironmentStrength, 0.0);
+    }
     ambientLight *= ambientOcclusion;
 
     float directAO = mix(1.0, ambientOcclusion, clamp(uAODirectInfluence, 0.0, 1.0));
@@ -7159,6 +7356,9 @@ uniform int max_light_number;
 /* Ambient */
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
+uniform int uSAEnvironmentEnabled;
+uniform vec3 uSAEnvironmentAmbient;
+uniform float uSAEnvironmentStrength;
 
 /* Artistic controls */
 uniform float uExposure;
@@ -7190,6 +7390,7 @@ uniform float uShadowFloor;
 */
 uniform float shadowPixelResolution;
 uniform float shadowThreshold;
+uniform bool PIXELATED_SHADOWS;
 uniform float shadowFilterScale;
 uniform float shadowFeather;
 
@@ -7502,6 +7703,7 @@ vec4 getPointShadowCoordAtUV(
 }
 
 float pixelShadowMask(float visibility) {
+    if (!PIXELATED_SHADOWS) return visibility;
     float threshold = clamp(shadowThreshold, 0.0, 1.0);
     float feather = clamp(shadowFeather, 0.0, 0.49);
 
@@ -7776,6 +7978,10 @@ float getPixelatedLightShadow(
 ) {
     if (uLightCastShadow[lightIndex] == 0) {
         return 1.0;
+    }
+
+    if (!PIXELATED_SHADOWS) {
+        targetUV = currentUV;
     }
 
     int shadowIndex = uLightShadowIndex[lightIndex];
@@ -8061,6 +8267,10 @@ void main() {
     vec3 ambientLight =
         max(uAmbientColor, vec3(0.0)) *
         max(uAmbient, 0.0);
+    if (uSAEnvironmentEnabled == 1) {
+        ambientLight += max(uSAEnvironmentAmbient, vec3(0.0)) *
+            max(uSAEnvironmentStrength, 0.0);
+    }
 
     ambientLight *= ambientOcclusion;
 
@@ -8144,6 +8354,13 @@ void main() {
                         step: 0.05,
                         allow_higher: true,
                         allow_lower: false
+                    },
+
+                    "PIXELATED_SHADOWS": {
+                        type: "bool",
+                        value: true,
+                        expose: true,
+                        advanced: false
                     },
 
                     "shadowThreshold": {
@@ -10253,6 +10470,9 @@ uniform int uLightShadowIndex[16];
 
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
+uniform int uSAEnvironmentEnabled;
+uniform vec3 uSAEnvironmentAmbient;
+uniform float uSAEnvironmentStrength;
 
 uniform float uExposure;
 uniform int uToneMapping;
@@ -10381,6 +10601,10 @@ ${lumaForgeLightflowHelpers}`
         vec3 ambientLight =
             max(uAmbientColor, vec3(0.0)) *
             max(uAmbient, 0.0);
+        if (uSAEnvironmentEnabled == 1) {
+            ambientLight += max(uSAEnvironmentAmbient, vec3(0.0)) *
+                max(uSAEnvironmentStrength, 0.0);
+        }
         ambientLight *= ambientOcclusion;
 
         float directAO = mix(
@@ -10646,6 +10870,7 @@ ${lumaForgeLightflowHelpers}`
                 enumerable: false
             });
             this.materials['pbr_metallic_roughness'] = pbr_metallic_roughness;
+            this.materials['vibrant_visuals_pbr'] = vibrant_visuals_pbr;
             this.materials['pixelated_shaded_lightflow'] = pixelated_shaded_lightflow;
             this.materials['minecraft_promotional_bevel'] = minecraft_promotional_bevel;
             this.materials['cinematic_craft'] = cinematic_craft;
@@ -10951,7 +11176,23 @@ ${lumaForgeLightflowHelpers}`
             ensureUniform('uSA_SSRCameraFar', () => 1000.0);
             ensureUniform('uSA_SSRCameraIsPerspective', () => 1);
             ensureUniform('uSA_SSRCameraProjectionMatrix', () => new THREE.Matrix4());
+            ensureUniform('uSA_SSRViewToWorld', () => new THREE.Matrix4());
             ensureUniform('uSA_SSRTime', () => 0.0);
+            ensureUniform('uSA_EnvironmentEnabled', () => 0);
+            ensureUniform('uSA_EnvironmentZenith', () => new THREE.Vector3(0.47, 0.65, 1.0));
+            ensureUniform('uSA_EnvironmentHorizon', () => new THREE.Vector3(0.72, 0.82, 1.0));
+            ensureUniform('uSA_EnvironmentGround', () => new THREE.Vector3(0.2, 0.24, 0.28));
+            ensureUniform('uSA_EnvironmentCelestialDirection', () => new THREE.Vector3(0, 1, 0));
+            ensureUniform('uSA_EnvironmentCelestialColor', () => new THREE.Vector3(1.0, 0.95, 0.75));
+            ensureUniform('uSA_EnvironmentCelestialSize', () => 0.055);
+            ensureUniform('uSA_EnvironmentCloudColor', () => new THREE.Vector3(0.95, 0.96, 0.98));
+            ensureUniform('uSA_EnvironmentCloudCoverage', () => 0.54);
+            ensureUniform('uSA_EnvironmentCloudOpacity', () => 0.0);
+            ensureUniform('uSA_EnvironmentCloudTime', () => 0.0);
+            ensureUniform('uSA_EnvironmentDaylight', () => 1.0);
+            ensureUniform('uSA_EnvironmentTwilight', () => 0.0);
+            ensureUniform('uSA_EnvironmentVibrant', () => 0.0);
+            ensureUniform('uSA_EnvironmentIntensity', () => 0.0);
             return true;
         },
 
@@ -10982,6 +11223,35 @@ ${lumaForgeLightflowHelpers}`
             if (camera && camera.projectionMatrix) {
                 uniforms.uSA_SSRCameraProjectionMatrix.value.copy(camera.projectionMatrix);
             }
+            if (camera && camera.matrixWorld) {
+                uniforms.uSA_SSRViewToWorld.value.copy(camera.matrixWorld);
+            }
+            const environment = window.LightflowEnvironment?.getLightingState?.();
+            const copyEnvironmentColor = (uniformName, source, fallback) => {
+                const value = Array.isArray(source) ? source : fallback;
+                uniforms[uniformName].value.set(
+                    Number(value[0]) || 0,
+                    Number(value[1]) || 0,
+                    Number(value[2]) || 0
+                );
+            };
+            uniforms.uSA_EnvironmentEnabled.value = environment?.enabled ? 1 : 0;
+            uniforms.uSA_EnvironmentIntensity.value = environment?.enabled
+                ? Math.max(0, Number(environment.environmentIntensity) || 0)
+                : 0;
+            copyEnvironmentColor('uSA_EnvironmentZenith', environment?.zenithColor, [0.47, 0.65, 1.0]);
+            copyEnvironmentColor('uSA_EnvironmentHorizon', environment?.horizonColor, [0.72, 0.82, 1.0]);
+            copyEnvironmentColor('uSA_EnvironmentGround', environment?.groundColor, [0.2, 0.24, 0.28]);
+            copyEnvironmentColor('uSA_EnvironmentCelestialDirection', environment?.celestialDirection, [0, 1, 0]);
+            copyEnvironmentColor('uSA_EnvironmentCelestialColor', environment?.sunColor, [1.0, 0.95, 0.75]);
+            copyEnvironmentColor('uSA_EnvironmentCloudColor', environment?.cloudColor, [0.95, 0.96, 0.98]);
+            uniforms.uSA_EnvironmentCelestialSize.value = Math.max(0.001, Number(environment?.celestialSize) || 0.055);
+            uniforms.uSA_EnvironmentCloudCoverage.value = Math.max(0, Math.min(1, Number(environment?.cloudCoverage) || 0));
+            uniforms.uSA_EnvironmentCloudOpacity.value = Math.max(0, Math.min(1, Number(environment?.cloudOpacity) || 0));
+            uniforms.uSA_EnvironmentCloudTime.value = Number(environment?.cloudTime) || 0;
+            uniforms.uSA_EnvironmentDaylight.value = Math.max(0, Math.min(1, Number(environment?.daylight) || 0));
+            uniforms.uSA_EnvironmentTwilight.value = Math.max(0, Math.min(1, Number(environment?.twilight) || 0));
+            uniforms.uSA_EnvironmentVibrant.value = environment?.vibrant ? 1 : 0;
             uniforms.uSA_SSRTime.value = performance.now() * 0.001;
             material.uniformsNeedUpdate = true;
         },
@@ -11129,6 +11399,13 @@ ${lumaForgeLightflowHelpers}`
                     preview.render();
                 }
             });
+        },
+
+        invalidateEnvironment() {
+            this.states.forEach(state => {
+                state.hasCaptured = false;
+            });
+            this.refresh();
         }
     };
 
@@ -16141,8 +16418,13 @@ ${stochasticAlpha
             this.cancelPendingLightUniformUpdate();
 
             const lights = (window.LightElement && Array.isArray(window.LightElement.all))
-                ? window.LightElement.all
+                ? window.LightElement.all.slice()
                 : [];
+            const environmentLight = window.LightflowEnvironment?.getVirtualLight?.();
+            if (environmentLight && !lights.some(light => light?.uuid === environmentLight.uuid)) {
+                // Keep the environment sun/moon inside the 16-light budget.
+                lights.unshift(environmentLight);
+            }
 
             const MAX_LIGHTS = 16;
 
@@ -16439,6 +16721,7 @@ ${stochasticAlpha
             };
 
             const updatedUniformGroups = new Set();
+            const environmentState = window.LightflowEnvironment?.getLightingState?.();
             this.getLightUniformMaterials().forEach(mat => {
                 if (!mat || !mat.uniforms) return;
 
@@ -16447,6 +16730,31 @@ ${stochasticAlpha
                 updatedUniformGroups.add(uniformGroupKey);
 
                 let lightUniformsUpdated = false;
+
+                const environmentEnabled = !!environmentState?.enabled;
+                const environmentAmbient = Array.isArray(environmentState?.ambientColor)
+                    ? environmentState.ambientColor
+                    : [1, 1, 1];
+                const environmentStrength = environmentEnabled
+                    ? Math.max(0, Number(environmentState.ambientIntensity) || 0)
+                    : 0;
+                ensureUniform(mat, 'uSAEnvironmentEnabled', () => 0).value = environmentEnabled ? 1 : 0;
+                const environmentUniform = ensureUniform(
+                    mat,
+                    'uSAEnvironmentAmbient',
+                    () => new THREE.Vector3(1, 1, 1)
+                );
+                environmentUniform.value = toVector3(
+                    environmentUniform.value,
+                    () => new THREE.Vector3(1, 1, 1)
+                );
+                environmentUniform.value.set(
+                    Number(environmentAmbient[0]) || 0,
+                    Number(environmentAmbient[1]) || 0,
+                    Number(environmentAmbient[2]) || 0
+                );
+                ensureUniform(mat, 'uSAEnvironmentStrength', () => 0).value = environmentStrength;
+                lightUniformsUpdated = true;
 
                 if (mat.uniforms.max_light_number) {
                     mat.uniforms.max_light_number.value = activeLightCount;
@@ -18598,7 +18906,7 @@ ${stochasticAlpha
         author: 'MidFord327',
         description: 'Build advanced Blockbench materials with real-time Lightflow presets, editable GLSL, material instances, and deep Light Manager integration. Requires Light Manager for lights and shadows.',
         tags: ['Lightflow', 'Shaders', 'Materials', 'Rendering', 'GLSL', 'Lighting'],
-        version: '2.6.0',
+        version: '2.7.0',
         min_version: '4.9.0',
         variant: 'both',
 

--- a/shader_architect.js
+++ b/shader_architect.js
@@ -2091,6 +2091,44 @@ vec3 saApplyBlockbenchRenderModeEmission(vec3 litColor, vec3 baseColor, float al
         return target;
     }
 
+    /*
+        Three r129 defines this helper in <bsdfs>, while <lights_pars_begin>
+        calls it. Lightflow's custom shaders intentionally do not include
+        <bsdfs> because they provide their own BRDF functions. Keep the
+        compatibility overloads local to those shaders instead of mutating
+        THREE.ShaderChunk.common and breaking stock Lambert/Phong programs.
+    */
+    const LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT = `
+#ifndef SA_PUNCTUAL_LIGHT_COMPAT
+#define SA_PUNCTUAL_LIGHT_COMPAT
+float punctualLightIntensityToIrradianceFactor(
+    const in float lightDistance,
+    const in float cutoffDistance,
+    const in float decayExponent
+) {
+#if defined(PHYSICALLY_CORRECT_LIGHTS)
+    float distanceFalloff = 1.0 / max(pow(lightDistance, decayExponent), 0.01);
+    if (cutoffDistance > 0.0) {
+        distanceFalloff *= pow2(saturate(1.0 - pow4(lightDistance / cutoffDistance)));
+    }
+    return distanceFalloff;
+#else
+    if (cutoffDistance > 0.0 && decayExponent > 0.0) {
+        return pow(saturate(-lightDistance / cutoffDistance + 1.0), decayExponent);
+    }
+    return 1.0;
+#endif
+}
+
+float punctualLightIntensityToIrradianceFactor(
+    const in float lightDistance,
+    const in float cutoffDistance
+) {
+    return punctualLightIntensityToIrradianceFactor(lightDistance, cutoffDistance, 1.0);
+}
+#endif
+`;
+
     const SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT = `
 #define SA_SSR_STEPS 56
 
@@ -4807,6 +4845,7 @@ void main() {
 }`,
                 fragment: `#include <common>
 #include <packing>
+${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
 #include <shadowmap_pars_fragment>
 ${SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT}
@@ -6756,6 +6795,7 @@ void main() {
 }`,
                 fragment: `#include <common>
 #include <packing>
+${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
 #include <shadowmap_pars_fragment>
 ${SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT}
@@ -7332,6 +7372,7 @@ void main() {
 
                 fragment: `#include <common>
 #include <packing>
+${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
 #include <shadowmap_pars_fragment>
 
@@ -7352,6 +7393,9 @@ uniform float uLightPenumbra[16];
 uniform int uLightType[16];
 uniform vec3 uLightColor[16];
 uniform int max_light_number;
+
+uniform int uLightCastShadow[16];
+uniform int uLightShadowIndex[16];
 
 /* Ambient */
 uniform float uAmbient;
@@ -10454,6 +10498,7 @@ varying vec4 vSA_SSRClipPosition;
 uniform sampler2D map;`,
                     `#include <common>
 #include <packing>
+${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
 #include <shadowmap_pars_fragment>
 ${SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT}
@@ -10750,6 +10795,7 @@ ${lumaForgeLightflowHelpers}`
                 fragment: `
                                 #include <common>
                                 #include <packing>
+                                ${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
                                 #include <lights_pars_begin>
                                 #include <shadowmap_pars_fragment>
                                 #include <shadowmask_pars_fragment>
@@ -11361,32 +11407,55 @@ ${lumaForgeLightflowHelpers}`
             const previousTarget = renderer.getRenderTarget();
             const previousAutoClear = renderer.autoClear;
             const hiddenMeshes = this.setReflectiveMeshesVisible(false);
+            const fallbackTexture = this.getFallbackTexture();
+            let captureSucceeded = false;
+
+            /*
+                Never sample captureTarget while it is the active framebuffer.
+                Reflective meshes are hidden for the clean capture, but pooled
+                materials or auxiliary preview objects can still retain the
+                same SSR uniforms. Binding the fallback closes that path and
+                prevents WebGL feedback-loop errors.
+            */
+            materials.forEach(material => {
+                if (!this.ensureMaterialUniforms(material)) return;
+                material.uniforms.uSA_SSRScene.value = fallbackTexture;
+                material.uniforms.uSA_SSRDepth.value = fallbackTexture;
+                material.uniforms.uSA_SSRHasDepth.value = 0;
+                material.uniformsNeedUpdate = true;
+            });
 
             try {
                 renderer.autoClear = true;
                 renderer.setRenderTarget(state.captureTarget);
                 renderer.clear(true, true, true);
                 renderer.render(Canvas.scene, camera);
-                renderer.setRenderTarget(previousTarget);
-                renderer.autoClear = previousAutoClear;
-                this.restoreMeshVisibility(hiddenMeshes);
-                this.invalidateShadowMaps(preview, {
-                    studio: !!preview.sa_studio_render_active
-                });
                 state.hasCaptured = true;
                 state.lastCaptureFrame = state.frameIndex;
-
-                materials.forEach(material => {
-                    this.updateMaterialUniformsForPreview(material, state, camera);
-                });
+                captureSucceeded = true;
             } catch (error) {
+                state.hasCaptured = false;
+            } finally {
                 renderer.setRenderTarget(previousTarget);
                 renderer.autoClear = previousAutoClear;
                 this.restoreMeshVisibility(hiddenMeshes);
                 this.invalidateShadowMaps(preview, {
                     studio: !!preview.sa_studio_render_active
                 });
-            } finally {
+
+                if (captureSucceeded) {
+                    materials.forEach(material => {
+                        this.updateMaterialUniformsForPreview(material, state, camera);
+                    });
+                } else {
+                    materials.forEach(material => {
+                        if (!this.ensureMaterialUniforms(material)) return;
+                        material.uniforms.uSA_SSRScene.value = fallbackTexture;
+                        material.uniforms.uSA_SSRDepth.value = fallbackTexture;
+                        material.uniforms.uSA_SSRHasDepth.value = 0;
+                        material.uniformsNeedUpdate = true;
+                    });
+                }
                 state.capturing = false;
             }
         },
@@ -18906,7 +18975,7 @@ ${stochasticAlpha
         author: 'MidFord327',
         description: 'Build advanced Blockbench materials with real-time Lightflow presets, editable GLSL, material instances, and deep Light Manager integration. Requires Light Manager for lights and shadows.',
         tags: ['Lightflow', 'Shaders', 'Materials', 'Rendering', 'GLSL', 'Lighting'],
-        version: '2.7.0',
+        version: '2.7.1',
         min_version: '4.9.0',
         variant: 'both',
 

--- a/shader_architect.js
+++ b/shader_architect.js
@@ -546,8 +546,8 @@
     // =========================================================================
     Language.addTranslations('en', {
         'panel.global_renderer_properties': 'WORLD',
-        'panel.material_instance_manager': 'OVERRIDES',
-        'panel.material_properties': 'MATERIAL',
+        'panel.material_instance_manager': 'INSTANCES',
+        'panel.material_properties': 'OVERRIDES',
 
         'shader_architect.material_panel.no_selected': 'Select a single cube or multiple cubes to edit their material instance properties.',
         'shader_architect.material_panel.no_instance': 'Create a material instance to override the global material on this cube.',
@@ -556,6 +556,9 @@
         'shader_architect.material_panel.properties': 'Material Instance Properties',
 
         'shader_architect.material_panel.title': 'Material Instance',
+        'shader_architect.material_panel.instances_title': 'INSTANCES',
+        'shader_architect.material_panel.overrides_title': 'OVERRIDES',
+        'shader_architect.material_panel.scope': 'Override Scope',
         'shader_architect.material_panel.global_material': 'Global Material',
         'shader_architect.material_panel.element_material': 'Element Material',
         'shader_architect.material_panel.mixed_instances': '(Mixed Instances)',
@@ -630,6 +633,8 @@
         "shader_architect.world.brightness": "Brightness",
         "shader_architect.world.brightness.desc": "Global Blockbench viewport brightness.",
         "shader_architect.world.shading": "Shading",
+        "shader_architect.world.ao": "Ambient Occlusion",
+        "shader_architect.world.ao_settings": "Ambient Occlusion Settings",
         "shader_architect.world.grids": "Grid",
         "shader_architect.world.ground": "Ground",
         "shader_architect.material.new_material": "New Material",
@@ -923,7 +928,7 @@
         "shader_architect.uniform.uSSSAmbient": "SSS Ambient",
         "shader_architect.uniform.uSSSAmbient.desc": "Soft ambient energy returned by the scattering medium",
         "shader_architect.uniform.uSSSShadowMix": "SSS Shadows",
-        "shader_architect.uniform.uSSSShadowMix.desc": "How strongly cast shadows block subsurface light",
+        "shader_architect.uniform.uSSSShadowMix.desc": "Additional subsurface attenuation inside cast-shadow penumbras (never bypasses full occlusion)",
         "shader_architect.uniform.uSSSUseNativePBR": "Native PBR SSS",
         "shader_architect.uniform.uSSSUseNativePBR.desc": "Read Blockbench material-config SSS and MER Subsurface alpha automatically",
         "shader_architect.uniform.uUseSSSMaskMap": "MER SSS Mask",
@@ -1024,20 +1029,16 @@
         "shader_architect.uniform.uSSRRenderScale.desc": "Internal capture resolution scale for screen-space reflections",
         "shader_architect.uniform.uSSRFrameInterval": "SSR Refresh",
         "shader_architect.uniform.uSSRFrameInterval.desc": "How often reflections refresh while previewing",
-        "shader_architect.uniform.shadowPixelResolution": "Pixel Size",
-        "shader_architect.uniform.shadowPixelResolution.desc": "Size of the pixelated shadow grid",
-        "shader_architect.uniform.shadowThreshold": "Cutoff",
-        "shader_architect.uniform.shadowThreshold.desc": "Shadow threshold for the pixelated shadow mask",
-        "shader_architect.uniform.PIXELATED_SHADOWS": "Pixelated Shadows",
-        "shader_architect.uniform.PIXELATED_SHADOWS.desc": "Switch the Vibrant Visuals-style stepped shadow response without changing material",
-        "shader_architect.uniform.uPixelatedShadows": "Pixelated Shadows",
-        "shader_architect.uniform.uPixelatedShadows.desc": "Quantize PBR shadow visibility into stable screen-space pixel cells",
-        "shader_architect.uniform.uPixelShadowSteps": "Shadow Tone Steps",
-        "shader_architect.uniform.uPixelShadowScale": "Shadow Pixel Size",
-        "shader_architect.uniform.shadowFilterScale": "Filter Scale",
-        "shader_architect.uniform.shadowFilterScale.desc": "Multiplies the light shadow softness used by pixelated shadows",
-        "shader_architect.uniform.shadowFeather": "Feather",
-        "shader_architect.uniform.shadowFeather.desc": "Softens the pixelated shadow threshold instead of making it fully binary",
+        "shader_architect.uniform.uLFPixelatedShadowsEnabled": "Pixel Shadows",
+        "shader_architect.uniform.uLFPixelatedShadowsEnabled.desc": "Enables pixel-aligned shadow sampling on model faces",
+        "shader_architect.uniform.uLFPixelatedShadowResolution": "Shadow Scale",
+        "shader_architect.uniform.uLFPixelatedShadowResolution.desc": "Controls the pixel grid density used to sample shadows",
+        "shader_architect.uniform.uLFPixelatedShadowLevels": "Shadow Steps",
+        "shader_architect.uniform.uLFPixelatedShadowLevels.desc": "Quantizes shadow intensity into a fixed number of levels; zero keeps smooth intensity",
+        "shader_architect.uniform.uLFPixelatedShadowGlobalResolution": "Global Grid",
+        "shader_architect.uniform.uLFPixelatedShadowGlobalResolution.desc": "Uses the physical face size instead of the UV region to calculate shadow pixels",
+        "shader_architect.uniform.uLFPixelatedShadowStrength": "Pixel Strength",
+        "shader_architect.uniform.uLFPixelatedShadowStrength.desc": "Controls how strongly pixelated shadows replace the original shadow result",
         "shader_architect.uniform.AUTO_TILE": "Auto Tile",
         "shader_architect.uniform.AUTO_TILE.desc": "Scale texture tiling from face size",
         "shader_architect.uniform.TILING": "Tiling",
@@ -1072,14 +1073,17 @@
 
     Language.addTranslations('es', {
         'panel.global_renderer_properties': 'MUNDO',
-        'panel.material_instance_manager': 'OVERRIDES',
-        'panel.material_properties': 'MATERIAL',
+        'panel.material_instance_manager': 'INSTANCIAS',
+        'panel.material_properties': 'REEMPLAZOS',
         'shader_architect.material_panel.no_selected': 'Selecciona uno o varios cubos para editar sus instancias de material.',
         'shader_architect.material_panel.no_instance': 'Crea una instancia de material para sobrescribir el material global en este cubo.',
         'shader_architect.material_panel.no_face_instance': 'Asigna una instancia de material a esta cara para sobrescribir el material del elemento.',
         'shader_architect.material_panel.multiple_instances': 'Hay varias instancias de material seleccionadas. Todos los cubos seleccionados deben compartir la misma instancia.',
         'shader_architect.material_panel.properties': 'Propiedades de instancia de material',
         'shader_architect.material_panel.title': 'Instancia de material',
+        'shader_architect.material_panel.instances_title': 'INSTANCIAS',
+        'shader_architect.material_panel.overrides_title': 'REEMPLAZOS',
+        'shader_architect.material_panel.scope': 'Alcance del reemplazo',
         'shader_architect.material_panel.global_material': 'Material global',
         'shader_architect.material_panel.element_material': 'Material del elemento',
         'shader_architect.material_panel.mixed_instances': '(Instancias diferentes)',
@@ -1154,6 +1158,8 @@
         "shader_architect.world.brightness": "Brillo",
         "shader_architect.world.brightness.desc": "Brillo global del viewport de Blockbench.",
         "shader_architect.world.shading": "Sombreado",
+        "shader_architect.world.ao": "Oclusión ambiental",
+        "shader_architect.world.ao_settings": "Ajustes de oclusión ambiental",
         "shader_architect.world.grids": "Grid",
         "shader_architect.world.ground": "Suelo",
         "shader_architect.material.new_material": "Material nuevo",
@@ -1297,7 +1303,7 @@
         "shader_architect.uniform.uSSSAmbient": "Ambiente SSS",
         "shader_architect.uniform.uSSSAmbient.desc": "Energia ambiente suave devuelta por el medio",
         "shader_architect.uniform.uSSSShadowMix": "Sombras SSS",
-        "shader_architect.uniform.uSSSShadowMix.desc": "Cuanto bloquean las sombras proyectadas la luz subsuperficial",
+        "shader_architect.uniform.uSSSShadowMix.desc": "Atenuacion subsuperficial adicional en la penumbra (nunca atraviesa una oclusion total)",
         "shader_architect.uniform.uSSSUseNativePBR": "SSS PBR Nativo",
         "shader_architect.uniform.uSSSUseNativePBR.desc": "Lee automaticamente el SSS del material y el alfa MER Subsurface de Blockbench",
         "shader_architect.uniform.uUseSSSMaskMap": "Mascara MER SSS",
@@ -1552,14 +1558,16 @@
         "shader_architect.uniform.AUTO_TILE.desc": "Ajusta repeticion por tamano de cara",
         "shader_architect.uniform.TILING": "Tile",
         "shader_architect.uniform.TILING.desc": "Repeticion manual de textura",
-        "shader_architect.uniform.shadowPixelResolution": "Pixel",
-        "shader_architect.uniform.shadowPixelResolution.desc": "Tamano del pixel de sombra",
-        "shader_architect.uniform.shadowThreshold": "Corte",
-        "shader_architect.uniform.shadowThreshold.desc": "Umbral de sombra pixelada",
-        "shader_architect.uniform.shadowFilterScale": "Escala de filtro",
-        "shader_architect.uniform.shadowFilterScale.desc": "Multiplica la suavidad de sombra de la luz usada por sombras pixeladas",
-        "shader_architect.uniform.shadowFeather": "Pluma",
-        "shader_architect.uniform.shadowFeather.desc": "Suaviza el umbral de sombra pixelada en vez de hacerlo completamente binario",
+        "shader_architect.uniform.uLFPixelatedShadowsEnabled": "Sombras píxel",
+        "shader_architect.uniform.uLFPixelatedShadowsEnabled.desc": "Activa el muestreo de sombras alineado con los píxeles de las caras",
+        "shader_architect.uniform.uLFPixelatedShadowResolution": "Escala sombra",
+        "shader_architect.uniform.uLFPixelatedShadowResolution.desc": "Controla la densidad de la cuadrícula de píxeles utilizada para muestrear las sombras",
+        "shader_architect.uniform.uLFPixelatedShadowLevels": "Niveles sombra",
+        "shader_architect.uniform.uLFPixelatedShadowLevels.desc": "Reduce la intensidad de la sombra a una cantidad fija de niveles; cero conserva una intensidad continua",
+        "shader_architect.uniform.uLFPixelatedShadowGlobalResolution": "Cuadrícula global",
+        "shader_architect.uniform.uLFPixelatedShadowGlobalResolution.desc": "Usa el tamaño físico de la cara en vez de la región UV para calcular los píxeles de sombra",
+        "shader_architect.uniform.uLFPixelatedShadowStrength": "Fuerza píxel",
+        "shader_architect.uniform.uLFPixelatedShadowStrength.desc": "Controla cuánto reemplazan las sombras pixeladas al resultado de sombra original",
         "shader_architect.uniform.uShadowStrength": "Sombra",
         "shader_architect.uniform.uShadowStrength.desc": "Intensidad de las sombras proyectadas",
         "shader_architect.uniform.uShadowFloor": "Min Sombra",
@@ -1970,7 +1978,7 @@ vec3 saApplyBlockbenchRenderModeEmission(vec3 litColor, vec3 baseColor, float al
         if (/^(BEVEL_|EDGE_FALLBACK_LIGHT_DIRECTION)/.test(name)) return 'bevel';
         if (/^OUTLINE_/.test(name)) return 'outline';
         if (/^PROMO_RIM_/.test(name)) return 'rim';
-        if (name === 'SHADOWS' || /^(uShadow|shadowPixelResolution|shadowThreshold)/.test(name)) return 'shadows';
+        if (name === 'SHADOWS' || /^(uShadow|uLFPixelatedShadow)/.test(name)) return 'shadows';
         if (/^uAO/.test(name)) return 'ao';
         if (name === 'map' || name === 'AUTO_TILE' || name === 'TILING' || /Map|TEXTURE_SIZE/.test(name)) {
             return 'texture';
@@ -2383,6 +2391,841 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
     return sourceColor;
 }
 `;
+
+    const LIGHTFLOW_TEXTURE_TILING = /* glsl */`
+#ifndef LIGHTFLOW_TEXTURE_TILING_MODULE
+#define LIGHTFLOW_TEXTURE_TILING_MODULE
+
+uniform bool AUTO_TILE;
+uniform vec2 TILING;
+uniform vec2 TEXTURE_SIZE;
+
+vec2 lfResolveTextureTiling(vec2 faceSize) {
+    if (AUTO_TILE) {
+        return abs(faceSize) /
+            max(abs(TEXTURE_SIZE), vec2(1.0));
+    }
+
+    return TILING;
+}
+
+#endif
+`;
+
+    const LIGHTFLOW_PIXELATED_SHADOWS_VERTEX = /* glsl */`
+#ifndef LIGHTFLOW_PIXELATED_SHADOWS_VERTEX_MODULE
+#define LIGHTFLOW_PIXELATED_SHADOWS_VERTEX_MODULE
+
+#include <shadowmap_pars_vertex>
+
+uniform float uLFPixelatedShadowResolution;
+uniform bool uLFPixelatedShadowGlobalResolution;
+
+varying vec2 lfVPixelatedShadowFaceUv;
+varying vec2 lfVPixelatedShadowGrid;
+varying float lfVPixelatedShadowInfluence;
+
+vec3 lfSafeShadowNormal(vec3 normalValue) {
+    float lengthSquared = dot(normalValue, normalValue);
+
+    if (lengthSquared <= 1e-12) {
+        return vec3(0.0, 1.0, 0.0);
+    }
+
+    return normalValue * inversesqrt(lengthSquared);
+}
+
+/*
+    worldPosition:
+        Posición mundial final del vértice.
+
+    worldNormal:
+        Normal física mundial. No debe ser la normal estilizada,
+        ya que shadowNormalBias debe seguir la geometría real.
+
+    normalizedFaceUv:
+        UV local de la cara, normalmente entre 0 y 1.
+
+    faceSize:
+        Tamaño global de la cara en píxeles o unidades voxel.
+
+    uvSize:
+        Tamaño normalizado de la región UV.
+
+    affectedByShadow:
+        Influencia por cara, entre 0 y 1.
+*/
+void lfPixelatedShadowVertexSetup(
+    const in vec4 worldPosition,
+    const in vec3 worldNormal,
+    const in vec2 normalizedFaceUv,
+    const in vec2 faceSize,
+    const in vec2 uvSize,
+    const in float affectedByShadow
+) {
+    lfVPixelatedShadowFaceUv = normalizedFaceUv;
+
+    vec2 baseGrid = uLFPixelatedShadowGlobalResolution
+        ? faceSize
+        : uvSize * faceSize;
+
+    lfVPixelatedShadowGrid = max(
+        baseGrid * max(uLFPixelatedShadowResolution, 0.0),
+        vec2(1.0)
+    );
+
+    lfVPixelatedShadowInfluence =
+        clamp(affectedByShadow, 0.0, 1.0);
+
+#ifdef USE_SHADOWMAP
+
+    vec3 shadowWorldNormal =
+        lfSafeShadowNormal(worldNormal);
+
+    vec4 shadowWorldPosition;
+
+#if NUM_DIR_LIGHT_SHADOWS > 0
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
+        shadowWorldPosition =
+            worldPosition +
+            vec4(
+                shadowWorldNormal *
+                directionalLightShadows[i].shadowNormalBias,
+                0.0
+            );
+
+        vDirectionalShadowCoord[i] =
+            directionalShadowMatrix[i] *
+            shadowWorldPosition;
+    }
+    #pragma unroll_loop_end
+
+#endif
+
+#if NUM_SPOT_LIGHT_SHADOWS > 0
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
+        shadowWorldPosition =
+            worldPosition +
+            vec4(
+                shadowWorldNormal *
+                spotLightShadows[i].shadowNormalBias,
+                0.0
+            );
+
+        vSpotShadowCoord[i] =
+            spotShadowMatrix[i] *
+            shadowWorldPosition;
+    }
+    #pragma unroll_loop_end
+
+#endif
+
+#if NUM_POINT_LIGHT_SHADOWS > 0
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
+        shadowWorldPosition =
+            worldPosition +
+            vec4(
+                shadowWorldNormal *
+                pointLightShadows[i].shadowNormalBias,
+                0.0
+            );
+
+        vPointShadowCoord[i] =
+            pointShadowMatrix[i] *
+            shadowWorldPosition;
+    }
+    #pragma unroll_loop_end
+
+#endif
+
+#endif
+}
+
+#endif
+`;
+
+    const LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT = /* glsl */`
+#ifndef LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT_MODULE
+#define LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT_MODULE
+
+#include <shadowmap_pars_fragment>
+
+uniform bool uLFPixelatedShadowsEnabled;
+uniform float uLFPixelatedShadowResolution;
+uniform float uLFPixelatedShadowLevels;
+uniform float uLFPixelatedShadowStrength;
+uniform bool uLFPixelatedShadowGlobalResolution;
+
+varying vec2 lfVPixelatedShadowFaceUv;
+varying vec2 lfVPixelatedShadowGrid;
+varying float lfVPixelatedShadowInfluence;
+
+#define LFPS_DETERMINANT_EPSILON 1e-12
+#define LFPS_QUALITY_EPSILON 1e-5
+#define LFPS_PROJECTIVE_W_EPSILON 1e-7
+
+#define LFPS_PROJECTED_COORD_MARGIN 0.05
+#define LFPS_PROJECTED_MAX_XY_JUMP 0.25
+#define LFPS_PROJECTED_MAX_Z_JUMP 0.25
+
+#define LFPS_POINT_MIN_LENGTH 1e-6
+#define LFPS_POINT_MAX_ABSOLUTE_JUMP 0.75
+#define LFPS_POINT_MAX_RELATIVE_JUMP 0.35
+
+vec2 lfpsGetPixelCenterUv(
+    vec2 localUv,
+    vec2 requestedGrid
+) {
+    vec2 grid = max(
+        floor(requestedGrid + vec2(0.5)),
+        vec2(1.0)
+    );
+
+    vec2 cell = floor(localUv * grid);
+
+    cell = clamp(
+        cell,
+        vec2(0.0),
+        grid - vec2(1.0)
+    );
+
+    return (cell + vec2(0.5)) / grid;
+}
+
+void lfpsGetUvBasis(
+    vec2 currentUv,
+    out vec2 dUvDx,
+    out vec2 dUvDy,
+    out float inverseDeterminant,
+    out bool valid
+) {
+    dUvDx = dFdx(currentUv);
+    dUvDy = dFdy(currentUv);
+
+    float determinant =
+        dUvDx.x * dUvDy.y -
+        dUvDx.y * dUvDy.x;
+
+    float uvArea =
+        length(dUvDx) *
+        length(dUvDy);
+
+    float absoluteDeterminant =
+        abs(determinant);
+
+    float quality =
+        absoluteDeterminant /
+        max(uvArea, LFPS_DETERMINANT_EPSILON);
+
+    inverseDeterminant = 0.0;
+    valid = false;
+
+    if (
+        absoluteDeterminant > LFPS_DETERMINANT_EPSILON &&
+        quality > LFPS_QUALITY_EPSILON
+    ) {
+        inverseDeterminant = 1.0 / determinant;
+        valid = true;
+    }
+}
+
+vec4 lfpsGetRawShadowCoordAtDelta(
+    vec4 currentShadowCoord,
+    vec2 deltaUv,
+    vec2 dUvDx,
+    vec2 dUvDy,
+    float inverseDeterminant,
+    bool basisIsValid
+) {
+    /*
+        Estas derivadas deben evaluarse antes de cualquier discard
+        y fuera de ramas divergentes dependientes del fragmento.
+    */
+    vec4 dCoordDx = dFdx(currentShadowCoord);
+    vec4 dCoordDy = dFdy(currentShadowCoord);
+
+    if (!basisIsValid) {
+        return currentShadowCoord;
+    }
+
+    vec4 dCoordDu =
+        (
+            dCoordDx * dUvDy.y -
+            dCoordDy * dUvDx.y
+        ) * inverseDeterminant;
+
+    vec4 dCoordDv =
+        (
+            dCoordDy * dUvDx.x -
+            dCoordDx * dUvDy.x
+        ) * inverseDeterminant;
+
+    return currentShadowCoord +
+        dCoordDu * deltaUv.x +
+        dCoordDv * deltaUv.y;
+}
+
+vec4 lfpsGetProjectedShadowCoord(
+    vec4 currentShadowCoord,
+    vec2 deltaUv,
+    vec2 dUvDx,
+    vec2 dUvDy,
+    float inverseDeterminant,
+    bool basisIsValid
+) {
+    vec4 candidate = lfpsGetRawShadowCoordAtDelta(
+        currentShadowCoord,
+        deltaUv,
+        dUvDx,
+        dUvDy,
+        inverseDeterminant,
+        basisIsValid
+    );
+
+    if (
+        !basisIsValid ||
+        currentShadowCoord.w <= LFPS_PROJECTIVE_W_EPSILON ||
+        candidate.w <= LFPS_PROJECTIVE_W_EPSILON
+    ) {
+        return currentShadowCoord;
+    }
+
+    vec3 currentProjected =
+        currentShadowCoord.xyz /
+        currentShadowCoord.w;
+
+    vec3 candidateProjected =
+        candidate.xyz /
+        candidate.w;
+
+    bool candidateInsideBounds =
+        candidateProjected.x >
+            -LFPS_PROJECTED_COORD_MARGIN &&
+        candidateProjected.x <
+            1.0 + LFPS_PROJECTED_COORD_MARGIN &&
+
+        candidateProjected.y >
+            -LFPS_PROJECTED_COORD_MARGIN &&
+        candidateProjected.y <
+            1.0 + LFPS_PROJECTED_COORD_MARGIN &&
+
+        candidateProjected.z >
+            -LFPS_PROJECTED_COORD_MARGIN &&
+        candidateProjected.z <
+            1.0 + LFPS_PROJECTED_COORD_MARGIN;
+
+    bool candidateIsClose =
+        distance(
+            candidateProjected.xy,
+            currentProjected.xy
+        ) < LFPS_PROJECTED_MAX_XY_JUMP &&
+
+        abs(
+            candidateProjected.z -
+            currentProjected.z
+        ) < LFPS_PROJECTED_MAX_Z_JUMP;
+
+    if (
+        candidateInsideBounds &&
+        candidateIsClose
+    ) {
+        return candidate;
+    }
+
+    return currentShadowCoord;
+}
+
+vec4 lfpsGetPointShadowCoord(
+    vec4 currentShadowCoord,
+    vec2 deltaUv,
+    vec2 dUvDx,
+    vec2 dUvDy,
+    float inverseDeterminant,
+    bool basisIsValid
+) {
+    vec4 candidate = lfpsGetRawShadowCoordAtDelta(
+        currentShadowCoord,
+        deltaUv,
+        dUvDx,
+        dUvDy,
+        inverseDeterminant,
+        basisIsValid
+    );
+
+    if (!basisIsValid) {
+        return currentShadowCoord;
+    }
+
+    float currentLength =
+        length(currentShadowCoord.xyz);
+
+    float candidateLength =
+        length(candidate.xyz);
+
+    float allowedJump = max(
+        LFPS_POINT_MAX_ABSOLUTE_JUMP,
+        currentLength *
+            LFPS_POINT_MAX_RELATIVE_JUMP
+    );
+
+    bool candidateIsReasonable =
+        candidateLength > LFPS_POINT_MIN_LENGTH &&
+        abs(
+            candidateLength -
+            currentLength
+        ) < allowedJump;
+
+    if (candidateIsReasonable) {
+        return candidate;
+    }
+
+    return currentShadowCoord;
+}
+
+/*
+    Devuelve:
+
+    x = producto de sombras direccionales
+    y = producto de sombras spot
+    z = producto de sombras puntuales
+*/
+vec3 lfpsGetRawShadowByType() {
+    vec3 shadowByType = vec3(1.0);
+
+#ifdef USE_SHADOWMAP
+
+    /*
+        Ambos son uniforms, por lo que esta rama es uniforme durante
+        todo el draw call y puede evitar el trabajo costoso cuando
+        el efecto está desactivado.
+    */
+    if (
+        !uLFPixelatedShadowsEnabled ||
+        uLFPixelatedShadowResolution <= 0.0 ||
+        uLFPixelatedShadowStrength <= 0.0
+    ) {
+        return shadowByType;
+    }
+
+    vec2 currentUv =
+        lfVPixelatedShadowFaceUv;
+
+    vec2 targetUv = lfpsGetPixelCenterUv(
+        currentUv,
+        lfVPixelatedShadowGrid
+    );
+
+    vec2 deltaUv =
+        targetUv - currentUv;
+
+    vec2 dUvDx;
+    vec2 dUvDy;
+    float inverseDeterminant;
+    bool basisIsValid;
+
+    lfpsGetUvBasis(
+        currentUv,
+        dUvDx,
+        dUvDy,
+        inverseDeterminant,
+        basisIsValid
+    );
+
+    vec4 shadowCoord;
+
+#if NUM_DIR_LIGHT_SHADOWS > 0
+
+    DirectionalLightShadow directionalShadow;
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
+        directionalShadow =
+            directionalLightShadows[i];
+
+        shadowCoord = lfpsGetProjectedShadowCoord(
+            vDirectionalShadowCoord[i],
+            deltaUv,
+            dUvDx,
+            dUvDy,
+            inverseDeterminant,
+            basisIsValid
+        );
+
+        shadowByType.x *= getShadow(
+            directionalShadowMap[i],
+            directionalShadow.shadowMapSize,
+            directionalShadow.shadowBias,
+            directionalShadow.shadowRadius,
+            shadowCoord
+        );
+    }
+    #pragma unroll_loop_end
+
+#endif
+
+#if NUM_SPOT_LIGHT_SHADOWS > 0
+
+    SpotLightShadow spotShadow;
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
+        spotShadow =
+            spotLightShadows[i];
+
+        shadowCoord = lfpsGetProjectedShadowCoord(
+            vSpotShadowCoord[i],
+            deltaUv,
+            dUvDx,
+            dUvDy,
+            inverseDeterminant,
+            basisIsValid
+        );
+
+        shadowByType.y *= getShadow(
+            spotShadowMap[i],
+            spotShadow.shadowMapSize,
+            spotShadow.shadowBias,
+            spotShadow.shadowRadius,
+            shadowCoord
+        );
+    }
+    #pragma unroll_loop_end
+
+#endif
+
+#if NUM_POINT_LIGHT_SHADOWS > 0
+
+    PointLightShadow pointShadow;
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
+        pointShadow =
+            pointLightShadows[i];
+
+        shadowCoord = lfpsGetPointShadowCoord(
+            vPointShadowCoord[i],
+            deltaUv,
+            dUvDx,
+            dUvDy,
+            inverseDeterminant,
+            basisIsValid
+        );
+
+        shadowByType.z *= getPointShadow(
+            pointShadowMap[i],
+            pointShadow.shadowMapSize,
+            pointShadow.shadowBias,
+            pointShadow.shadowRadius,
+            shadowCoord,
+            pointShadow.shadowCameraNear,
+            pointShadow.shadowCameraFar
+        );
+    }
+    #pragma unroll_loop_end
+
+#endif
+
+#endif
+
+    return clamp(
+        shadowByType,
+        vec3(0.0),
+        vec3(1.0)
+    );
+}
+
+float lfpsQuantizeShadow(float shadow) {
+    shadow = clamp(shadow, 0.0, 1.0);
+
+    if (uLFPixelatedShadowLevels <= 0.0) {
+        return shadow;
+    }
+
+    float resolutionLimit = max(
+        floor(
+            max(
+                uLFPixelatedShadowResolution,
+                1.0
+            ) + 0.5
+        ),
+        1.0
+    );
+
+    float levelCount = clamp(
+        floor(
+            uLFPixelatedShadowLevels +
+            0.5
+        ),
+        1.0,
+        resolutionLimit
+    );
+
+    return clamp(
+        floor(
+            shadow * levelCount +
+            0.5
+        ) / levelCount,
+        0.0,
+        1.0
+    );
+}
+
+float lfpsFinalizeShadow(float rawShadow) {
+    float influence = clamp(
+        lfVPixelatedShadowInfluence *
+        uLFPixelatedShadowStrength,
+        0.0,
+        1.0
+    );
+
+    float shadow = mix(
+        1.0,
+        clamp(rawShadow, 0.0, 1.0),
+        influence
+    );
+
+    return lfpsQuantizeShadow(shadow);
+}
+
+/*
+    API simple.
+
+    Multiplica todas las sombras de todas las clases.
+    Ideal cuando existe una única luz principal con sombras.
+*/
+float lfGetPixelatedCombinedShadow() {
+    vec3 rawShadow =
+        lfpsGetRawShadowByType();
+
+    return lfpsFinalizeShadow(
+        rawShadow.x *
+        rawShadow.y *
+        rawShadow.z
+    );
+}
+
+/*
+    API recomendada para Lightflow.
+
+    x = directional
+    y = spot
+    z = point
+*/
+vec3 lfGetPixelatedShadowByType() {
+    vec3 rawShadow =
+        lfpsGetRawShadowByType();
+
+    return vec3(
+        lfpsFinalizeShadow(rawShadow.x),
+        lfpsFinalizeShadow(rawShadow.y),
+        lfpsFinalizeShadow(rawShadow.z)
+    );
+}
+
+vec3 lfApplyPixelatedCombinedShadow(
+    vec3 directLight
+) {
+    return directLight *
+        lfGetPixelatedCombinedShadow();
+}
+
+#endif
+`;
+
+    const LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT = /* glsl */`
+#ifndef LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT_MODULE
+#define LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT_MODULE
+
+uniform int uLightCastShadow[16];
+uniform int uLightShadowIndex[16];
+uniform float uShadowStrength;
+uniform float uShadowFloor;
+
+#define LF_SHADOW_LIGHT_POINT 0
+#define LF_SHADOW_LIGHT_DIRECTIONAL 1
+#define LF_SHADOW_LIGHT_SPOT 2
+
+float lfGetRegularDirectionalShadowByIndex(
+    int shadowIndex
+) {
+    float result = 1.0;
+
+#ifdef USE_SHADOWMAP
+#if NUM_DIR_LIGHT_SHADOWS > 0
+
+    DirectionalLightShadow directionalShadow;
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
+        directionalShadow = directionalLightShadows[i];
+
+        if (UNROLLED_LOOP_INDEX == shadowIndex) {
+            result = getShadow(
+                directionalShadowMap[i],
+                directionalShadow.shadowMapSize,
+                directionalShadow.shadowBias,
+                directionalShadow.shadowRadius,
+                vDirectionalShadowCoord[i]
+            );
+        }
+    }
+    #pragma unroll_loop_end
+
+#endif
+#endif
+
+    return result;
+}
+
+float lfGetRegularSpotShadowByIndex(
+    int shadowIndex
+) {
+    float result = 1.0;
+
+#ifdef USE_SHADOWMAP
+#if NUM_SPOT_LIGHT_SHADOWS > 0
+
+    SpotLightShadow spotShadow;
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
+        spotShadow = spotLightShadows[i];
+
+        if (UNROLLED_LOOP_INDEX == shadowIndex) {
+            result = getShadow(
+                spotShadowMap[i],
+                spotShadow.shadowMapSize,
+                spotShadow.shadowBias,
+                spotShadow.shadowRadius,
+                vSpotShadowCoord[i]
+            );
+        }
+    }
+    #pragma unroll_loop_end
+
+#endif
+#endif
+
+    return result;
+}
+
+float lfGetRegularPointShadowByIndex(
+    int shadowIndex
+) {
+    float result = 1.0;
+
+#ifdef USE_SHADOWMAP
+#if NUM_POINT_LIGHT_SHADOWS > 0
+
+    PointLightShadow pointShadow;
+
+    #pragma unroll_loop_start
+    for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
+        pointShadow = pointLightShadows[i];
+
+        if (UNROLLED_LOOP_INDEX == shadowIndex) {
+            result = getPointShadow(
+                pointShadowMap[i],
+                pointShadow.shadowMapSize,
+                pointShadow.shadowBias,
+                pointShadow.shadowRadius,
+                vPointShadowCoord[i],
+                pointShadow.shadowCameraNear,
+                pointShadow.shadowCameraFar
+            );
+        }
+    }
+    #pragma unroll_loop_end
+
+#endif
+#endif
+
+    return result;
+}
+
+float lfGetRegularShadowForLight(
+    int lightType,
+    int shadowIndex
+) {
+    if (lightType == LF_SHADOW_LIGHT_DIRECTIONAL) {
+        return lfGetRegularDirectionalShadowByIndex(shadowIndex);
+    }
+
+    if (lightType == LF_SHADOW_LIGHT_SPOT) {
+        return lfGetRegularSpotShadowByIndex(shadowIndex);
+    }
+
+    return lfGetRegularPointShadowByIndex(shadowIndex);
+}
+
+float lfGetPixelatedShadowForLightType(
+    vec3 pixelatedShadowByType,
+    int lightType
+) {
+    if (lightType == LF_SHADOW_LIGHT_DIRECTIONAL) {
+        return pixelatedShadowByType.x;
+    }
+
+    if (lightType == LF_SHADOW_LIGHT_SPOT) {
+        return pixelatedShadowByType.y;
+    }
+
+    return pixelatedShadowByType.z;
+}
+
+float lfApplySharedShadowControls(float shadow) {
+    shadow = clamp(shadow, 0.0, 1.0);
+    shadow = max(
+        shadow,
+        clamp(uShadowFloor, 0.0, 1.0)
+    );
+
+    return mix(
+        1.0,
+        shadow,
+        clamp(uShadowStrength, 0.0, 1.0)
+    );
+}
+
+float lfGetLightShadow(
+    int lightIndex,
+    int lightType,
+    vec3 pixelatedShadowByType
+) {
+    if (
+        !receiveShadow ||
+        uLightCastShadow[lightIndex] == 0
+    ) {
+        return 1.0;
+    }
+
+    int shadowIndex = uLightShadowIndex[lightIndex];
+    if (shadowIndex < 0) {
+        return 1.0;
+    }
+
+    float shadow = uLFPixelatedShadowsEnabled
+        ? lfGetPixelatedShadowForLightType(
+            pixelatedShadowByType,
+            lightType
+        )
+        : lfGetRegularShadowForLight(
+            lightType,
+            shadowIndex
+        );
+
+    return lfApplySharedShadowControls(shadow);
+}
+
+#endif
+`;
+
     const pluginStyle = /*css*/`
     /* Dialog Layout Restructuring for fixed window with internal scrollbars */
     #sa_material_studio_dialog {
@@ -3096,6 +3939,10 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                     this.uniforms.map.repeat = false;
                 }
             }
+
+            if (this.uniforms.AUTO_TILE) {
+                this.uniforms.map.repeat = true;
+            }
         }
 
         // Serializer for the JSON format
@@ -3295,7 +4142,7 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                 if (key === 'value' || key === 'hexValue' || key === 'repeat') continue;
                 targetDef[key] = this.cloneUniformValue(baseDef[key]);
             }
-            if (baseDef.repeat !== undefined && targetDef.repeat === undefined) {
+            if (baseDef.repeat !== undefined) {
                 targetDef.repeat = baseDef.repeat;
             }
             return targetDef;
@@ -4455,6 +5302,11 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                     );
                 }
             }
+
+            if (uniforms.AUTO_TILE && uniforms.map) {
+                uniforms.map.repeat = true;
+            }
+
             return uniforms;
         },
 
@@ -4673,16 +5525,18 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                 name: tl('shader_architect.preset.classic'),
                 icon: 'grid_view',
                 isCustom: false,
-                vertex: `
-                    //Classic
-                    attribute float highlight;
+                 vertex: `
+                     //Classic
+                     attribute float highlight;
+                    attribute vec2 globalFaceSize;
 
-                    uniform bool SHADE;
-                    uniform int LIGHTSIDE;
+                     uniform bool SHADE;
+                     uniform int LIGHTSIDE;
 
-                    varying vec2 vUv;
-                    varying float light;
-                    varying float lift;
+                     varying vec2 vUv;
+                    varying vec2 vFaceSize;
+                     varying float light;
+                     varying float lift;
 
                     void main() {
                         if (SHADE) {
@@ -4701,24 +5555,30 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                             light = 1.0;
                         }
 
-                        lift = (highlight == 2.0) ? 0.22 : (highlight == 1.0) ? 0.1 : 0.0;
-                        vUv = uv;
+                         lift = (highlight == 2.0) ? 0.22 : (highlight == 1.0) ? 0.1 : 0.0;
+                         vUv = uv;
+                        vFaceSize = globalFaceSize;
 
-                        gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-                    }
-                `,
-                fragment: `
-                    uniform sampler2D map;
-                    uniform bool EMISSIVE;
-                    uniform vec3 LIGHTCOLOR;
+                         gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                     }
+                 `,
+                 fragment: `
+                    ${LIGHTFLOW_TEXTURE_TILING}
 
-                    varying vec2 vUv;
-                    varying float light;
-                    varying float lift;
+                     uniform sampler2D map;
+                     uniform bool EMISSIVE;
+                     uniform vec3 LIGHTCOLOR;
 
-                    void main() {
-                        vec4 color = texture2D(map, vUv);
-                        if(color.a < 0.01) discard;
+                     varying vec2 vUv;
+                    varying vec2 vFaceSize;
+                     varying float light;
+                     varying float lift;
+
+                     void main() {
+                        vec2 materialUv =
+                            vUv * lfResolveTextureTiling(vFaceSize);
+                        vec4 color = texture2D(map, materialUv);
+                         if(color.a < 0.01) discard;
 
                         if (!EMISSIVE) {
                             gl_FragColor = vec4(lift + color.rgb * light, color.a);
@@ -4732,14 +5592,119 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                             gl_FragColor.rg *= vec2(0.6, 0.7);
                         }
                     }
-                `,
-                uniforms: {
+                 `,
+                 uniforms: {
+                    "map": { type: "sampler2D", value: null, repeat: true, expose: true },
                     "LIGHTCOLOR": { type: "vec3", value: new THREE.Vector3(1, 1, 1), hexValue: "#ffffff", expose: true, is_color: true },
-                    "SHADE": { type: "bool", value: true, expose: true },
-                    "LIGHTSIDE": { type: "int", value: 0, expose: true, min: 0, max: 5, step: 1, allow_higher: false, allow_lower: false },
-                    "EMISSIVE": { type: "bool", value: false, expose: true }
-                }
-            });
+                     "SHADE": { type: "bool", value: true, expose: true },
+                     "LIGHTSIDE": { type: "int", value: 0, expose: true, min: 0, max: 5, step: 1, allow_higher: false, allow_lower: false },
+                    "EMISSIVE": { type: "bool", value: false, expose: true },
+                    "AUTO_TILE": { type: "bool", value: false, expose: true },
+                    "TILING": { type: "vec2", value: new THREE.Vector2(1, 1), expose: true, min: 0.1, max: 10.0, step: 0.1 },
+                    "TEXTURE_SIZE": { type: "vec2", value: new THREE.Vector2(16, 16), expose: false }
+                 }
+             });
+
+            const createLightflowPixelatedShadowUniforms = (options = {}) => {
+                const config = {
+                    enabled: options.enabled ?? false,
+                    resolution: options.resolution ?? 1.0,
+                    levels: options.levels ?? 0,
+                    globalResolution: options.globalResolution ?? false,
+                    strength: options.strength ?? 1.0
+                };
+
+                return {
+                    /*
+                        Master toggle.
+
+                        Mantiene el shader compilado y permite activar o
+                        desactivar el efecto sin reconstruir el material.
+                    */
+                    "uLFPixelatedShadowsEnabled": {
+                        type: "bool",
+                        value: config.enabled,
+                        expose: true,
+                        advanced: false
+                    },
+
+                    /*
+                        Multiplicador de resolución de la cuadrícula.
+
+                        1.0 = un píxel de sombra por píxel lógico.
+                        < 1.0 = bloques de sombra más grandes.
+                        > 1.0 = sombras pixeladas más detalladas.
+                    */
+                    "uLFPixelatedShadowResolution": {
+                        type: "float",
+                        value: config.resolution,
+                        expose: true,
+                        advanced: false,
+                        min: 0.125,
+                        max: 8.0,
+                        step: 0.125,
+                        allow_higher: true,
+                        allow_lower: false
+                    },
+
+                    /*
+                        Cantidad de escalones de intensidad.
+
+                        0 = intensidad continua.
+                        1 = transición binaria aproximada.
+                        2–8 = varios niveles de sombra.
+                    */
+                    "uLFPixelatedShadowLevels": {
+                        type: "float",
+                        value: config.levels,
+                        expose: true,
+                        advanced: false,
+                        min: 0,
+                        max: 8,
+                        step: 1,
+                        allow_higher: true,
+                        allow_lower: false
+                    },
+
+                    /*
+                        Define cómo se calcula la cuadrícula:
+
+                        false:
+                            uvSize * faceSize
+
+                        true:
+                            globalFaceSize
+
+                        El modo global evita que la densidad cambie debido
+                        al tamaño de la región UV dentro de la textura.
+                    */
+                    "uLFPixelatedShadowGlobalResolution": {
+                        type: "bool",
+                        value: config.globalResolution,
+                        expose: true,
+                        advanced: true
+                    },
+
+                    /*
+                        Mezcla entre sombra normal y sombra pixelada.
+
+                        0.0 = sin influencia.
+                        1.0 = efecto completo.
+                    */
+                    "uLFPixelatedShadowStrength": {
+                        type: "float",
+                        value: config.strength,
+                        expose: true,
+                        advanced: false,
+                        min: 0.0,
+                        max: 1.0,
+                        step: 0.05,
+                        allow_higher: false,
+                        allow_lower: false
+                    }
+                };
+            };
+
 
             // =========================================================================
             // PBR METALLIC/ROUGHNESS SHADER - corrected v2 for Shader Architect / Blockbench
@@ -4750,11 +5715,16 @@ vec4 saApplyScreenSpaceReflection(vec4 sourceColor, vec3 viewNormal, vec3 viewPo
                 name: tl('shader_architect.preset.pbr_metallic_roughness'),
                 icon: 'hexagon',
                 isCustom: false,
-                vertex: `#include <common>
-#include <shadowmap_pars_vertex>
+                 vertex: `#include <common>
+
+${LIGHTFLOW_PIXELATED_SHADOWS_VERTEX}
+${LIGHTFLOW_TEXTURE_TILING}
 
 attribute float highlight;
+attribute float affected_by_shadow;
 attribute vec2 normalizedFaceUv;
+attribute vec2 globalFaceSize;
+attribute vec2 uvSize;
 
 uniform bool SHADE;
 uniform int LIGHTSIDE;
@@ -4762,7 +5732,7 @@ uniform mat3 uWorldNormalMatrix;
 uniform float uStylizedNormalInfluence;
 
 varying vec2 vUv;
-varying vec2 v_uvSize;
+varying vec2 vFaceSize;
 varying float lift;
 varying vec3 vWorldPos;
 varying vec3 vWorldNormal;
@@ -4806,12 +5776,6 @@ vec3 applyLightSide(vec3 n) {
 void main() {
     vec4 worldPosition = modelMatrix * vec4(position, 1.0);
 
-    /*
-        Three.js r129 requires this exact variable for #include <shadowmap_vertex>.
-        Keep it even though custom lighting uses uWorldNormalMatrix.
-    */
-    vec3 transformedNormal = normalize(normalMatrix * normal);
-
     vWorldPos = worldPosition.xyz;
 
     vec3 physicalNormal = safeNormalizeVertex(uWorldNormalMatrix * normal, vec3(0.0, 1.0, 0.0));
@@ -4828,7 +5792,7 @@ void main() {
     }
 
     vUv = uv;
-    v_uvSize = normalizedFaceUv;
+    vFaceSize = globalFaceSize;
     vViewDir = safeNormalizeVertex(cameraPosition - vWorldPos, vec3(0.0, 0.0, 1.0));
     vec4 saSSRViewPosition4 = modelViewMatrix * vec4(position, 1.0);
     vSA_SSRViewPosition = saSSRViewPosition4.xyz;
@@ -4839,15 +5803,26 @@ void main() {
            highlight == 1.0 ? 0.10 :
            0.0;
 
-    gl_Position = vSA_SSRClipPosition;
+    lfPixelatedShadowVertexSetup(
+        worldPosition,
+        physicalNormal,
+        normalizedFaceUv,
+        globalFaceSize,
+        uvSize * abs(
+            lfResolveTextureTiling(globalFaceSize)
+        ),
+        affected_by_shadow
+    );
 
-    #include <shadowmap_vertex>
+    gl_Position = vSA_SSRClipPosition;
 }`,
                 fragment: `#include <common>
 #include <packing>
 ${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
-#include <shadowmap_pars_fragment>
+${LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT}
+${LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT}
+${LIGHTFLOW_TEXTURE_TILING}
 ${SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT}
 
 uniform sampler2D map;
@@ -4954,9 +5929,6 @@ uniform int uLightType[16];
 uniform vec3 uLightColor[16];
 uniform int max_light_number;
 
-uniform int uLightCastShadow[16];
-uniform int uLightShadowIndex[16];
-
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
 uniform int uSAEnvironmentEnabled;
@@ -4974,14 +5946,8 @@ uniform float uAOPower;
 uniform float uAOMin;
 uniform float uAODirectInfluence;
 
-uniform float uShadowStrength;
-uniform float uShadowFloor;
-uniform bool uPixelatedShadows;
-uniform float uPixelShadowSteps;
-uniform float uPixelShadowScale;
-
 varying vec2 vUv;
-varying vec2 v_uvSize;
+varying vec2 vFaceSize;
 varying float lift;
 varying vec3 vWorldPos;
 varying vec3 vWorldNormal;
@@ -5158,131 +6124,6 @@ vec3 getLightRadiance(int lightIndex, float attenuation) {
 }
 
 // -------------------------------------------------------------------------
-// Shadow functions: intentionally kept compatible with shaded_lightflow.
-// -------------------------------------------------------------------------
-float getDirectionalShadowByIndex(int shadowIndex) {
-    float result = 1.0;
-
-    #ifdef USE_SHADOWMAP
-
-    #if NUM_DIR_LIGHT_SHADOWS > 0
-
-        DirectionalLightShadow directionalLight;
-
-        #pragma unroll_loop_start
-        for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {
-            directionalLight = directionalLightShadows[ i ];
-
-            if (UNROLLED_LOOP_INDEX == shadowIndex) {
-                result = receiveShadow ? getShadow(
-                    directionalShadowMap[ i ],
-                    directionalLight.shadowMapSize,
-                    directionalLight.shadowBias,
-                    directionalLight.shadowRadius,
-                    vDirectionalShadowCoord[ i ]
-                ) : 1.0;
-            }
-        }
-        #pragma unroll_loop_end
-
-    #endif
-
-    #endif
-
-    return result;
-}
-
-float getSpotShadowByIndex(int shadowIndex) {
-    float result = 1.0;
-
-    #ifdef USE_SHADOWMAP
-
-    #if NUM_SPOT_LIGHT_SHADOWS > 0
-
-        SpotLightShadow spotLight;
-
-        #pragma unroll_loop_start
-        for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {
-            spotLight = spotLightShadows[ i ];
-
-            if (UNROLLED_LOOP_INDEX == shadowIndex) {
-                result = receiveShadow ? getShadow(
-                    spotShadowMap[ i ],
-                    spotLight.shadowMapSize,
-                    spotLight.shadowBias,
-                    spotLight.shadowRadius,
-                    vSpotShadowCoord[ i ]
-                ) : 1.0;
-            }
-        }
-        #pragma unroll_loop_end
-
-    #endif
-
-    #endif
-
-    return result;
-}
-
-float getPointShadowByIndex(int shadowIndex) {
-    float result = 1.0;
-
-    #ifdef USE_SHADOWMAP
-
-    #if NUM_POINT_LIGHT_SHADOWS > 0
-
-        PointLightShadow pointLight;
-
-        #pragma unroll_loop_start
-        for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {
-            pointLight = pointLightShadows[ i ];
-
-            if (UNROLLED_LOOP_INDEX == shadowIndex) {
-                result = receiveShadow ? getPointShadow(
-                    pointShadowMap[ i ],
-                    pointLight.shadowMapSize,
-                    pointLight.shadowBias,
-                    pointLight.shadowRadius,
-                    vPointShadowCoord[ i ],
-                    pointLight.shadowCameraNear,
-                    pointLight.shadowCameraFar
-                ) : 1.0;
-            }
-        }
-        #pragma unroll_loop_end
-
-    #endif
-
-    #endif
-
-    return result;
-}
-
-float getCustomLightShadow(int lightIndex) {
-    if (uLightCastShadow[lightIndex] == 0) return 1.0;
-
-    int shadowIndex = uLightShadowIndex[lightIndex];
-    if (shadowIndex < 0) return 1.0;
-
-    int type = uLightType[lightIndex];
-
-    float shadow = 1.0;
-
-    if (type == SA_LIGHT_DIRECTIONAL) {
-        shadow = getDirectionalShadowByIndex(shadowIndex);
-    } else if (type == SA_LIGHT_SPOT) {
-        shadow = getSpotShadowByIndex(shadowIndex);
-    } else {
-        shadow = getPointShadowByIndex(shadowIndex);
-    }
-
-    shadow = clamp(shadow, 0.0, 1.0);
-    shadow = max(shadow, clamp(uShadowFloor, 0.0, 1.0));
-
-    return mix(1.0, shadow, clamp(uShadowStrength, 0.0, 1.0));
-}
-
-// -------------------------------------------------------------------------
 // Ambient occlusion: same stylized face-cavity idea as shaded_lightflow.
 // -------------------------------------------------------------------------
 float computeFaceCavityAO(vec2 faceUv) {
@@ -5348,11 +6189,16 @@ vec3 evaluateIridescence(float NdotV, float thickness) {
     return wave;
 }
 
-void buildSurfaceTangentFrame(vec3 normal, out vec3 tangent, out vec3 bitangent) {
+void buildSurfaceTangentFrame(
+    vec3 normal,
+    vec2 materialUv,
+    out vec3 tangent,
+    out vec3 bitangent
+) {
     vec3 positionDx = dFdx(vWorldPos);
     vec3 positionDy = dFdy(vWorldPos);
-    vec2 uvDx = dFdx(vUv);
-    vec2 uvDy = dFdy(vUv);
+    vec2 uvDx = dFdx(materialUv);
+    vec2 uvDy = dFdy(materialUv);
     float determinant = uvDx.x * uvDy.y - uvDx.y * uvDy.x;
 
     vec3 fallbackTangent = safeNormalize(
@@ -5374,15 +6220,23 @@ void buildSurfaceTangentFrame(vec3 normal, out vec3 tangent, out vec3 bitangent)
     }
 }
 
-vec3 applyCheapNormalMap(vec3 normal) {
+vec3 applyCheapNormalMap(vec3 normal, vec2 materialUv) {
     if (!uUseNormalMap) return normal;
 
-    vec3 nTex = texture2D(uNormalMap, vUv * uNormalMapScale).xyz * 2.0 - 1.0;
+    vec3 nTex = texture2D(
+        uNormalMap,
+        materialUv * uNormalMapScale
+    ).xyz * 2.0 - 1.0;
     nTex.y *= uNormalYSign;
 
     vec3 tangent;
     vec3 bitangent;
-    buildSurfaceTangentFrame(normal, tangent, bitangent);
+    buildSurfaceTangentFrame(
+        normal,
+        materialUv,
+        tangent,
+        bitangent
+    );
     float normalStrength = clamp(uNormalScale, 0.0, 2.0);
     vec3 tangentNormal = safeNormalize(
         vec3(nTex.xy * normalStrength, max(nTex.z, 0.001)),
@@ -5396,10 +6250,13 @@ vec3 applyCheapNormalMap(vec3 normal) {
     return bumped;
 }
 
-vec3 applyHeightMap(vec3 normal) {
+vec3 applyHeightMap(vec3 normal, vec2 materialUv) {
     if (!uUseHeightMap) return normal;
 
-    float height = texture2D(uHeightMap, vUv * uHeightMapScale).r;
+    float height = texture2D(
+        uHeightMap,
+        materialUv * uHeightMapScale
+    ).r;
     float heightDx = dFdx(height);
     float heightDy = dFdy(height);
 
@@ -5416,8 +6273,18 @@ vec3 applyHeightMap(vec3 normal) {
     );
 }
 
-void buildAnisotropyFrame(vec3 normal, out vec3 tangent, out vec3 bitangent) {
-    buildSurfaceTangentFrame(normal, tangent, bitangent);
+void buildAnisotropyFrame(
+    vec3 normal,
+    vec2 materialUv,
+    out vec3 tangent,
+    out vec3 bitangent
+) {
+    buildSurfaceTangentFrame(
+        normal,
+        materialUv,
+        tangent,
+        bitangent
+    );
 
     vec2 direction = uAnisotropyDirection;
     float directionLength = length(direction);
@@ -5432,8 +6299,13 @@ void buildAnisotropyFrame(vec3 normal, out vec3 tangent, out vec3 bitangent) {
 }
 
 void main() {
-    vec4 texel = texture2D(map, vUv);
+    vec2 materialUv =
+        vUv * lfResolveTextureTiling(vFaceSize);
+    vec4 texel = texture2D(map, materialUv);
     texel.a *= clamp(uBaseAlpha, 0.0, 1.0);
+
+    vec3 pixelatedShadowByType =
+        lfGetPixelatedShadowByType();
 
     if (texel.a < 0.01) discard;
 
@@ -5457,11 +6329,17 @@ void main() {
     vec3 emissive = uEmissiveColor * max(uEmissiveStrength, 0.0);
 
     if (uUseBaseColorMap) {
-        baseColor *= texture2D(uBaseColorMap, vUv * uBaseColorMapScale).rgb;
+        baseColor *= texture2D(
+            uBaseColorMap,
+            materialUv * uBaseColorMapScale
+        ).rgb;
     }
 
     if (uUseMetallicRoughnessMap) {
-        vec4 mr = texture2D(uMetallicRoughnessMap, vUv * uMetallicRoughnessMapScale);
+        vec4 mr = texture2D(
+            uMetallicRoughnessMap,
+            materialUv * uMetallicRoughnessMapScale
+        );
         metallic *= mr.r;
         roughness *= uUseBlockbenchMERMap ? mr.b : mr.g;
         if (uUseBlockbenchMERMap) {
@@ -5474,11 +6352,17 @@ void main() {
     }
 
     if (uUseAOMap) {
-        aoMapValue *= texture2D(uAOMap, vUv * uAOMapScale).r;
+        aoMapValue *= texture2D(
+            uAOMap,
+            materialUv * uAOMapScale
+        ).r;
     }
 
     if (uUseEmissiveMap) {
-        emissive += texture2D(uEmissiveMap, vUv * uEmissiveMapScale).rgb * max(uEmissiveStrength, 0.0);
+        emissive += texture2D(
+            uEmissiveMap,
+            materialUv * uEmissiveMapScale
+        ).rgb * max(uEmissiveStrength, 0.0);
     }
 
     metallic = clamp(metallic, 0.0, 1.0);
@@ -5515,8 +6399,8 @@ void main() {
     );
 
     vec3 N = safeNormalize(vWorldNormal, vec3(0.0, 1.0, 0.0));
-    N = applyCheapNormalMap(N);
-    N = applyHeightMap(N);
+    N = applyCheapNormalMap(N, materialUv);
+    N = applyHeightMap(N, materialUv);
 
     vec3 V = safeNormalize(vViewDir, vec3(0.0, 0.0, 1.0));
     float NdotV = max(dot(N, V), 0.001);
@@ -5544,7 +6428,12 @@ void main() {
     vec3 anisotropyTangent = vec3(1.0, 0.0, 0.0);
     vec3 anisotropyBitangent = vec3(0.0, 0.0, 1.0);
     if (uAnisotropyEnabled && anisotropyAmount > 0.0001) {
-        buildAnisotropyFrame(N, anisotropyTangent, anisotropyBitangent);
+        buildAnisotropyFrame(
+            N,
+            materialUv,
+            anisotropyTangent,
+            anisotropyBitangent
+        );
     }
 
     for (int i = 0; i < 16; i++) {
@@ -5552,15 +6441,12 @@ void main() {
 
         vec3 L = getLightDirection(i, vWorldPos);
         float attenuation = getLightAttenuation(i, vWorldPos, L);
-        float shadow = getCustomLightShadow(i);
-        if (uPixelatedShadows) {
-            float levels = max(2.0, uPixelShadowSteps);
-            vec2 pixelCell = floor(gl_FragCoord.xy / max(uPixelShadowScale, 1.0));
-            float dither = fract(dot(pixelCell, vec2(0.75487766, 0.56984029))) - 0.5;
-            shadow = floor(clamp(shadow + dither / levels, 0.0, 1.0) * levels + 0.5) / levels;
-        }
-        vec3 incidentRadiance = getLightRadiance(i, attenuation);
-        vec3 radiance = incidentRadiance * shadow;
+        float shadow = lfGetLightShadow(
+            i,
+            uLightType[i],
+            pixelatedShadowByType
+        );
+        vec3 radiance = getLightRadiance(i, attenuation) * shadow;
 
         float NdotLRaw = dot(N, L);
         float NdotL = max(NdotLRaw, 0.0);
@@ -5627,29 +6513,34 @@ void main() {
             scatterProfile += backScatter * (0.35 + 0.65 * viewScatter) * throughProfile;
             scatterProfile = min(scatterProfile, 2.0);
 
-            // SSS can pass through the casting surface, but artists can restore full
-            // shadowing with SSS Shadow Mix when a denser material is required.
-            float sssShadow = mix(1.0, shadow, clamp(uSSSShadowMix, 0.0, 1.0));
-            directSubsurface += incidentRadiance
+            // SSS may cross the receiving surface, but it must not bypass another
+            // object's cast shadow. The control only deepens partial penumbras.
+            float sssPenumbra = mix(
+                1.0,
+                shadow,
+                clamp(uSSSShadowMix, 0.0, 1.0)
+            );
+            directSubsurface += radiance
                 * baseColor
                 * max(uSSSColor, vec3(0.0))
                 * scatterProfile
-                * sssShadow
+                * sssPenumbra
                 * sssWeight;
         }
 
         if (uTransmissionEnabled && transmission > 0.0001) {
             float transmissionBacklight = max(-NdotLRaw, 0.0);
-            float transmissionShadow = mix(1.0, shadow, uThinWalled ? 0.15 : 0.45);
-            directTransmission += incidentRadiance
+            // Thin surfaces transmit light through themselves, not through unrelated
+            // occluders between the light and this fragment.
+            directTransmission += radiance
                 * baseColor
-                * transmissionBacklight
-                * transmissionShadow;
+                * transmissionBacklight;
         }
     }
 
-    // Contact AO is applied once as the depth-aware Lightflow SSAO pass.
-    float ambientOcclusion = 1.0;
+    // Material/baked AO belongs in the BRDF. Contact AO is still applied once by
+    // the separate depth-aware Lightflow pass.
+    float ambientOcclusion = aoMapValue;
     float directAO = mix(1.0, ambientOcclusion, clamp(uAODirectInfluence, 0.0, 1.0));
     float specAO = mix(1.0, ambientOcclusion, clamp(uAODirectInfluence * 0.35, 0.0, 1.0));
 
@@ -5664,12 +6555,32 @@ void main() {
     vec3 ambientSpecular = ambientLight * F_ambient * max(uEnvSpecularStrength, 0.0) * (0.25 + 0.75 * (1.0 - roughness));
     ambientSpecular *= mix(vec3(1.0), baseColor, metallic) * ambientOcclusion;
 
+    vec3 specularLighting = ambientSpecular;
+    specularLighting += directSpecular * specAO;
+    specularLighting += directClearcoat * specAO;
+
+    // Iridescence is a thin-film tint of reflected light, not an emissive glow.
+    // Keeping it on the already lit specular carrier makes direct iridescence obey
+    // cast shadows while preserving legitimate environment reflections.
+    if (uIridescenceEnabled && iridescence > 0.0001) {
+        vec3 iridescenceTint = clamp(
+            evaluateIridescence(NdotV, iridescenceThickness) * 2.0,
+            vec3(0.0),
+            vec3(2.0)
+        );
+        float iridescenceWeight = iridescence * (
+            0.35 + 0.65 * (1.0 - roughness)
+        );
+        specularLighting *= mix(
+            vec3(1.0),
+            iridescenceTint,
+            clamp(iridescenceWeight, 0.0, 1.0)
+        );
+    }
+
     vec3 color = vec3(0.0);
     color += ambientDiffuse;
-    color += ambientSpecular;
     color += directDiffuse * directAO;
-    color += directSpecular * specAO;
-    color += directClearcoat * specAO;
     color += directSheen * directAO;
 
     float sssDiffusion = 1.0 - exp(-sssRadius * max(sssThickness, 0.05));
@@ -5678,17 +6589,20 @@ void main() {
         * max(uSSSColor, vec3(0.0))
         * max(uSSSAmbient, 0.0)
         * sssWeight
-        * (0.2 + 0.8 * sssDiffusion);
+        * (0.2 + 0.8 * sssDiffusion)
+        * ambientOcclusion;
     color += (directSubsurface + ambientSubsurface) * mix(1.0, directAO, 0.35);
 
     float transmissionFactor = transmission * (1.0 - metallic);
-    vec3 transmitted = (ambientLight * baseColor + directTransmission) * transmissionAbsorption;
-    color = mix(color, transmitted + directSpecular * specAO, transmissionFactor);
+    vec3 transmitted = (
+        ambientLight * baseColor * ambientOcclusion +
+        directTransmission
+    ) * transmissionAbsorption;
+    color = mix(color, transmitted, transmissionFactor);
 
-    if (uIridescenceEnabled && iridescence > 0.0001) {
-        vec3 irid = evaluateIridescence(NdotV, iridescenceThickness);
-        color += irid * iridescence * (0.08 + 0.35 * (1.0 - roughness));
-    }
+    // Surface reflection stays above the transmissive body layer. This also keeps
+    // the iridescence tint attached to real reflected light at every transmission.
+    color += specularLighting;
 
     color += emissive;
 
@@ -5717,6 +6631,8 @@ void main() {
     );
 }`,
                 uniforms: Object.assign({
+                    "map": { type: "sampler2D", value: null, repeat: true, expose: true },
+
                     // Base PBR Properties
                     "uBaseColor": { type: "vec3", value: new THREE.Vector3(1, 1, 1), hexValue: "#ffffff", expose: true, is_color: true },
                     "uBaseAlpha": { type: "float", value: 1.0, expose: false },
@@ -5851,16 +6767,17 @@ void main() {
                     // Shadows
                     "uShadowStrength": { type: "float", value: 1.0, expose: true, min: 0.0, max: 1.0, step: 0.05, allow_higher: false, allow_lower: false },
                     "uShadowFloor": { type: "float", value: 0.0, expose: true, min: 0.0, max: 1.0, step: 0.05, allow_higher: false, allow_lower: false },
-                    "uPixelatedShadows": { type: "bool", value: false, expose: true },
-                    "uPixelShadowSteps": { type: "float", value: 4.0, expose: true, min: 2.0, max: 16.0, step: 1.0, allow_higher: false, allow_lower: false },
-                    "uPixelShadowScale": { type: "float", value: 2.0, expose: true, min: 1.0, max: 16.0, step: 1.0, allow_higher: false, allow_lower: false },
 
                     // Blockbench-style controls
                     "SHADE": { type: "bool", value: true, expose: true },
                     "LIGHTSIDE": { type: "int", value: 0, expose: true, min: 0, max: 5, step: 1, allow_higher: false, allow_lower: false },
                     "LIGHTCOLOR": { type: "vec3", value: new THREE.Vector3(1, 1, 1), hexValue: "#ffffff", expose: true, is_color: true },
+                    "AUTO_TILE": { type: "bool", value: false, expose: true },
+                    "TILING": { type: "vec2", value: new THREE.Vector2(1, 1), expose: true, min: 0.1, max: 10.0, step: 0.1 },
                     "TEXTURE_SIZE": { type: "vec2", value: new THREE.Vector2(16, 16), expose: false }
-                }, createScreenSpaceReflectionUniforms({
+                }, createLightflowPixelatedShadowUniforms({
+                    enabled: false
+                }), createScreenSpaceReflectionUniforms({
                     intensity: 0.82,
                     roughness: 0.16,
                     quality: 0.72,
@@ -5890,9 +6807,8 @@ void main() {
             setVibrantDefault('uSSRRoughness', 0.22);
             setVibrantDefault('uSSRQuality', 0.72);
             setVibrantDefault('uSSRRenderScale', 0.85);
-            setVibrantDefault('uPixelatedShadows', true);
-            setVibrantDefault('uPixelShadowSteps', 4.0);
-            setVibrantDefault('uPixelShadowScale', 2.0);
+            setVibrantDefault('uLFPixelatedShadowsEnabled', true);
+            setVibrantDefault('uLFPixelatedShadowLevels', 4.0);
 
             const vibrant_visuals_pbr = new FancyShaderMaterial({
                 id: 'vibrant_visuals_pbr',
@@ -5926,14 +6842,25 @@ void main() {
                 if (typeof options === 'boolean') {
                     return {
                         shadows: options,
-                        screenSpaceReflections: false
+                        screenSpaceReflections: false,
+                        pixelatedShadows: null
                     };
                 }
 
                 const config = options || {};
+                const pixelatedShadows = config.pixelatedShadows === true
+                    ? {}
+                    : (
+                        config.pixelatedShadows &&
+                        typeof config.pixelatedShadows === 'object'
+                            ? config.pixelatedShadows
+                            : null
+                    );
+
                 return {
                     shadows: !!(config.shadows || config.withShadowBinding),
-                    screenSpaceReflections: config.screenSpaceReflections === true || config.ssr === true
+                    screenSpaceReflections: config.screenSpaceReflections === true || config.ssr === true,
+                    pixelatedShadows
                 };
             };
 
@@ -6263,6 +7190,15 @@ void main() {
                         allow_higher: false,
                         allow_lower: false
                     };
+
+                    if (config.pixelatedShadows) {
+                        Object.assign(
+                            uniforms,
+                            createLightflowPixelatedShadowUniforms(
+                                config.pixelatedShadows
+                            )
+                        );
+                    }
                 }
 
                 if (config.screenSpaceReflections) {
@@ -6277,7 +7213,13 @@ void main() {
                 name: tl('shader_architect.preset.lightflow'),
                 icon: 'wb_sunny',
                 isCustom: false,
-                vertex: `attribute float highlight;
+                vertex: `#include <common>
+
+${LIGHTFLOW_PIXELATED_SHADOWS_VERTEX}
+${LIGHTFLOW_TEXTURE_TILING}
+
+attribute float highlight;
+attribute float affected_by_shadow;
 uniform bool SHADE;
 uniform int LIGHTSIDE;
 uniform mat3 uWorldNormalMatrix;
@@ -6351,14 +7293,31 @@ void main() {
            highlight == 1.0 ? 0.10 :
            0.0;
 
+    lfPixelatedShadowVertexSetup(
+        worldPosition,
+        physicalNormal,
+        normalizedFaceUv,
+        globalFaceSize,
+        uvSize * abs(
+            lfResolveTextureTiling(globalFaceSize)
+        ),
+        affected_by_shadow
+    );
+
     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }`,
-                fragment: `uniform sampler2D map;
+                fragment: `#include <common>
+#include <packing>
+${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
+#include <lights_pars_begin>
+${LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT}
+${LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT}
+${LIGHTFLOW_TEXTURE_TILING}
+
+uniform sampler2D map;
 uniform vec3 LIGHTCOLOR;
 uniform bool EMISSIVE;
-uniform vec2 TILING;
-uniform bool AUTO_TILE;
-uniform vec2 TEXTURE_SIZE;
+uniform bool SHADOWS;
 
 uniform vec3 uLightPos[16];
 uniform vec3 uLightDir[16];
@@ -6610,12 +7569,13 @@ vec3 applyToneMapping(vec3 color) {
 }
 
 void main() {
-    vec2 tiling_value = TILING;
-    if (AUTO_TILE) {
-        tiling_value = v_faceSize / TEXTURE_SIZE;
-    }
+    vec2 tiling_value =
+        lfResolveTextureTiling(v_faceSize);
     vec4 texel = texture2D(map, vUv * tiling_value);
     texel = saApplyNativePBRBaseColor(texel);
+
+    vec3 pixelatedShadowByType =
+        lfGetPixelatedShadowByType();
 
     if (texel.a < 0.01) discard;
 
@@ -6632,7 +7592,19 @@ void main() {
         if (i >= max_light_number) break;
         if (uLightIntensity[i] <= 0.0) continue;
 
-        directLight += computeLightContribution(i, normal, vWorldPos);
+        vec3 lightContribution =
+            computeLightContribution(i, normal, vWorldPos);
+        float shadow = 1.0;
+
+        if (SHADOWS) {
+            shadow = lfGetLightShadow(
+                i,
+                uLightType[i],
+                pixelatedShadowByType
+            );
+        }
+
+        directLight += lightContribution * shadow;
     }
 
     float ambientOcclusion = 1.0;
@@ -6689,7 +7661,13 @@ void main() {
 
     gl_FragColor = vec4(finalColor, EMISSIVE ? 1.0 : texel.a);
 }`,
-                uniforms: createLightflowUniforms()
+                uniforms: createLightflowUniforms({
+                    shadows: true,
+                    pixelatedShadows: {
+                        enabled: false
+                    }
+                }),
+                enableShadows: true
             });
 
             let shaded_lightflow = new FancyShaderMaterial({
@@ -6698,9 +7676,12 @@ void main() {
                 icon: 'flare',
                 isCustom: false,
                 vertex: `#include <common>
-#include <shadowmap_pars_vertex>
+
+${LIGHTFLOW_PIXELATED_SHADOWS_VERTEX}
+${LIGHTFLOW_TEXTURE_TILING}
 
 attribute float highlight;
+attribute float affected_by_shadow;
 
 uniform bool SHADE;
 uniform int LIGHTSIDE;
@@ -6754,13 +7735,6 @@ vec3 applyLightSide(vec3 n) {
 void main() {
     vec4 worldPosition = modelMatrix * vec4(position, 1.0);
 
-    /*
-        IMPORTANTE:
-        Three.js r129 requires this exact variable for #include <shadowmap_vertex>.
-        Keep it even though custom lighting uses uWorldNormalMatrix.
-    */
-    vec3 transformedNormal = normalize(normalMatrix * normal);
-
     vWorldPos = worldPosition.xyz;
 
     vec3 physicalNormal = normalize(uWorldNormalMatrix * normal);
@@ -6789,24 +7763,32 @@ void main() {
            highlight == 1.0 ? 0.10 :
            0.0;
 
-    gl_Position = vSA_SSRClipPosition;
+    lfPixelatedShadowVertexSetup(
+        worldPosition,
+        physicalNormal,
+        normalizedFaceUv,
+        globalFaceSize,
+        uvSize * abs(
+            lfResolveTextureTiling(globalFaceSize)
+        ),
+        affected_by_shadow
+    );
 
-    #include <shadowmap_vertex>
+    gl_Position = vSA_SSRClipPosition;
 }`,
                 fragment: `#include <common>
 #include <packing>
 ${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
-#include <shadowmap_pars_fragment>
+${LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT}
+${LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT}
+${LIGHTFLOW_TEXTURE_TILING}
 ${SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT}
 
 uniform sampler2D map;
 uniform vec3 LIGHTCOLOR;
 uniform bool EMISSIVE;
 uniform bool SHADOWS;
-uniform vec2 TILING;
-uniform bool AUTO_TILE;
-uniform vec2 TEXTURE_SIZE;
 
 uniform vec3 uLightPos[16];
 uniform vec3 uLightDir[16];
@@ -6817,9 +7799,6 @@ uniform float uLightPenumbra[16];
 uniform int uLightType[16];
 uniform vec3 uLightColor[16];
 uniform int max_light_number;
-
-uniform int uLightCastShadow[16];
-uniform int uLightShadowIndex[16];
 
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
@@ -6846,9 +7825,6 @@ uniform float uAOFaceNormalWeight;
 uniform bool uClampLighting;
 
 ${NATIVE_PBR_FRAGMENT}
-
-uniform float uShadowStrength;
-uniform float uShadowFloor;
 
 varying vec2 vUv;
 varying float lift;
@@ -7164,12 +8140,13 @@ vec3 applyToneMapping(vec3 color) {
 }
 
 void main() {
-    vec2 tiling_value = TILING;
-    if (AUTO_TILE) {
-        tiling_value = v_faceSize / TEXTURE_SIZE;
-    }
+    vec2 tiling_value =
+        lfResolveTextureTiling(v_faceSize);
     vec4 texel = texture2D(map, vUv * tiling_value);
     texel = saApplyNativePBRBaseColor(texel);
+
+    vec3 pixelatedShadowByType =
+        lfGetPixelatedShadowByType();
 
     if (texel.a < 0.01) discard;
 
@@ -7195,9 +8172,11 @@ void main() {
         float shadow = 1.0;
 
         if (SHADOWS) {
-            if (uLightCastShadow[i] != 0) {
-                shadow = getCustomLightShadow(i);
-            }
+            shadow = lfGetLightShadow(
+                i,
+                uLightType[i],
+                pixelatedShadowByType
+            );
         }
 
         directLight += lightContribution * shadow;
@@ -7269,6 +8248,9 @@ void main() {
 }`,
                 uniforms: createLightflowUniforms({
                     shadows: true,
+                    pixelatedShadows: {
+                        enabled: false
+                    },
                     screenSpaceReflections: true
                 }),
                 supportsScreenSpaceReflections: true,
@@ -7282,9 +8264,12 @@ void main() {
                 isCustom: false,
 
                 vertex: `#include <common>
-#include <shadowmap_pars_vertex>
+
+${LIGHTFLOW_PIXELATED_SHADOWS_VERTEX}
+${LIGHTFLOW_TEXTURE_TILING}
 
 attribute float highlight;
+attribute float affected_by_shadow;
 attribute vec2 normalizedFaceUv;
 attribute vec2 faceSize;
 attribute vec2 globalFaceSize;
@@ -7298,8 +8283,6 @@ uniform float uStylizedNormalInfluence;
 varying vec2 vUv;
 varying vec2 vNormalizedFaceUv;
 varying vec2 vfaceSize;
-varying vec2 vGlobalFaceSize;
-varying vec2 vuvSize;
 
 varying float lift;
 varying vec3 vWorldPos;
@@ -7334,12 +8317,6 @@ vec3 applyLightSide(vec3 n) {
 void main() {
     vec4 worldPosition = modelMatrix * vec4(position, 1.0);
 
-    /*
-        Requerido por shadowmap_vertex de Three.js.
-        No sustituir por vWorldNormal: Three necesita esta variable exacta.
-    */
-    vec3 transformedNormal = normalize(normalMatrix * normal);
-
     vWorldPos = worldPosition.xyz;
 
     vec3 physicalNormal = normalize(uWorldNormalMatrix * normal);
@@ -7357,31 +8334,38 @@ void main() {
 
     vUv = uv;
     vNormalizedFaceUv = normalizedFaceUv;
-    vfaceSize = faceSize;
-    vGlobalFaceSize = globalFaceSize;
-    vuvSize = uvSize;
+    vfaceSize = globalFaceSize;
 
     lift = highlight == 2.0 ? 0.22 :
            highlight == 1.0 ? 0.10 :
            0.0;
 
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    lfPixelatedShadowVertexSetup(
+        worldPosition,
+        physicalNormal,
+        normalizedFaceUv,
+        globalFaceSize,
+        uvSize * abs(
+            lfResolveTextureTiling(globalFaceSize)
+        ),
+        affected_by_shadow
+    );
 
-    #include <shadowmap_vertex>
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
 }`,
 
                 fragment: `#include <common>
 #include <packing>
 ${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
-#include <shadowmap_pars_fragment>
+${LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT}
+${LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT}
+${LIGHTFLOW_TEXTURE_TILING}
 
 uniform sampler2D map;
 uniform vec3 LIGHTCOLOR;
 uniform bool EMISSIVE;
-uniform vec2 TILING;
-uniform bool AUTO_TILE;
-uniform vec2 TEXTURE_SIZE;
+uniform bool SHADOWS;
 
 /* Lightflow lights */
 uniform vec3 uLightPos[16];
@@ -7393,9 +8377,6 @@ uniform float uLightPenumbra[16];
 uniform int uLightType[16];
 uniform vec3 uLightColor[16];
 uniform int max_light_number;
-
-uniform int uLightCastShadow[16];
-uniform int uLightShadowIndex[16];
 
 /* Ambient */
 uniform float uAmbient;
@@ -7423,26 +8404,9 @@ uniform float uAOEdgeSharpness;
 uniform float uAOCornerWeight;
 uniform float uAOFaceNormalWeight;
 
-/*
-    Lightflow shadow controls are applied after the pixelated threshold.
-*/
-uniform float uShadowStrength;
-uniform float uShadowFloor;
-
-/*
-    Legacy pixelated-shadow controls.
-*/
-uniform float shadowPixelResolution;
-uniform float shadowThreshold;
-uniform bool PIXELATED_SHADOWS;
-uniform float shadowFilterScale;
-uniform float shadowFeather;
-
 varying vec2 vUv;
 varying vec2 vNormalizedFaceUv;
 varying vec2 vfaceSize;
-varying vec2 vGlobalFaceSize;
-varying vec2 vuvSize;
 
 varying float lift;
 varying vec3 vWorldPos;
@@ -7459,9 +8423,6 @@ varying vec3 vWorldNormal;
 #define TM_HABLE 4
 #define TM_FILMIC 5
 #define TM_LINEAR 6
-
-#define SHADOW_DET_EPS 1e-12
-#define SHADOW_QUALITY_EPS 1e-5
 
 vec3 safeNormalize(vec3 v, vec3 fallback) {
     float lenSq = dot(v, v);
@@ -7580,490 +8541,6 @@ vec3 computeLightContribution(
         diffuse *
         intensity *
         attenuation;
-}
-
-/* ------------------------------------------------------------
-   PIXELATED LEGACY SHADOWS
-   Keep this path independent from uLightShadowIndex to preserve
-   the legacy pixelated behavior.
------------------------------------------------------------- */
-
-vec2 getPixelCenterUV(vec2 localUV, vec2 gridSize) {
-    vec2 grid = max(floor(gridSize + 0.5), vec2(1.0));
-
-    vec2 safeUV = clamp(
-        localUV,
-        vec2(0.001),
-        vec2(0.999)
-    );
-
-    return (floor(safeUV * grid) + 0.5) / grid;
-}
-
-vec4 getRawShadowCoordAtUV(
-    vec4 currentShadowCoord,
-    vec2 targetUV,
-    vec2 currentUV,
-    out bool valid
-) {
-    valid = false;
-
-    vec2 deltaUV = targetUV - currentUV;
-
-    vec2 dUV_dx = dFdx(currentUV);
-    vec2 dUV_dy = dFdy(currentUV);
-
-    vec4 dCoord_dx = dFdx(currentShadowCoord);
-    vec4 dCoord_dy = dFdy(currentShadowCoord);
-
-    float det =
-        dUV_dx.x * dUV_dy.y -
-        dUV_dx.y * dUV_dy.x;
-
-    float uvArea =
-        length(dUV_dx) *
-        length(dUV_dy);
-
-    float quality = abs(det) / max(
-        uvArea,
-        SHADOW_DET_EPS
-    );
-
-    if (
-        abs(det) > SHADOW_DET_EPS &&
-        quality > SHADOW_QUALITY_EPS
-    ) {
-        float invDet = 1.0 / det;
-
-        vec4 dCoord_du =
-            (dCoord_dx * dUV_dy.y -
-            dCoord_dy * dUV_dx.y) *
-            invDet;
-
-        vec4 dCoord_dv =
-            (dCoord_dy * dUV_dx.x -
-            dCoord_dx * dUV_dy.x) *
-            invDet;
-
-        valid = true;
-
-        return currentShadowCoord +
-            dCoord_du * deltaUV.x +
-            dCoord_dv * deltaUV.y;
-    }
-
-    return currentShadowCoord;
-}
-
-vec4 snapShadowCoordToTexel(
-    vec4 shadowCoord,
-    vec2 shadowMapSize
-) {
-    if (abs(shadowCoord.w) < 1e-6) {
-        return shadowCoord;
-    }
-
-    vec2 safeShadowMapSize = max(
-        shadowMapSize,
-        vec2(1.0)
-    );
-
-    vec3 projected = shadowCoord.xyz / shadowCoord.w;
-
-    projected.xy = (
-        floor(projected.xy * safeShadowMapSize) + 0.5
-    ) / safeShadowMapSize;
-
-    shadowCoord.xy = projected.xy * shadowCoord.w;
-
-    return shadowCoord;
-}
-
-vec4 getProjectedShadowCoordAtUV(
-    vec4 currentShadowCoord,
-    vec2 targetUV,
-    vec2 currentUV,
-    vec2 shadowMapSize
-) {
-    bool valid;
-
-    vec4 candidate = getRawShadowCoordAtUV(
-        currentShadowCoord,
-        targetUV,
-        currentUV,
-        valid
-    );
-
-    if (valid && candidate.w > 0.0) {
-        vec3 projCandidate = candidate.xyz / candidate.w;
-
-        if (
-            projCandidate.x >= 0.0 &&
-            projCandidate.x <= 1.0 &&
-            projCandidate.y >= 0.0 &&
-            projCandidate.y <= 1.0
-        ) {
-            return snapShadowCoordToTexel(
-                candidate,
-                shadowMapSize
-            );
-        }
-    }
-
-    return snapShadowCoordToTexel(
-        currentShadowCoord,
-        shadowMapSize
-    );
-}
-
-vec4 getPointShadowCoordAtUV(
-    vec4 currentShadowCoord,
-    vec2 targetUV,
-    vec2 currentUV,
-    vec2 shadowMapSize
-) {
-    bool valid;
-
-    vec4 candidate = getRawShadowCoordAtUV(
-        currentShadowCoord,
-        targetUV,
-        currentUV,
-        valid
-    );
-
-    if (valid) {
-        float currentLen = length(currentShadowCoord.xyz);
-        float candidateLen = length(candidate.xyz);
-
-        if (
-            candidateLen > 0.1 &&
-            abs(candidateLen - currentLen) < 1.0
-        ) {
-            return candidate;
-        }
-    }
-
-    return currentShadowCoord;
-}
-
-float pixelShadowMask(float visibility) {
-    if (!PIXELATED_SHADOWS) return visibility;
-    float threshold = clamp(shadowThreshold, 0.0, 1.0);
-    float feather = clamp(shadowFeather, 0.0, 0.49);
-
-    if (feather <= 0.0001) {
-        return step(threshold, visibility);
-    }
-
-    return smoothstep(
-        max(0.0, threshold - feather),
-        min(1.0, threshold + feather),
-        visibility
-    );
-}
-
-float getPixelatedShadowAtUV(
-    vec2 targetUV,
-    vec2 currentUV
-) {
-    float shadow = 1.0;
-
-    #ifdef USE_SHADOWMAP
-
-    vec4 shadowCoord;
-
-    #if NUM_DIR_LIGHT_SHADOWS > 0
-        DirectionalLightShadow directionalLight;
-
-        #pragma unroll_loop_start
-        for (int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i++) {
-            directionalLight = directionalLightShadows[i];
-
-            vec2 safeShadowMapSize = max(
-                directionalLight.shadowMapSize,
-                vec2(1.0)
-            );
-
-            shadowCoord = getProjectedShadowCoordAtUV(
-                vDirectionalShadowCoord[i],
-                targetUV,
-                currentUV,
-                safeShadowMapSize
-            );
-
-            if (receiveShadow) {
-                float rawShadow = getShadow(
-                    directionalShadowMap[i],
-                    safeShadowMapSize,
-                    directionalLight.shadowBias,
-                    max(0.0, directionalLight.shadowRadius * shadowFilterScale),
-                    shadowCoord
-                );
-
-                shadow *= pixelShadowMask(rawShadow);
-            }
-        }
-        #pragma unroll_loop_end
-    #endif
-
-    #if NUM_SPOT_LIGHT_SHADOWS > 0
-        SpotLightShadow spotLight;
-
-        #pragma unroll_loop_start
-        for (int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i++) {
-            spotLight = spotLightShadows[i];
-
-            vec2 safeShadowMapSize = max(
-                spotLight.shadowMapSize,
-                vec2(1.0)
-            );
-
-            shadowCoord = getProjectedShadowCoordAtUV(
-                vSpotShadowCoord[i],
-                targetUV,
-                currentUV,
-                safeShadowMapSize
-            );
-
-            if (receiveShadow) {
-                float rawShadow = getShadow(
-                    spotShadowMap[i],
-                    safeShadowMapSize,
-                    spotLight.shadowBias,
-                    max(0.0, spotLight.shadowRadius * shadowFilterScale),
-                    shadowCoord
-                );
-
-                shadow *= pixelShadowMask(rawShadow);
-            }
-        }
-        #pragma unroll_loop_end
-    #endif
-
-    #if NUM_POINT_LIGHT_SHADOWS > 0
-        PointLightShadow pointLight;
-
-        #pragma unroll_loop_start
-        for (int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i++) {
-            pointLight = pointLightShadows[i];
-
-            vec2 safeShadowMapSize = max(
-                pointLight.shadowMapSize,
-                vec2(1.0)
-            );
-
-            shadowCoord = getPointShadowCoordAtUV(
-                vPointShadowCoord[i],
-                targetUV,
-                currentUV,
-                safeShadowMapSize
-            );
-
-            if (receiveShadow) {
-                float rawShadow = getPointShadow(
-                    pointShadowMap[i],
-                    safeShadowMapSize,
-                    pointLight.shadowBias,
-                    max(0.0, pointLight.shadowRadius * shadowFilterScale),
-                    shadowCoord,
-                    pointLight.shadowCameraNear,
-                    pointLight.shadowCameraFar
-                );
-
-                shadow *= pixelShadowMask(rawShadow);
-            }
-        }
-        #pragma unroll_loop_end
-    #endif
-
-    #endif
-
-    return shadow;
-}
-
-float getPixelatedDirectionalShadowByIndex(
-    int shadowIndex,
-    vec2 targetUV,
-    vec2 currentUV
-) {
-    float result = 1.0;
-
-    #ifdef USE_SHADOWMAP
-    #if NUM_DIR_LIGHT_SHADOWS > 0
-        DirectionalLightShadow directionalLight;
-
-        #pragma unroll_loop_start
-        for (int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i++) {
-            directionalLight = directionalLightShadows[i];
-
-            if (UNROLLED_LOOP_INDEX == shadowIndex) {
-                vec2 safeShadowMapSize = max(
-                    directionalLight.shadowMapSize,
-                    vec2(1.0)
-                );
-
-                vec4 shadowCoord = getProjectedShadowCoordAtUV(
-                    vDirectionalShadowCoord[i],
-                    targetUV,
-                    currentUV,
-                    safeShadowMapSize
-                );
-
-                result = receiveShadow ? pixelShadowMask(getShadow(
-                    directionalShadowMap[i],
-                    safeShadowMapSize,
-                    directionalLight.shadowBias,
-                    max(0.0, directionalLight.shadowRadius * shadowFilterScale),
-                    shadowCoord
-                )) : 1.0;
-            }
-        }
-        #pragma unroll_loop_end
-    #endif
-    #endif
-
-    return result;
-}
-
-float getPixelatedSpotShadowByIndex(
-    int shadowIndex,
-    vec2 targetUV,
-    vec2 currentUV
-) {
-    float result = 1.0;
-
-    #ifdef USE_SHADOWMAP
-    #if NUM_SPOT_LIGHT_SHADOWS > 0
-        SpotLightShadow spotLight;
-
-        #pragma unroll_loop_start
-        for (int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i++) {
-            spotLight = spotLightShadows[i];
-
-            if (UNROLLED_LOOP_INDEX == shadowIndex) {
-                vec2 safeShadowMapSize = max(
-                    spotLight.shadowMapSize,
-                    vec2(1.0)
-                );
-
-                vec4 shadowCoord = getProjectedShadowCoordAtUV(
-                    vSpotShadowCoord[i],
-                    targetUV,
-                    currentUV,
-                    safeShadowMapSize
-                );
-
-                result = receiveShadow ? pixelShadowMask(getShadow(
-                    spotShadowMap[i],
-                    safeShadowMapSize,
-                    spotLight.shadowBias,
-                    max(0.0, spotLight.shadowRadius * shadowFilterScale),
-                    shadowCoord
-                )) : 1.0;
-            }
-        }
-        #pragma unroll_loop_end
-    #endif
-    #endif
-
-    return result;
-}
-
-float getPixelatedPointShadowByIndex(
-    int shadowIndex,
-    vec2 targetUV,
-    vec2 currentUV
-) {
-    float result = 1.0;
-
-    #ifdef USE_SHADOWMAP
-    #if NUM_POINT_LIGHT_SHADOWS > 0
-        PointLightShadow pointLight;
-
-        #pragma unroll_loop_start
-        for (int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i++) {
-            pointLight = pointLightShadows[i];
-
-            if (UNROLLED_LOOP_INDEX == shadowIndex) {
-                vec2 safeShadowMapSize = max(
-                    pointLight.shadowMapSize,
-                    vec2(1.0)
-                );
-
-                vec4 shadowCoord = getPointShadowCoordAtUV(
-                    vPointShadowCoord[i],
-                    targetUV,
-                    currentUV,
-                    safeShadowMapSize
-                );
-
-                result = receiveShadow ? pixelShadowMask(getPointShadow(
-                    pointShadowMap[i],
-                    safeShadowMapSize,
-                    pointLight.shadowBias,
-                    max(0.0, pointLight.shadowRadius * shadowFilterScale),
-                    shadowCoord,
-                    pointLight.shadowCameraNear,
-                    pointLight.shadowCameraFar
-                )) : 1.0;
-            }
-        }
-        #pragma unroll_loop_end
-    #endif
-    #endif
-
-    return result;
-}
-
-float getPixelatedLightShadow(
-    int lightIndex,
-    vec2 targetUV,
-    vec2 currentUV
-) {
-    if (uLightCastShadow[lightIndex] == 0) {
-        return 1.0;
-    }
-
-    if (!PIXELATED_SHADOWS) {
-        targetUV = currentUV;
-    }
-
-    int shadowIndex = uLightShadowIndex[lightIndex];
-    if (shadowIndex < 0) {
-        return 1.0;
-    }
-
-    int type = uLightType[lightIndex];
-    float shadow = 1.0;
-
-    if (type == SA_LIGHT_DIRECTIONAL) {
-        shadow = getPixelatedDirectionalShadowByIndex(
-            shadowIndex,
-            targetUV,
-            currentUV
-        );
-    } else if (type == SA_LIGHT_SPOT) {
-        shadow = getPixelatedSpotShadowByIndex(
-            shadowIndex,
-            targetUV,
-            currentUV
-        );
-    } else {
-        shadow = getPixelatedPointShadowByIndex(
-            shadowIndex,
-            targetUV,
-            currentUV
-        );
-    }
-
-    shadow = clamp(shadow, 0.0, 1.0);
-    shadow = max(shadow, clamp(uShadowFloor, 0.0, 1.0));
-
-    return mix(
-        1.0,
-        shadow,
-        clamp(uShadowStrength, 0.0, 1.0)
-    );
 }
 
 /* ------------------------------------------------------------
@@ -8241,23 +8718,22 @@ vec3 applyToneMapping(vec3 color) {
 }
 
 void main() {
-    vec2 tiling_value = TILING;
-    if (AUTO_TILE) {
-        tiling_value = vfaceSize / TEXTURE_SIZE;
-    }
-    vec4 texel = texture2D(map, vUv * tiling_value);
+    vec2 tiling_value =
+        lfResolveTextureTiling(vfaceSize);
+
+    vec2 tiledUv = vUv * tiling_value;
+    vec4 texel = texture2D(map, tiledUv);
     texel = saApplyNativePBRBaseColor(texel);
 
     /*
-        Preserve the legacy visual flow:
-        face UV -> pixel center -> extrapolated shadow-map snap.
+        The module uses derivatives to reconstruct the pixel-aligned shadow
+        coordinates, so this must run before any fragment can be discarded.
     */
-    vec2 shadowCurrentUV = vNormalizedFaceUv;
+    vec3 pixelatedShadowByType = lfGetPixelatedShadowByType();
 
-    vec2 shadowTargetUV = getPixelCenterUV(
-        shadowCurrentUV,
-        vfaceSize * shadowPixelResolution
-    );
+    if (texel.a < 0.01) {
+        discard;
+    }
 
     /*
         Lightflow evaluates lighting in linear color space.
@@ -8273,7 +8749,7 @@ void main() {
     );
     normal = saApplyNativePBRNormal(
         normal,
-        vUv * tiling_value,
+        tiledUv,
         vWorldPos
     );
 
@@ -8293,20 +8769,23 @@ void main() {
             normal,
             vWorldPos
         );
-        float shadow = getPixelatedLightShadow(
-            i,
-            shadowTargetUV,
-            shadowCurrentUV
-        );
+        float shadow = 1.0;
+
+        if (SHADOWS) {
+            shadow = lfGetLightShadow(
+                i,
+                uLightType[i],
+                pixelatedShadowByType
+            );
+        }
 
         directLight += lightContribution * shadow;
     }
 
-    if (texel.a < 0.01) {
-        discard;
-    }
-
-    float ambientOcclusion = 1.0;
+    float ambientOcclusion = computeVoxelAO(
+        vNormalizedFaceUv,
+        normal
+    );
 
     vec3 ambientLight =
         max(uAmbientColor, vec3(0.0)) *
@@ -8343,9 +8822,9 @@ void main() {
         }
     }
 
-    float nativeMetallic = saGetNativePBRMetallic(vUv * tiling_value);
-    float nativeRoughness = saGetNativePBRRoughness(vUv * tiling_value);
-    vec3 nativeEmissive = saGetNativePBREmissive(vUv * tiling_value, texel.rgb);
+    float nativeMetallic = saGetNativePBRMetallic(tiledUv);
+    float nativeRoughness = saGetNativePBRRoughness(tiledUv);
+    vec3 nativeEmissive = saGetNativePBREmissive(tiledUv, texel.rgb);
 
     vec3 finalColor = texel.rgb * lighting;
     finalColor +=
@@ -8384,58 +8863,16 @@ void main() {
     gl_FragColor = vec4(finalColor, EMISSIVE ? 1.0 : texel.a);
 }`,
 
-                uniforms: {
-                    ...createLightflowUniforms({
-                        shadows: true
-                    }),
-
-                    "shadowPixelResolution": {
-                        type: "float",
-                        value: 1.0,
-                        expose: true,
-                        min: 1.0,
-                        max: 16.0,
-                        step: 0.05,
-                        allow_higher: true,
-                        allow_lower: false
-                    },
-
-                    "PIXELATED_SHADOWS": {
-                        type: "bool",
-                        value: true,
-                        expose: true,
-                        advanced: false
-                    },
-
-                    "shadowThreshold": {
-                        type: "float",
-                        value: 0.55,
-                        expose: true,
-                        min: 0.0,
-                        max: 1.0,
-                        step: 0.05,
-                        allow_higher: false,
-                        allow_lower: false
-                    },
-
-                    "shadowFilterScale": {
-                        type: "float",
-                        value: 1.0,
-                        expose: true,
-                        min: 0.0,
-                        max: 3.0,
-                        step: 0.05
-                    },
-
-                    "shadowFeather": {
-                        type: "float",
-                        value: 0.10,
-                        expose: true,
-                        min: 0.0,
-                        max: 0.49,
-                        step: 0.01
+                uniforms: createLightflowUniforms({
+                    shadows: true,
+                    pixelatedShadows: {
+                        enabled: false,
+                        resolution: 1.0,
+                        levels: 0,
+                        globalResolution: false,
+                        strength: 1.0
                     }
-                },
+                }),
 
                 enableShadows: true
             });
@@ -8454,6 +8891,7 @@ void main() {
 attribute float highlight;
 attribute vec2 normalizedFaceUv;
 attribute vec2 faceSize;
+attribute vec2 globalFaceSize;
 attribute vec2 uvSize;
 
 uniform bool SHADE;
@@ -8463,6 +8901,7 @@ uniform mat3 uWorldNormalMatrix;
 varying vec2 vPromoMapUv;
 varying vec2 vPromoElementUv;
 varying vec2 vPromoElementSize;
+varying vec2 vPromoGlobalFaceSize;
 varying vec2 vPromoElementUvSize;
 
 varying vec3 vPromoWorldPosition;
@@ -8534,6 +8973,7 @@ void main() {
     vPromoMapUv = uv;
     vPromoElementUv = normalizedFaceUv;
     vPromoElementSize = faceSize;
+    vPromoGlobalFaceSize = globalFaceSize;
     vPromoElementUvSize = uvSize;
 
     if (SHADE) {
@@ -8569,12 +9009,12 @@ void main() {
 }`,
 
                 fragment: `#include <common>
+${LIGHTFLOW_TEXTURE_TILING}
 
 uniform sampler2D map;
 
 uniform bool EMISSIVE;
 uniform vec3 LIGHTCOLOR;
-uniform vec2 TEXTURE_SIZE;
 
 uniform vec3 uLightPos[16];
 uniform vec3 uLightDir[16];
@@ -8660,6 +9100,7 @@ ${NATIVE_PBR_FRAGMENT}
 varying vec2 vPromoMapUv;
 varying vec2 vPromoElementUv;
 varying vec2 vPromoElementSize;
+varying vec2 vPromoGlobalFaceSize;
 varying vec2 vPromoElementUvSize;
 
 varying vec3 vPromoWorldPosition;
@@ -8667,6 +9108,11 @@ varying vec3 vPromoWorldNormal;
 
 varying float vPromoClassicLight;
 varying float vPromoHighlightLift;
+
+vec2 promoGetMapUv() {
+    return vPromoMapUv *
+        lfResolveTextureTiling(vPromoGlobalFaceSize);
+}
 
 #define SA_PROMO_POINT_LIGHT 0
 #define SA_PROMO_DIRECTIONAL_LIGHT 1
@@ -8743,8 +9189,9 @@ mat2 promoGetElementToMapJacobian() {
     vec2 localDx = dFdx(vPromoElementUv);
     vec2 localDy = dFdy(vPromoElementUv);
 
-    vec2 mapDx = dFdx(vPromoMapUv);
-    vec2 mapDy = dFdy(vPromoMapUv);
+    vec2 mapUv = promoGetMapUv();
+    vec2 mapDx = dFdx(mapUv);
+    vec2 mapDy = dFdy(mapUv);
 
     float determinant =
         localDx.x * localDy.y -
@@ -9142,17 +9589,8 @@ float promoSampleNeighborAlpha(
     }
 
     vec2 mapSample =
-        vPromoMapUv +
+        promoGetMapUv() +
         mapOffset;
-
-    if (
-        mapSample.x < 0.0 ||
-        mapSample.y < 0.0 ||
-        mapSample.x > 1.0 ||
-        mapSample.y > 1.0
-    ) {
-        return 0.0;
-    }
 
     return texture2D(map, mapSample).a;
 }
@@ -9864,9 +10302,10 @@ void main() {
         faceTangentV
     );
 
+    vec2 materialUv = promoGetMapUv();
     vec4 sampledColor = texture2D(
         map,
-        vPromoMapUv
+        materialUv
     );
     sampledColor = saApplyNativePBRBaseColor(sampledColor);
 
@@ -10441,6 +10880,12 @@ void main() {
             for (const key in minecraft_promotional_bevel.uniforms) {
                 lumaForgeUniforms[key] = cloneUniformDefinition(minecraft_promotional_bevel.uniforms[key]);
             }
+            Object.assign(
+                lumaForgeUniforms,
+                createLightflowPixelatedShadowUniforms({
+                    enabled: false
+                })
+            );
             addScreenSpaceReflectionUniforms(lumaForgeUniforms, lightflowScreenSpaceReflectionDefaults);
             // Cinematic Craft opens with a trailer-oriented grade while remaining fully editable.
             Object.entries(MATERIAL_OVERRIDE_PRESETS.trailer_hero.values).forEach(([key, value]) => {
@@ -10459,6 +10904,39 @@ void main() {
             );
 
             const lumaForgeVertex = minecraft_promotional_bevel.vertex
+                .replace(
+                    `#include <common>
+#include <shadowmap_pars_vertex>
+`,
+                    `#include <common>
+${LIGHTFLOW_PIXELATED_SHADOWS_VERTEX}
+${LIGHTFLOW_TEXTURE_TILING}
+`
+                )
+                .replace(
+                    `attribute float highlight;
+attribute vec2 normalizedFaceUv;`,
+                    `attribute float highlight;
+attribute float affected_by_shadow;
+attribute vec2 normalizedFaceUv;`
+                )
+                .replace(
+                    `    vPromoElementUvSize = uvSize;
+`,
+                    `    vPromoElementUvSize = uvSize;
+
+    lfPixelatedShadowVertexSetup(
+        worldPosition,
+        vPromoWorldNormal,
+        normalizedFaceUv,
+        globalFaceSize,
+        uvSize * abs(
+            lfResolveTextureTiling(globalFaceSize)
+        ),
+        affected_by_shadow
+    );
+`
+                )
                 .replace(
                     `varying float vPromoClassicLight;
 varying float vPromoHighlightLift;
@@ -10489,18 +10967,26 @@ varying vec4 vSA_SSRClipPosition;
 
     gl_Position = vSA_SSRClipPosition;
 `
+                )
+                .replace(
+                    `    #include <shadowmap_vertex>
+`,
+                    ``
                 );
 
             const lumaForgeFragment = minecraft_promotional_bevel.fragment
                 .replace(
                     `#include <common>
+${LIGHTFLOW_TEXTURE_TILING}
 
 uniform sampler2D map;`,
                     `#include <common>
 #include <packing>
 ${LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT}
 #include <lights_pars_begin>
-#include <shadowmap_pars_fragment>
+${LIGHTFLOW_PIXELATED_SHADOWS_FRAGMENT}
+${LIGHTFLOW_SHADOW_SELECTOR_FRAGMENT}
+${LIGHTFLOW_TEXTURE_TILING}
 ${SCREEN_SPACE_REFLECTIONS_PARS_FRAGMENT}
 
 uniform sampler2D map;`
@@ -10509,9 +10995,6 @@ uniform sampler2D map;`
                     `uniform int max_light_number;
 `,
                     `uniform int max_light_number;
-
-uniform int uLightCastShadow[16];
-uniform int uLightShadowIndex[16];
 
 uniform float uAmbient;
 uniform vec3 uAmbientColor;
@@ -10535,9 +11018,6 @@ uniform float uAOFaceNormalWeight;
 
 uniform bool uClampLighting;
 uniform bool SHADOWS;
-
-uniform float uShadowStrength;
-uniform float uShadowFloor;
 `
                 )
                 .replace(
@@ -10572,9 +11052,13 @@ ${lumaForgeLightflowHelpers}`
         faceTangentV
     );
 
+    vec2 materialUv = promoGetMapUv();
+    vec3 pixelatedShadowByType =
+        lfGetPixelatedShadowByType();
+
     vec4 sampledColor = texture2D(
         map,
-        vPromoMapUv
+        materialUv
     );
     sampledColor = saApplyNativePBRBaseColor(sampledColor);
 
@@ -10618,7 +11102,7 @@ ${lumaForgeLightflowHelpers}`
         );
         normal = saApplyNativePBRNormal(
             normal,
-            vPromoMapUv,
+            materialUv,
             vPromoWorldPosition
         );
 
@@ -10634,8 +11118,12 @@ ${lumaForgeLightflowHelpers}`
                 vPromoWorldPosition
             );
             float shadow = 1.0;
-            if (SHADOWS && uLightCastShadow[i] != 0) {
-                shadow = getCustomLightShadow(i);
+            if (SHADOWS) {
+                shadow = lfGetLightShadow(
+                    i,
+                    uLightType[i],
+                    pixelatedShadowByType
+                );
             }
 
             directLight += lightContribution * shadow;
@@ -10666,9 +11154,9 @@ ${lumaForgeLightflowHelpers}`
             }
         }
 
-        float nativeMetallic = saGetNativePBRMetallic(vPromoMapUv);
-        float nativeRoughness = saGetNativePBRRoughness(vPromoMapUv);
-        vec3 nativeEmissive = saGetNativePBREmissive(vPromoMapUv, texel.rgb);
+        float nativeMetallic = saGetNativePBRMetallic(materialUv);
+        float nativeRoughness = saGetNativePBRRoughness(materialUv);
+        vec3 nativeEmissive = saGetNativePBREmissive(materialUv, texel.rgb);
 
         finalColor = texel.rgb * lighting;
         finalColor +=
@@ -11566,7 +12054,7 @@ ${lumaForgeLightflowHelpers}`
                     void main(){ vec4 color=texture2D(tScene,vUv); float d=texture2D(tDepth,vUv).x; float sceneD=texture2D(tSceneDepth,vUv).x; if(!solid(d)||!solid(sceneD)){gl_FragColor=color;return;} vec3 c=pos(vUv,d), sceneP=pos(vUv,sceneD); float receiverTolerance=max(.0025,abs(c.z)*.00035); if(abs(sceneP.z-c.z)>receiverTolerance){gl_FragColor=color;return;} vec3 n=norm(vUv,c); vec3 axis=abs(n.z)<.95?vec3(0,0,1):vec3(0,1,0); vec3 t=normalize(cross(axis,n)), b=cross(n,t); float oc=0.0, count=0.0, rotation=hash(floor(gl_FragCoord.xy*.5))*6.2831853; for(int i=0;i<24;i++){if(i>=uSamples)continue; float q=(float(i)+.5)/float(max(uSamples,1)); float phi=float(i)*2.39996323+rotation; float z=mix(.16,.96,q); float radial=sqrt(max(1.0-z*z,0.0)); vec3 k=vec3(cos(phi)*radial,sin(phi)*radial,z); vec3 s=c+mat3(t,b,n)*k*uRadius*mix(.15,1.0,q*q); vec4 clip=uProjection*vec4(s,1.0); if(clip.w<=.000001)continue; vec2 uv=clip.xy/clip.w*.5+.5; if(uv.x<=.001||uv.y<=.001||uv.x>=.999||uv.y>=.999)continue; float sd=texture2D(tDepth,uv).x; if(!solid(sd))continue; vec3 sp=pos(uv,sd); float delta=sp.z-s.z; float localBias=max(uBias,abs(c.z)*.00012); float range=smoothstep(0.0,1.0,uRadius/max(abs(c.z-sp.z),.001)); float facing=smoothstep(-.15,.35,dot(n,normalize(sp-c+vec3(.000001)))); oc+=step(localBias,delta)*range*(1.0-facing*.35); count+=1.0;} float ao=count<1.0?1.0:pow(clamp(1.0-oc/count*uStrength,0.0,1.0),uPower); gl_FragColor=vec4(color.rgb*ao,color.a); }
                 `
             });
-            const postScene = new THREE.Scene(), postCamera = new THREE.OrthographicCamera(-1,1,1,-1,0,1), quad = new THREE.Mesh(new THREE.PlaneGeometry(2,2), material);
+            const postScene = new THREE.Scene(), postCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1), quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
             postScene.add(quad);
             const state = { preview, renderer, sceneTarget, cubeTarget, depthTexture, sceneDepthTexture, material, uniforms, postScene, postCamera, quad, width: 1, height: 1, sceneWidth: 1, sceneHeight: 1, rendering: false };
             this.states.set(preview, state);
@@ -11779,7 +12267,7 @@ ${lumaForgeLightflowHelpers}`
                 state.rendering = false;
             }
         },
-        patchPreview(preview) { if (!preview?.renderer || this.patchedPreviews.has(preview)) return; const originalRender=preview.render; if(typeof originalRender!=='function')return; const manager=this; const patchedRender=function lightflowSSAORender(){ const result=originalRender.apply(this,arguments); manager.composite(this); return result; }; preview.render=patchedRender; this.patchedPreviews.set(preview,{originalRender,patchedRender}); },
+        patchPreview(preview) { if (!preview?.renderer || this.patchedPreviews.has(preview)) return; const originalRender = preview.render; if (typeof originalRender !== 'function') return; const manager = this; const patchedRender = function lightflowSSAORender() { const result = originalRender.apply(this, arguments); manager.composite(this); return result; }; preview.render = patchedRender; this.patchedPreviews.set(preview, { originalRender, patchedRender }); },
         patchAllPreviews() { collectShaderArchitectRenderPreviews().forEach(preview => this.patchPreview(preview)); }
     };
 
@@ -15017,7 +15505,7 @@ ${lumaForgeLightflowHelpers}`
             });
         },
 
-        applyBlockbenchTextureModeUniforms(targetMaterial, sourceState) {
+        applyBlockbenchTextureModeUniforms(targetMaterial, sourceState, mapDef) {
             if (!targetMaterial || !targetMaterial.uniforms) return;
 
             const layered = !!(sourceState && sourceState.layered);
@@ -15036,6 +15524,10 @@ ${lumaForgeLightflowHelpers}`
                 const value = layered
                     ? (layeredTextures[i] || this.getTransparentFallbackTexture())
                     : this.getTransparentFallbackTexture();
+
+                if (value && value.isTexture && mapDef) {
+                    this.configureTextureWrap(value, mapDef);
+                }
 
                 if (!targetMaterial.uniforms[key]) {
                     targetMaterial.uniforms[key] = {
@@ -15775,8 +16267,8 @@ if (vSaShadowStochastic > 0.5) {
                             alphaFragment = `float saShadowAlpha = clamp(diffuseColor.a * ${baseAlpha}, 0.0, 1.0);
 float saShadowNoise = fract(52.9829189 * fract(dot(gl_FragCoord.xy, vec2(0.06711056, 0.00583715))));
 ${stochasticAlpha
-    ? 'if (saShadowAlpha <= saShadowNoise) discard;'
-    : `if (saShadowAlpha < ${sourceAlphaTest.toFixed(6)}) discard;`}`;
+                                    ? 'if (saShadowAlpha <= saShadowNoise) discard;'
+                                    : `if (saShadowAlpha < ${sourceAlphaTest.toFixed(6)}) discard;`}`;
                         }
 
                         compiledShader.fragmentShader = compiledShader.fragmentShader.replace(
@@ -15880,7 +16372,11 @@ ${stochasticAlpha
                 if (targetMaterial.map && mapDef) {
                     this.configureTextureWrap(targetMaterial.map, mapDef, { forceUpdate: true });
                 }
-                this.applyBlockbenchTextureModeUniforms(targetMaterial, sourceState);
+                this.applyBlockbenchTextureModeUniforms(
+                    targetMaterial,
+                    sourceState,
+                    mapDef
+                );
                 this.syncNativePBRUniforms(targetMaterial, sourceState, activeShader, getFallbackTexture());
 
                 if (!targetMaterial.uniforms.uWorldNormalMatrix) {
@@ -16388,7 +16884,11 @@ ${stochasticAlpha
                         if (mapDef && mat.map && mat.map.isTexture) {
                             this.configureTextureWrap(mat.map, mapDef);
                         }
-                        this.applyBlockbenchTextureModeUniforms(mat, sourceState);
+                        this.applyBlockbenchTextureModeUniforms(
+                            mat,
+                            sourceState,
+                            mapDef
+                        );
                         this.syncNativePBRUniforms(mat, sourceState, renderShader, this.getFallbackTexture());
 
                         ScreenSpaceReflectionManager.configureMaterial(mat, renderShader);
@@ -16728,25 +17228,25 @@ ${stochasticAlpha
                     element.render_intensity !== undefined
                         ? Math.max(0, Number(element.render_intensity) || 0)
                         : Math.max(0, Number(element.intensity) || 0)
-                ;
+                    ;
 
                 distanceArray[activeLightCount] =
                     element.distance !== undefined
                         ? Math.max(0, Number(element.distance) || 0)
                         : 0.0
-                ;
+                    ;
 
                 coneAngleArray[activeLightCount] =
                     THREE.MathUtils.degToRad(
                         Math.max(0.001, Math.min(89.9, Number(element.angle) || 45))
                     )
-                ;
+                    ;
 
                 penumbraArray[activeLightCount] =
                     element.penumbra !== undefined
                         ? Math.max(0, Math.min(1, Number(element.penumbra) || 0))
                         : 0.0
-                ;
+                    ;
 
                 castShadowArray[activeLightCount] = castsShadow ? 1 : 0;
                 shadowIndexArray[activeLightCount] = shadowIndex;
@@ -17190,6 +17690,13 @@ ${stochasticAlpha
                             this.selectedNativeUniformName,
                             MaterialManager.cloneUniformDefinition(def)
                         );
+
+                        if (
+                            this.selectedNativeUniformName === 'AUTO_TILE' &&
+                            this.activeMat.uniforms.map
+                        ) {
+                            this.activeMat.uniforms.map.repeat = true;
+                        }
                     },
                     removeUniform(key) {
                         this.$delete(this.activeMat.uniforms, key);
@@ -18825,8 +19332,8 @@ ${stochasticAlpha
         return new Promise((resolve, reject) => {
 
             // Use the existing ready flag when Light Manager has already loaded.
-            if (window.LIGHT_MANAGER_LOADED) {
-                resolve(window.LIGHT_MANAGER_LOADED);
+            if (window.LIGHT_MANAGER_LOADED && window.LightManagerUI && typeof window.applyIndestructibleFormGroups === 'function') {
+                resolve(window.LightManagerUI);
                 return;
             }
 
@@ -18843,10 +19350,11 @@ ${stochasticAlpha
 
             function onReady(event) {
                 if (finished) return;
+                if (!window.LIGHT_MANAGER_LOADED || !window.LightManagerUI || typeof window.applyIndestructibleFormGroups !== 'function') return;
                 finished = true;
 
                 clearTimeout(timer);
-                resolve(event.detail || window.LIGHT_MANAGER_LOADED);
+                resolve(window.LightManagerUI);
             }
 
             window.addEventListener('light_manager_initialized', onReady, { once: true });
@@ -18924,14 +19432,10 @@ ${stochasticAlpha
     let materialPropertiesShowAdvanced = false;
     let materialPropertiesUniformGroupsOpen = {};
     let activeMaterialOverridePreset = 'trailer_hero';
+    let activeMaterialOverrideScope = 'element';
 
-    let cube_material_instance;
-    let cube_material_instance_name;
-    let cube_face_material_instance;
-    let material_instance_properties_toolbar;
     let create_material_instance;
     let delete_material_instance;
-    let global_material_instance_text;
 
     function disposeTrackedResources() {
         const resources = deletables.slice();
@@ -18997,6 +19501,7 @@ ${stochasticAlpha
         version: '2.8.0',
         min_version: '4.9.0',
         variant: 'both',
+        dependencies: ['light_manager'],
 
         onload: async function () {
 
@@ -19265,210 +19770,160 @@ ${stochasticAlpha
                 ShaderEngine.requestPreviewRender({ cause });
             };
 
-            const worldBrightnessSlider = new window.ComboSlider('sa_world_brightness', {
-                label: 'shader_architect.world.brightness',
-                title: 'shader_architect.world.brightness.desc',
-                icon: 'brightness_6',
-                grow: true,
-                color: 'var(--color-axis-w)',
-                value: Number.isFinite(Number(getWorldSettingValue('brightness', 50)))
-                    ? Number(getWorldSettingValue('brightness', 50))
-                    : 50,
-                reset_value: 50,
-                min: 0,
-                max: 100,
-                step: 1,
-                allow_higher: false,
-                allow_lower: false,
-                onChange: function () {
-                    setWorldSettingValue('brightness', Number(this.value) || 0);
-                    refreshWorldRenderSettings('world_brightness_change');
-                }
-            });
+            let syncingWorldPanel = false;
+            let globalRendererPropertiesPanel = null;
+            const worldMarker = (index, tone, fallback) => window.LightManagerUI.markerColor(index, tone, fallback);
 
-            const worldShadingToggle = new Toggle('sa_world_shading', {
-                name: 'shader_architect.world.shading',
-                icon: 'wb_sunny',
-                category: 'render',
-                linked_setting: 'shading',
-                onChange: () => refreshWorldRenderSettings('world_shading_change')
-            });
-
-            const worldGridsToggle = new Toggle('sa_world_grids', {
-                name: 'shader_architect.world.grids',
-                icon: 'grid_on',
-                category: 'render',
-                linked_setting: 'grids',
-                onChange: () => ShaderEngine.requestPreviewRender({ cause: 'world_grid_change' })
-            });
-
-            const worldGroundToggle = new Toggle('sa_world_ground', {
-                name: 'shader_architect.world.ground',
-                icon: 'icon-format_free',
-                category: 'render',
-                linked_setting: 'ground_plane',
-                onChange: () => ShaderEngine.requestPreviewRender({ cause: 'world_ground_change' })
-            });
-
-            const worldAmbientOcclusionToggle = new Toggle('sa_world_ssao', {
-                name: 'Ambient Occlusion',
-                icon: 'grain',
-                category: 'render',
-                default: true,
-                value: AmbientOcclusionManager.settings.enabled,
-                onChange(value) {
-                    AmbientOcclusionManager.settings.enabled = !!value;
-                    AmbientOcclusionManager.patchAllPreviews();
-                    ShaderEngine.requestPreviewRender({ cause: 'ssao_toggle' });
-                }
-            });
-
-            const worldAmbientOcclusionSettings = new Action('sa_world_ssao_settings', {
-                name: 'Ambient Occlusion Settings',
-                icon: 'tune',
-                category: 'render',
-                condition: () => Project,
-                click() {
-                    const ao = AmbientOcclusionManager.settings;
-                    new Dialog('sa_ambient_occlusion_settings', {
-                        title: 'Ambient Occlusion',
-                        form: {
-                            quality: {
-                                label: 'Quality', type: 'select', value: String(ao.renderScale),
-                                options: { '0.5': 'Performance (50%)', '0.75': 'Balanced (75%)', '1': 'High (native resolution)' }
-                            },
-                            samples: { label: 'Samples', type: 'number', value: ao.samples, min: 4, max: 24, step: 1, description: 'Higher values reduce noise and improve contact detail.' },
-                            strength: { label: 'Strength', type: 'range', value: ao.strength, min: 0, max: 2, step: 0.01 },
-                            radius: { label: 'Radius', type: 'range', value: ao.radius, min: 0.05, max: 4, step: 0.01 },
-                            bias: { label: 'Bias', type: 'range', value: ao.bias, min: 0, max: 0.2, step: 0.001 },
-                            power: { label: 'Contrast', type: 'range', value: ao.power, min: 0.25, max: 4, step: 0.05 }
+            const openWorldAmbientOcclusionSettings = () => {
+                const ao = AmbientOcclusionManager.settings;
+                new Dialog('sa_ambient_occlusion_settings', {
+                    title: 'shader_architect.world.ao',
+                    form: {
+                        quality: {
+                            label: 'Quality', type: 'select', value: String(ao.renderScale),
+                            options: { '0.5': 'Performance (50%)', '0.75': 'Balanced (75%)', '1': 'High (native resolution)' }
                         },
-                        onConfirm(result) {
-                            ao.renderScale = Number(result.quality) || 1;
-                            ao.samples = Math.max(4, Math.min(24, Math.round(Number(result.samples) || 20)));
-                            ao.strength = Math.max(0, Math.min(2, Number(result.strength) || 0));
-                            ao.radius = Math.max(0.05, Math.min(4, Number(result.radius) || 0.05));
-                            ao.bias = Math.max(0, Math.min(0.2, Number(result.bias) || 0));
-                            ao.power = Math.max(0.25, Math.min(4, Number(result.power) || 1));
-                            AmbientOcclusionManager.patchAllPreviews();
-                            ShaderEngine.requestPreviewRender({ cause: 'ssao_settings' });
-                        }
-                    }).show();
-                }
-            });
-
-            const syncWorldToolbarControls = () => {
-                worldBrightnessSlider.set(Number(getWorldSettingValue('brightness', 50)) || 0);
-                [
-                    ['shading', worldShadingToggle],
-                    ['grids', worldGridsToggle],
-                    ['ground_plane', worldGroundToggle]
-                ].forEach(([settingKey, toggle]) => {
-                    if (!toggle) return;
-                    toggle.value = !!getWorldSettingValue(settingKey, toggle.value);
-                    if (typeof toggle.updateEnabledState === 'function') {
-                        toggle.updateEnabledState();
+                        samples: { label: 'Samples', type: 'number', value: ao.samples, min: 4, max: 24, step: 1, description: 'Higher values reduce noise and improve contact detail.' },
+                        strength: { label: 'Strength', type: 'range', value: ao.strength, min: 0, max: 2, step: 0.01 },
+                        radius: { label: 'Radius', type: 'range', value: ao.radius, min: 0.05, max: 4, step: 0.01 },
+                        bias: { label: 'Bias', type: 'range', value: ao.bias, min: 0, max: 0.2, step: 0.001 },
+                        power: { label: 'Contrast', type: 'range', value: ao.power, min: 0.25, max: 4, step: 0.05 }
+                    },
+                    onConfirm(result) {
+                        ao.renderScale = Number(result.quality) || 1;
+                        ao.samples = Math.max(4, Math.min(24, Math.round(Number(result.samples) || 20)));
+                        ao.strength = Math.max(0, Math.min(2, Number(result.strength) || 0));
+                        ao.radius = Math.max(0.05, Math.min(4, Number(result.radius) || 0.05));
+                        ao.bias = Math.max(0, Math.min(0.2, Number(result.bias) || 0));
+                        ao.power = Math.max(0.25, Math.min(4, Number(result.power) || 1));
+                        AmbientOcclusionManager.patchAllPreviews();
+                        ShaderEngine.requestPreviewRender({ cause: 'ssao_settings' });
                     }
-                });
-                worldAmbientOcclusionToggle.value = !!AmbientOcclusionManager.settings.enabled;
-                worldAmbientOcclusionToggle.updateEnabledState?.();
+                }).show();
             };
 
-            const worldSettingsToolbar = new Toolbar({
-                id: 'sa_world_settings',
-                name: 'panel.global_renderer_properties',
-                label: false,
-                condition: () => Project,
-                children: [
-                    'sa_world_brightness',
-                    '#',
-                    'sa_world_shading',
-                    'sa_world_ssao',
-                    'sa_world_ssao_settings',
-                    'sa_world_grids',
-                    'sa_world_ground'
-                ]
-            });
-
-            const worldSettingsListener = Blockbench.on('update_scene_shading', syncWorldToolbarControls);
-            syncWorldToolbarControls();
-            deletables.push(
-                worldBrightnessSlider,
-                worldShadingToggle,
-                worldAmbientOcclusionToggle,
-                worldAmbientOcclusionSettings,
-                worldGridsToggle,
-                worldGroundToggle,
-                worldSettingsToolbar,
-                worldSettingsListener
-            );
-
-            let renderWorkspaceMode = new Mode('render', {
-                name: 'Lightflow Render',
-                icon: 'photo_camera_back',
-                category: 'navigate',
-                condition: () => Project,
-                onSelect() {
-
+            const createWorldPanelForm = () => ({
+                world_header: {
+                    type: 'bar_display', value: tl('panel.global_renderer_properties'), icon: 'public',
+                    paragraph: false, expand: true, color: 'var(--color-text)'
+                },
+                world_shading: {
+                    type: 'action_toggle', value: !!getWorldSettingValue('shading', true),
+                    description: 'shader_architect.world.shading', icon_on: 'wb_sunny', icon_off: 'wb_sunny',
+                    bg_on: worldMarker(1, 'standard', '#F4D714'), color_on: 'var(--color-ui)',
+                    color_off: 'var(--color-subtle_text)'
+                },
+                world_ssao: {
+                    type: 'action_toggle', value: !!AmbientOcclusionManager.settings.enabled,
+                    description: 'shader_architect.world.ao', icon_on: 'grain', icon_off: 'grain',
+                    bg_on: worldMarker(4, 'standard', '#B55AF8'), color_on: 'var(--color-ui)',
+                    color_off: 'var(--color-subtle_text)'
+                },
+                world_ssao_settings: {
+                    type: 'action_button', icon: 'tune', description: 'shader_architect.world.ao_settings',
+                    color: worldMarker(4, 'pastel', '#C5A6E8'), click: openWorldAmbientOcclusionSettings
+                },
+                world_grids: {
+                    type: 'action_toggle', value: !!getWorldSettingValue('grids', true),
+                    description: 'shader_architect.world.grids', icon_on: 'grid_3x3', icon_off: 'grid_3x3_off',
+                    bg_on: worldMarker(0, 'standard', '#58C0FF'), color_on: 'var(--color-ui)',
+                    color_off: 'var(--color-subtle_text)'
+                },
+                world_ground: {
+                    type: 'action_toggle', value: !!getWorldSettingValue('ground_plane', true),
+                    description: 'shader_architect.world.ground', icon_on: 'layers', icon_off: 'layers_clear',
+                    bg_on: worldMarker(6, 'standard', '#00CE71'), color_on: 'var(--color-ui)',
+                    color_off: 'var(--color-subtle_text)'
+                },
+                world_brightness: {
+                    type: 'combo_slider', label: 'shader_architect.world.brightness', icon: 'brightness_6',
+                    description: 'shader_architect.world.brightness.desc', color: worldMarker(1, 'pastel', '#FFF899'),
+                    value: Number(getWorldSettingValue('brightness', 50)) || 0,
+                    resettable: true, reset_value: 50, min: 0, max: 100, step: 1
                 }
             });
-            deletables.push(renderWorkspaceMode);
 
-            Panels.outliner.condition.modes.push('render');
+            const syncWorldPanel = () => {
+                if (!globalRendererPropertiesPanel?.form || syncingWorldPanel) return;
+                const controls = globalRendererPropertiesPanel.form.form_data;
+                if (!controls) return;
+                syncingWorldPanel = true;
+                try {
+                    controls.world_brightness?.setValue?.(Number(getWorldSettingValue('brightness', 50)) || 0);
+                    controls.world_shading?.setValue?.(!!getWorldSettingValue('shading', true));
+                    controls.world_ssao?.setValue?.(!!AmbientOcclusionManager.settings.enabled);
+                    controls.world_grids?.setValue?.(!!getWorldSettingValue('grids', true));
+                    controls.world_ground?.setValue?.(!!getWorldSettingValue('ground_plane', true));
+                } finally {
+                    syncingWorldPanel = false;
+                }
+                globalRendererPropertiesPanel.form.update();
+            };
 
-            let globalRendererPropertiesPanel = new Panel('global_renderer_properties', {
-                icon: 'motion_mode',
+            globalRendererPropertiesPanel = new Panel('global_renderer_properties', {
+                name: 'panel.global_renderer_properties',
+                icon: 'public',
                 growable: true,
                 resizable: true,
                 condition: { modes: ['render'] },
                 default_position: {
-                    slot: "left_bar",
-                    float_position: [
-                        1322,
-                        57
-                    ],
-                    float_size: [
-                        314,
-                        57
-                    ],
-                    height: 57,
-                    folded: false,
-                    fixed_height: true,
-                    attached_to: "",
-                    attached_index: 0,
-                    sidebar_index: 0
+                    slot: 'left_bar', float_position: [1322, 57], float_size: [314, 120], height: 120,
+                    folded: false, fixed_height: false, attached_to: '', attached_index: 0, sidebar_index: 0
                 },
                 mode_positions: {
                     render: {
-                        slot: "left_bar",
-                        float_position: [
-                            1322,
-                            57
-                        ],
-                        float_size: [
-                            314,
-                            57
-                        ],
-                        height: 57,
-                        folded: false,
-                        fixed_height: true,
-                        attached_to: "",
-                        attached_index: 0,
-                        sidebar_index: 0
+                        slot: 'left_bar', float_position: [1322, 57], float_size: [314, 120], height: 120,
+                        folded: false, fixed_height: false, attached_to: '', attached_index: 0, sidebar_index: 0
                     }
                 },
-                toolbars: [
-                    worldSettingsToolbar
-                ]
+                form: createWorldPanelForm()
             });
 
-            deletables.push(globalRendererPropertiesPanel);
+            globalRendererPropertiesPanel.form.on('change', ({ result, changed_keys }) => {
+                if (syncingWorldPanel) return;
+                const keys = Array.isArray(changed_keys) && changed_keys.length ? changed_keys : Object.keys(result || {});
+                let shadingChanged = false;
+                let previewChanged = false;
+                if (keys.includes('world_brightness')) {
+                    setWorldSettingValue('brightness', Number(result.world_brightness) || 0);
+                    shadingChanged = true;
+                }
+                if (keys.includes('world_shading')) {
+                    setWorldSettingValue('shading', !!result.world_shading);
+                    shadingChanged = true;
+                }
+                if (keys.includes('world_grids')) {
+                    setWorldSettingValue('grids', !!result.world_grids);
+                    previewChanged = true;
+                }
+                if (keys.includes('world_ground')) {
+                    setWorldSettingValue('ground_plane', !!result.world_ground);
+                    previewChanged = true;
+                }
+                if (keys.includes('world_ssao')) {
+                    AmbientOcclusionManager.settings.enabled = !!result.world_ssao;
+                    AmbientOcclusionManager.patchAllPreviews();
+                    previewChanged = true;
+                }
+                if (shadingChanged) refreshWorldRenderSettings('world_panel_change');
+                else if (previewChanged) ShaderEngine.requestPreviewRender({ cause: 'world_panel_change' });
+            });
 
-
-
-            const setBarControl = (control, value) => {
-                if (control && typeof control.set === 'function') control.set(value);
-            };
+            window.applyIndestructibleFormGroups(globalRendererPropertiesPanel.form, [
+                {
+                    elements: ['world_header', '+', 'world_shading', 'world_ssao', 'world_ssao_settings', 'world_grids', 'world_ground'], gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: {
+                        world_header: '1 1 auto', world_shading: '0 0 auto', world_ssao: '0 0 auto',
+                        world_ssao_settings: '0 0 auto', world_grids: '0 0 auto', world_ground: '0 0 auto'
+                    }
+                },
+                { elements: ['world_brightness'], gap: '2px', flex: { world_brightness: '1 1 100%' } }
+            ]);
+            const worldPanelStyles = window.LightManagerUI.addCompactPanelStyles('global_renderer_properties');
+            const worldSettingsListener = Blockbench.on('update_scene_shading', syncWorldPanel);
+            syncWorldPanel();
+            deletables.push(globalRendererPropertiesPanel, worldPanelStyles, worldSettingsListener);
 
             const getSelectedCubes = () => getSelectedShaderElements();
             const getSelectedCube = () => {
@@ -19479,20 +19934,18 @@ ${stochasticAlpha
             const areMultipleSelected = () => getSelectedCubes().length > 1;
             const ELEMENT_MATERIAL_SCOPE = 'element';
             const getActiveMaterialScope = () => {
-                let scope = cube_face_material_instance && typeof cube_face_material_instance.get === 'function'
-                    ? cube_face_material_instance.get()
-                    : ELEMENT_MATERIAL_SCOPE;
-
-                if (Array.isArray(scope)) {
-                    scope = scope[scope.length - 1] || ELEMENT_MATERIAL_SCOPE;
-                }
+                let scope = activeMaterialOverrideScope || ELEMENT_MATERIAL_SCOPE;
 
                 const elements = getSelectedCubes();
                 const faceScopeAvailable = elements.length > 0 && elements.every(element => (
                     typeof Cube !== 'undefined' && element instanceof Cube
                 ));
-                if (scope === ELEMENT_MATERIAL_SCOPE || !faceScopeAvailable) return ELEMENT_MATERIAL_SCOPE;
-                return MaterialManager.normalizeCubeFaceName(scope) || ELEMENT_MATERIAL_SCOPE;
+                if (scope === ELEMENT_MATERIAL_SCOPE || !faceScopeAvailable) {
+                    activeMaterialOverrideScope = ELEMENT_MATERIAL_SCOPE;
+                    return ELEMENT_MATERIAL_SCOPE;
+                }
+                activeMaterialOverrideScope = MaterialManager.normalizeCubeFaceName(scope) || ELEMENT_MATERIAL_SCOPE;
+                return activeMaterialOverrideScope;
             };
             const isFaceMaterialScope = scope => !!scope && scope !== ELEMENT_MATERIAL_SCOPE;
             const getCubeMaterialInstanceId = (cube, scope = ELEMENT_MATERIAL_SCOPE) => {
@@ -19583,12 +20036,111 @@ ${stochasticAlpha
                 if (changed) ShaderEngine.updateCubes(cubes, 'sanitize_instances');
             };
 
+            const getMaterialOverrideScopeOptions = () => {
+                const options = {
+                    element: {
+                        icon: 'view_in_ar',
+                        description: 'shader_architect.material_panel.face_scope.element',
+                        color: window.LightManagerUI.markerColor(9, 'pastel', '#E0E9FB')
+                    }
+                };
+                const elements = getSelectedCubes();
+                const supportsFaces = elements.length > 0 && elements.every(element => (
+                    typeof Cube !== 'undefined' && element instanceof Cube
+                ));
+                if (!supportsFaces) return options;
+                const faceLabels = ['N', 'S', 'E', 'W', 'U', 'D'];
+                const faceColors = [3, 5, 6, 8, 1, 0];
+                ['north', 'south', 'east', 'west', 'up', 'down'].forEach((face, index) => {
+                    options[face] = {
+                        name: faceLabels[index],
+                        description: `shader_architect.material_panel.face_scope.${face}`,
+                        color: window.LightManagerUI.markerColor(faceColors[index], 'standard', 'var(--color-text)')
+                    };
+                });
+                return options;
+            };
+
+            const assignSelectedMaterialInstance = nextInstanceId => {
+                if (!nextInstanceId || nextInstanceId === '__mixed__') return false;
+                if (nextInstanceId !== 'global' && !MaterialManager.instances[nextInstanceId]) return false;
+                const cubes = getSelectedCubes();
+                if (cubes.length === 0) return false;
+                const activeScope = getActiveMaterialScope();
+                const isFaceScope = isFaceMaterialScope(activeScope);
+                const labelKey = nextInstanceId === 'global'
+                    ? (isFaceScope ? 'shader_architect.material_panel.undo.clear_face_instance' : 'shader_architect.material_panel.undo.clear_instance')
+                    : (isFaceScope ? 'shader_architect.material_panel.undo.assign_face_instance' : 'shader_architect.material_panel.undo.assign_instance');
+
+                runMaterialInstanceUndo(labelKey, cubes, () => {
+                    cubes.forEach(cube => {
+                        if (nextInstanceId === 'global') {
+                            if (isFaceScope) MaterialManager.clearMaterialInstanceFromCubeFace(cube, activeScope, { apply: false });
+                            else MaterialManager.clearCubeMaterialAssignment(cube);
+                        } else if (isFaceScope) {
+                            MaterialManager.assignInstanceToCubeFace(cube, activeScope, nextInstanceId, { apply: false });
+                        } else {
+                            MaterialManager.assignInstanceToCube(cube, nextInstanceId, { apply: false });
+                        }
+                    });
+                });
+                ShaderEngine.updateCubes(cubes, 'update_instance');
+                return true;
+            };
+
+            const triggerMaterialPanelAction = action => {
+                if (!action) return;
+                if (typeof action.trigger === 'function') action.trigger();
+                else if (typeof action.click === 'function') action.click();
+            };
+
+            const createMaterialOverrideHeader = (instanceOptions, selectedInstanceId, contextText, instance = null) => ({
+                _sa_material_header: {
+                    type: 'bar_display', value: tl('shader_architect.material_panel.title'),
+                    paragraph: false, expand: true, color: 'var(--color-subtle_text)'
+                },
+                _sa_scope: {
+                    type: 'horizontal_select', value: getActiveMaterialScope(),
+                    description: 'shader_architect.material_panel.scope', expand: true,
+                    allow_empty: false, multi_select: true,
+                    background: 'var(--color-back)', divider_color: 'var(--color-border)',
+                    options: getMaterialOverrideScopeOptions()
+                },
+                _sa_instance: {
+                    type: 'compact_select', label: 'shader_architect.material_panel.instance', hide_label: true,
+                    description: 'shader_architect.material_panel.instance.desc', background: 'transparent',
+                    value: selectedInstanceId || 'global', options: instanceOptions
+                },
+                _sa_override_context: {
+                    type: 'bar_display', value: contextText, paragraph: false, expand: true,
+                    color: 'var(--color-text)', show_condition: () => !instance
+                },
+                _sa_instance_name: {
+                    type: 'compact_text', value: instance?.name || '',
+                    placeholder: 'shader_architect.material_panel.instance_name',
+                    description: 'shader_architect.material_panel.instance_name',
+                    show_condition: () => !!instance
+                },
+                _sa_create_instance: {
+                    type: 'action_button', icon: 'masked_transitions_add',
+                    description: 'shader_architect.material_panel.create_instance',
+                    color: window.LightManagerUI.markerColor(6, 'pastel', '#7BFFA3'),
+                    click: () => triggerMaterialPanelAction(create_material_instance)
+                },
+                _sa_delete_instance: {
+                    type: 'action_button', icon: 'delete',
+                    description: 'shader_architect.material_panel.delete_instance',
+                    color: window.LightManagerUI.markerColor(3, 'pastel', '#FF9B97'),
+                    show_condition: () => cubeHasMaterialInstance(getActiveMaterialScope()),
+                    click: () => triggerMaterialPanelAction(delete_material_instance)
+                }
+            });
+
             const updateMaterialInstancePanel = () => {
-                if (!Project.parsed || Blockbench.hasFlag('switching_project')) return;
+                if (!window.Project || !Project.parsed || Blockbench.hasFlag('switching_project')) return;
 
                 const cubes = getSelectedCubes();
                 if (cubes.length === 0) {
-                    global_material_instance_text.set(tl('shader_architect.material_panel.global_material'));
                     material_properties.form.form_config = {
                         no_cube_selected: {
                             type: 'bar_display',
@@ -19606,9 +20158,11 @@ ${stochasticAlpha
                 sanitizeSelectedMaterialInstances(cubes);
                 const activeScope = getActiveMaterialScope();
                 const isFaceScope = isFaceMaterialScope(activeScope);
-                global_material_instance_text.set(isFaceScope
+                const contextText = isFaceScope
                     ? tl('shader_architect.material_panel.element_material')
-                    : (MaterialManager.materials[ShaderEngine.globalRenderMode] ? MaterialManager.materials[ShaderEngine.globalRenderMode].name : tl('shader_architect.material_panel.global_material')));
+                    : (MaterialManager.materials[ShaderEngine.globalRenderMode]
+                        ? MaterialManager.materials[ShaderEngine.globalRenderMode].name
+                        : tl('shader_architect.material_panel.global_material'));
 
                 const isMultiple = areMultipleSelected();
                 const sameMaterialInstance = allSelectedHaveSameMaterialInstance(activeScope);
@@ -19633,10 +20187,10 @@ ${stochasticAlpha
                 }
 
                 if (isMultiple && !sameMaterialInstance) {
-                    cube_material_instance.setOptions(material_instances_options);
-                    cube_material_instance.update();
-                    setBarControl(cube_material_instance, '__mixed__');
-                    material_properties.form.form_config = {
+                    material_properties.form.form_config = Object.assign(
+                        {},
+                        createMaterialOverrideHeader(material_instances_options, '__mixed__', contextText),
+                        {
                         multiple_instances: {
                             type: 'bar_display',
                             value: tl('shader_architect.material_panel.multiple_instances'),
@@ -19645,39 +20199,49 @@ ${stochasticAlpha
                             expand: true,
                             color: 'var(--color-text)'
                         }
-                    };
+                        }
+                    );
                     material_properties.form.buildForm();
                 } else {
                     // Single cube, or multiple cubes that share the same material instance.
                     const firstCube = cubes[0];
                     const instanceId = getCubeMaterialInstanceId(firstCube, activeScope);
-                    cube_material_instance.setOptions(material_instances_options);
-                    cube_material_instance.update();
-                    setBarControl(cube_material_instance, instanceId ? instanceId : 'global');
+                    const selectedInstance = instanceId ? MaterialManager.instances[instanceId] : null;
+                    const overrideHeader = createMaterialOverrideHeader(
+                        material_instances_options,
+                        instanceId || 'global',
+                        contextText,
+                        selectedInstance
+                    );
 
-                    if (instanceId && MaterialManager.instances[instanceId]) {
-                        cube_material_instance_name.set(MaterialManager.instances[instanceId].name);
-                        cube_material_instance_name.update();
-
-                        const instance = MaterialManager.instances[instanceId];
+                    if (instanceId && selectedInstance) {
+                        const instance = selectedInstance;
                         MaterialManager.revalidateMaterialInstance(instance, { save: false });
 
                         const presetOptions = {};
-                        Object.entries(MATERIAL_OVERRIDE_PRESETS).forEach(([presetId, preset]) => {
-                            presetOptions[presetId] = tl(preset.label);
+                        Object.entries(MATERIAL_OVERRIDE_PRESETS).forEach(([presetId, preset], index) => {
+                            presetOptions[presetId] = {
+                                name: preset.label,
+                                icon: 'auto_awesome',
+                                color: window.LightManagerUI.markerColor((index + 4) % 10, 'pastel', '#C5A6E8')
+                            };
                         });
 
-                        let form_config = {
+                        let form_config = Object.assign({}, overrideHeader, {
                             _sa_override_preset: {
-                                type: 'select',
-                                label: tl('shader_architect.material_panel.quick_presets') + ':',
+                                type: 'compact_select',
+                                label: 'shader_architect.material_panel.quick_presets',
+                                hide_label: true,
                                 value: activeMaterialOverridePreset,
                                 options: presetOptions,
-                                description: tl('shader_architect.material_panel.quick_presets.desc')
+                                description: 'shader_architect.material_panel.quick_presets.desc',
+                                background: 'transparent'
                             },
                             _sa_apply_override_preset: {
-                                type: 'buttons',
-                                buttons: [tl('shader_architect.material_panel.apply_preset')],
+                                type: 'action_button',
+                                icon: 'auto_fix_high',
+                                description: 'shader_architect.material_panel.apply_preset',
+                                color: window.LightManagerUI.markerColor(4, 'pastel', '#C5A6E8'),
                                 click() {
                                     if (MaterialManager.applyMaterialOverridePreset(instance, activeMaterialOverridePreset)) {
                                         Blockbench.showQuickMessage(tl('shader_architect.message.preset_applied'), 1800);
@@ -19707,7 +20271,7 @@ ${stochasticAlpha
                                 description: tl('shader_architect.material_panel.show_advanced.desc'),
                                 padding_right: '32px'
                             }
-                        };
+                        });
                         const groupedUniformControls = {};
 
                         const isMaterialUniformGroupOpen = (groupId, groupDef) => {
@@ -19948,7 +20512,7 @@ ${stochasticAlpha
                         material_properties.form.buildForm();
                     }
                     else {
-                        material_properties.form.form_config = {
+                        material_properties.form.form_config = Object.assign({}, overrideHeader, {
                             no_instance: {
                                 type: 'bar_display',
                                 value: tl(isFaceScope ? 'shader_architect.material_panel.no_face_instance' : 'shader_architect.material_panel.no_instance'),
@@ -19957,20 +20521,11 @@ ${stochasticAlpha
                                 expand: true,
                                 color: 'var(--color-text)'
                             }
-                        };
+                        });
                         material_properties.form.buildForm();
                     }
                 }
-
-                material_instance_properties_toolbar.update();
             };
-
-            global_material_instance_text = new window.BarDisplay('sa_current_global_material', {
-                icon: 'info',
-                text: tl('shader_architect.material_panel.global_material'),
-                expand: true,
-                condition: () => { return !cubeHasMaterialInstance(getActiveMaterialScope()); }
-            });
 
             create_material_instance = new Action('sa_create_material_instance', {
                 name: 'shader_architect.material_panel.create_instance',
@@ -20145,167 +20700,10 @@ ${stochasticAlpha
                 }
             });
 
-            cube_material_instance = new CompactDropdownSelect('sa_cube_material_instance', {
-                name: 'shader_architect.material_panel.instance',
-                description: 'shader_architect.material_panel.instance.desc',
-                options: {
-                    global: { name: 'shader_architect.material_panel.global_material', icon: 'globe' }
-                },
-                condition: cubeSelectedCondition,
-                onChange: function () {
-                    if (this.value === '__mixed__') return;
-
-                    const cubes = getSelectedCubes();
-                    if (cubes.length === 0) return;
-
-                    const activeScope = getActiveMaterialScope();
-                    const isFaceScope = isFaceMaterialScope(activeScope);
-                    const nextInstanceId = this.value;
-                    const labelKey = nextInstanceId === 'global'
-                        ? (isFaceScope ? 'shader_architect.material_panel.undo.clear_face_instance' : 'shader_architect.material_panel.undo.clear_instance')
-                        : (isFaceScope ? 'shader_architect.material_panel.undo.assign_face_instance' : 'shader_architect.material_panel.undo.assign_instance');
-
-                    runMaterialInstanceUndo(labelKey, cubes, () => {
-                        cubes.forEach(cube => {
-                            if (nextInstanceId === 'global') {
-                                if (isFaceScope) {
-                                    MaterialManager.clearMaterialInstanceFromCubeFace(cube, activeScope, { apply: false });
-                                } else {
-                                    MaterialManager.clearCubeMaterialAssignment(cube);
-                                }
-                            } else {
-                                if (isFaceScope) {
-                                    MaterialManager.assignInstanceToCubeFace(cube, activeScope, nextInstanceId, { apply: false });
-                                } else {
-                                    MaterialManager.assignInstanceToCube(cube, nextInstanceId, { apply: false });
-                                }
-                            }
-                        });
-                    });
-
-                    ShaderEngine.updateCubes(cubes, 'update_instance');
-                    updateMaterialInstancePanel();
-                }
-            });
-
-            cube_face_material_instance = new HorizontalSelectWidget('sa_cube_face_material_instance', {
-                expand: true, // Will fill the horizontal space of the toolbar
-                bg_color: 'var(--color-back)', // Custom background color
-                divider_color: 'var(--color-border)', // Custom color for the '|' dividers
-                allow_empty: false, // Prevents deselecting the last active item
-                value: 'element',
-
-                options: {
-                    element: {
-                        //name: 'Element',
-                        icon: 'view_in_ar',
-                        color: 'var(--color-light)',
-                        description: 'shader_architect.material_panel.face_scope.element'
-                    },
-                    north: {
-                        name: 'N',
-                        color: 'var(--color-axis-x)',
-                        description: 'shader_architect.material_panel.face_scope.north'
-                    },
-                    south: {
-                        name: 'S',
-                        color: 'var(--color-axis-z)',
-                        description: 'shader_architect.material_panel.face_scope.south'
-                    },
-                    east: {
-                        name: 'E',
-                        color: 'var(--color-axis-y)',
-                        description: 'shader_architect.material_panel.face_scope.east'
-                    },
-                    west: {
-                        name: 'W',
-                        color: 'var(--color-axis-v)',
-                        description: 'shader_architect.material_panel.face_scope.west'
-                    },
-                    up: {
-                        name: 'U',
-                        color: 'var(--color-axis-w)',
-                        description: 'shader_architect.material_panel.face_scope.up'
-                    },
-                    down: {
-                        name: 'D',
-                        color: 'var(--color-axis-u)',
-                        description: 'shader_architect.material_panel.face_scope.down'
-                    }
-                },
-
-                onSelect: function (value) {
-                    const nextScope = Array.isArray(value)
-                        ? (value[value.length - 1] || ELEMENT_MATERIAL_SCOPE)
-                        : (value || ELEMENT_MATERIAL_SCOPE);
-                    const normalizedScope = nextScope === ELEMENT_MATERIAL_SCOPE
-                        ? ELEMENT_MATERIAL_SCOPE
-                        : (MaterialManager.normalizeCubeFaceName(nextScope) || ELEMENT_MATERIAL_SCOPE);
-
-                    if (value !== normalizedScope || Array.isArray(value)) {
-                        this.set(normalizedScope);
-                    }
-                    updateMaterialInstancePanel();
-                }
-            });
-            cube_face_material_instance.set(ELEMENT_MATERIAL_SCOPE);
-
-            cube_material_instance_name = new TextInputWidget('sa_material_instance_name', {
-                name: 'shader_architect.material_panel.instance_name',
-                placeholder: tl('shader_architect.material_panel.instance_name'),
-                default_text: tl('shader_architect.material_panel.new_instance_name'),
-                expand: true,
-                condition: () => {
-                    const cubes = getSelectedCubes();
-                    if (cubes.length === 0) return false;
-                    const activeScope = getActiveMaterialScope();
-                    if (areMultipleSelected() && !allSelectedHaveSameMaterialInstance(activeScope)) return false;
-                    return cubeHasMaterialInstance(activeScope);
-                },
-
-                onFinishEdit: (text, event) => {
-                    const cubes = getSelectedCubes();
-                    if (cubes.length === 0) return;
-                    const firstCube = cubes[0];
-                    const activeScope = getActiveMaterialScope();
-                    const instanceId = getCubeMaterialInstanceId(firstCube, activeScope);
-                    const instance = MaterialManager.instances[instanceId];
-                    if (instance && instance.name !== text) {
-                        runMaterialInstanceUndo('shader_architect.material_panel.undo.rename_instance', [], () => {
-                            const requestedName = typeof text === 'string' ? text.trim() : '';
-                            MaterialManager.renameMaterialInstance(instance, requestedName, {
-                                save: false,
-                                apply: false
-                            });
-                            if (requestedName && instance.name !== requestedName) {
-                                Blockbench.showQuickMessage(tl('shader_architect.message.instance_name_adjusted'), 1800);
-                            }
-                            MaterialManager.saveMaterialInstances({ cause: 'rename_instance' });
-                        });
-                        updateMaterialInstancePanel();
-                    }
-                }
-            });
-
-            material_instance_properties_toolbar = new Toolbar({
-                id: 'sa_material_instance_properties',
-                name: 'shader_architect.material_panel.title',
-                label: true,
-                condition: cubeSelectedCondition,
-                children: [
-                    'sa_cube_face_material_instance',
-                    '#',
-                    'sa_cube_material_instance',
-                    'sa_current_global_material',
-                    'sa_material_instance_name',
-                    'sa_create_material_instance',
-                    'sa_delete_material_instance'
-                ]
-            });
-            deletables.push(create_material_instance, delete_material_instance, cube_material_instance, cube_face_material_instance, cube_material_instance_name, global_material_instance_text, material_instance_properties_toolbar);
+            deletables.push(create_material_instance, delete_material_instance);
 
             const getEventCause = (event) => event && typeof event === 'object' ? event.cause : event;
-            const isProjectSwitching = () => !Project.parsed || Blockbench.hasFlag('switching_project');
+            const isProjectSwitching = () => !window.Project || !Project.parsed || Blockbench.hasFlag('switching_project');
             const skipMaterialPanelRefreshCauses = new Set(['project_update', 'select_project', 'rename_instance', 'update_form', 'update_instance_meta', 'sanitize_instances']);
 
             let materialPanelRenderListener = Blockbench.on('shader_update_complete', (event) => {
@@ -20318,7 +20716,7 @@ ${stochasticAlpha
 
             let materialPanelSelectionListener = Blockbench.on('update_selection', () => {
                 if (isProjectSwitching()) return;
-                cube_face_material_instance.set(ELEMENT_MATERIAL_SCOPE);
+                activeMaterialOverrideScope = ELEMENT_MATERIAL_SCOPE;
                 updateMaterialInstancePanel();
             });
             deletables.push(materialPanelSelectionListener);
@@ -20380,11 +20778,13 @@ ${stochasticAlpha
                 const baseMat = MaterialManager.materials[instance.baseMaterialId] || MaterialManager.materials['classic'];
                 material_instance_manager.form.form_config = {
                     manager_instance_id: {
-                        type: 'select',
+                        type: 'compact_select',
                         label: 'shader_architect.material_panel.select_instance',
+                        hide_label: true,
                         value: activeId,
                         options: getMaterialInstanceManagerOptions(),
-                        description: 'shader_architect.material_panel.select_instance.desc'
+                        description: 'shader_architect.material_panel.select_instance.desc',
+                        background: 'transparent'
                     },
                     manager_details_label: {
                         type: 'bar_display',
@@ -20401,11 +20801,12 @@ ${stochasticAlpha
                         placeholder: tl('shader_architect.material_panel.instance_name')
                     },
                     manager_base_material: {
-                        type: 'select',
+                        type: 'compact_select',
                         label: 'shader_architect.material_panel.base_material',
                         value: 'sa_' + (instance.baseMaterialId || 'classic'),
                         options: getGlobalMaterialMenuOptions(),
-                        description: 'shader_architect.material_panel.base_material.desc'
+                        description: 'shader_architect.material_panel.base_material.desc',
+                        background: 'transparent'
                     },
                     manager_instance_icon: {
                         type: 'text',
@@ -20426,6 +20827,7 @@ ${stochasticAlpha
             };
 
             material_instance_manager = new Panel('material_instance_manager', {
+                name: 'shader_architect.material_panel.instances_title',
                 icon: 'category',
                 growable: true,
                 resizable: true,
@@ -20438,9 +20840,9 @@ ${stochasticAlpha
                     ],
                     float_size: [
                         314,
-                        300
+                        260
                     ],
-                    height: 300,
+                    height: 260,
                     folded: false,
                     fixed_height: false,
                     attached_to: "global_renderer_properties",
@@ -20456,9 +20858,9 @@ ${stochasticAlpha
                         ],
                         float_size: [
                             314,
-                            300
+                            260
                         ],
-                        height: 300,
+                        height: 260,
                         folded: false,
                         fixed_height: false,
                         attached_to: "global_renderer_properties",
@@ -20477,6 +20879,14 @@ ${stochasticAlpha
                     }
                 }
             });
+
+            window.applyIndestructibleFormGroups(material_instance_manager.form, [
+                {
+                    elements: ['manager_details_label', '+', 'manager_instance_id'], gap: '2px',
+                    divider_color: 'var(--color-grid)',
+                    flex: { manager_details_label: '1 1 auto', manager_instance_id: '0 0 auto' }
+                }
+            ]);
 
             material_instance_manager.form.on('change', ({ result, changed_keys }) => {
                 if (isProjectSwitching()) return;
@@ -20580,6 +20990,7 @@ ${stochasticAlpha
             deletables.push(materialInstanceManagerListener);
 
             material_properties = new Panel('material_properties', {
+                name: 'shader_architect.material_panel.overrides_title',
                 icon: 'motion_mode',
                 growable: true,
                 resizable: true,
@@ -20592,9 +21003,9 @@ ${stochasticAlpha
                     ],
                     float_size: [
                         314,
-                        520
+                        420
                     ],
-                    height: 520,
+                    height: 420,
                     folded: false,
                     fixed_height: false,
                     attached_to: "",
@@ -20610,9 +21021,9 @@ ${stochasticAlpha
                         ],
                         float_size: [
                             314,
-                            520
+                            420
                         ],
-                        height: 520,
+                        height: 420,
                         folded: false,
                         fixed_height: false,
                         attached_to: "",
@@ -20620,9 +21031,6 @@ ${stochasticAlpha
                         sidebar_index: 1
                     }
                 },
-                toolbars: [
-                    material_instance_properties_toolbar
-                ],
                 form: {
                     no_cube_selected: {
                         type: 'bar_display',
@@ -20635,8 +21043,55 @@ ${stochasticAlpha
                 }
             });
 
+            window.applyIndestructibleFormGroups(material_properties.form, [
+                {
+                    elements: ['_sa_instance', '_sa_override_context', '_sa_instance_name', '_sa_create_instance', '_sa_delete_instance'], gap: '2px',
+                    flex: {
+                        _sa_instance: '0 0 auto', _sa_override_context: '1 1 auto', _sa_instance_name: '1 1 auto',
+                        _sa_create_instance: '0 0 auto', _sa_delete_instance: '0 0 auto'
+                    }
+                },
+                {
+                    elements: ['_sa_override_preset', '_sa_apply_override_preset'], gap: '2px',
+                    flex: { _sa_override_preset: '1 1 auto', _sa_apply_override_preset: '0 0 auto' }
+                }
+            ]);
+
             material_properties.form.on('change', ({ result, changed_keys }) => {
                 if (isProjectSwitching()) return;
+                const keysToProcess = Array.isArray(changed_keys) && changed_keys.length
+                    ? changed_keys
+                    : Object.keys(result || {});
+
+                if (keysToProcess.includes('_sa_scope')) {
+                    const currentScope = getActiveMaterialScope();
+                    const requestedValue = result && result._sa_scope;
+                    const requestedScope = Array.isArray(requestedValue)
+                        ? (requestedValue[requestedValue.length - 1] || ELEMENT_MATERIAL_SCOPE)
+                        : requestedValue;
+                    const normalizedScope = requestedScope === ELEMENT_MATERIAL_SCOPE
+                        ? ELEMENT_MATERIAL_SCOPE
+                        : (MaterialManager.normalizeCubeFaceName(requestedScope) || ELEMENT_MATERIAL_SCOPE);
+                    if (normalizedScope !== currentScope) {
+                        activeMaterialOverrideScope = normalizedScope;
+                        updateMaterialInstancePanel();
+                        return;
+                    }
+                }
+
+                if (keysToProcess.includes('_sa_instance')) {
+                    const activeScope = getActiveMaterialScope();
+                    const selectedCubes = getSelectedCubes();
+                    const currentInstanceId = selectedCubes.length && allSelectedHaveSameMaterialInstance(activeScope)
+                        ? (getCubeMaterialInstanceId(selectedCubes[0], activeScope) || 'global')
+                        : '__mixed__';
+                    const requestedInstanceId = result && result._sa_instance;
+                    if (requestedInstanceId && requestedInstanceId !== currentInstanceId) {
+                        if (assignSelectedMaterialInstance(requestedInstanceId)) updateMaterialInstancePanel();
+                        return;
+                    }
+                }
+
                 const advancedToggleKey = '_sa_show_advanced_uniforms';
                 const nextShowAdvanced = result && Object.prototype.hasOwnProperty.call(result, advancedToggleKey)
                     ? !!result[advancedToggleKey]
@@ -20651,10 +21106,26 @@ ${stochasticAlpha
                 const instanceId = getCubeMaterialInstanceId(firstCube, activeScope);
                 if (!instanceId || !MaterialManager.instances[instanceId]) return;
                 const instance = MaterialManager.instances[instanceId];
+
+                if (keysToProcess.includes('_sa_instance_name')) {
+                    const requestedName = String(result?._sa_instance_name ?? '').trim();
+                    if (requestedName !== instance.name) {
+                        runMaterialInstanceUndo('shader_architect.material_panel.undo.rename_instance', [], () => {
+                            MaterialManager.renameMaterialInstance(instance, requestedName, {
+                                save: false,
+                                apply: false
+                            });
+                            MaterialManager.saveMaterialInstances({ cause: 'rename_instance' });
+                        });
+                        if (requestedName && instance.name !== requestedName) {
+                            Blockbench.showQuickMessage(tl('shader_architect.message.instance_name_adjusted'), 1800);
+                        }
+                        updateMaterialInstancePanel();
+                        return;
+                    }
+                }
+
                 let uniformChanged = false;
-                const keysToProcess = Array.isArray(changed_keys) && changed_keys.length
-                    ? changed_keys
-                    : Object.keys(result || {});
 
                 for (let key of keysToProcess) {
                     if (key === '_sa_override_preset') {
@@ -20665,6 +21136,8 @@ ${stochasticAlpha
                     } else if (key === '_sa_apply_override_preset') {
                         continue;
                     } else if (key === advancedToggleKey) {
+                        continue;
+                    } else if (['_sa_material_header', '_sa_scope', '_sa_instance', '_sa_override_context', '_sa_instance_name', '_sa_create_instance', '_sa_delete_instance'].includes(key)) {
                         continue;
                     } else if (MaterialManager.isUniformGroupFormKey(key)) {
                         const groupId = MaterialManager.getUniformGroupIdFromFormKey(key);
@@ -20735,6 +21208,8 @@ ${stochasticAlpha
                 if (advancedModeChanged) updateMaterialInstancePanel();
             });
 
+            updateMaterialInstancePanel();
+
             const materialPanelStyle = Blockbench.addCSS(`
                 #panel_global_renderer_properties,
                 #panel_material_instance_manager,
@@ -20751,31 +21226,24 @@ ${stochasticAlpha
                     backdrop-filter: blur(8px);
                     border-bottom: 1px solid var(--color-border);
                 }
-                #panel_global_renderer_properties .toolbar_wrapper {
-                    margin: 6px;
-                    padding: 4px;
-                    border: 1px solid var(--color-border);
-                    border-radius: 7px;
-                    background: color-mix(in srgb, var(--color-back) 70%, var(--color-ui));
-                }
                 #panel_material_instance_manager .form,
                 #panel_material_properties .form {
                     overflow-y: auto !important;
                     overflow-x: hidden;
-                    padding: 8px !important;
+                    padding: 4px !important;
                     box-sizing: border-box;
                 }
                 #panel_material_instance_manager .dialog_bar,
                 #panel_material_properties .dialog_bar {
-                    margin: 0 0 7px !important;
-                    padding: 7px 8px !important;
-                    border: 1px solid color-mix(in srgb, var(--color-border) 82%, transparent);
-                    border-radius: 7px;
-                    background: color-mix(in srgb, var(--color-back) 72%, var(--color-ui));
+                    margin: 0 !important;
+                    padding: 3px 4px !important;
+                    border: 0;
+                    border-radius: 4px;
+                    background: transparent;
                 }
                 #panel_material_instance_manager .dialog_bar:hover,
                 #panel_material_properties .dialog_bar:hover {
-                    border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border));
+                    background: color-mix(in srgb, var(--color-selected) 16%, transparent);
                 }
                 #panel_material_instance_manager .dialog_bar label,
                 #panel_material_properties .dialog_bar label {
@@ -20791,26 +21259,20 @@ ${stochasticAlpha
                     border-radius: 3px;
                 }
                 #panel_material_properties .dialog_bar[class*="form_bar__sa_uniform_group_"] {
-                    margin-top: 7px;
+                    margin-top: 4px !important;
                     padding: 0 !important;
                     background: color-mix(in srgb, var(--color-accent) 7%, var(--color-back)) !important;
-                    border-color: color-mix(in srgb, var(--color-accent) 24%, var(--color-border));
+                    border: 1px solid color-mix(in srgb, var(--color-accent) 24%, var(--color-border));
                     border-radius: 7px;
                 }
                 #panel_material_properties .dialog_bar[class*="form_bar__sa_uniform_group_"] .custom_checkbox {
                     height: 28px !important;
                     font-weight: 600;
                 }
-                #panel_material_properties .toolbar_wrapper {
-                    margin: 6px 8px 0;
-                    padding: 4px;
-                    border: 1px solid var(--color-border);
-                    border-radius: 7px;
-                    background: color-mix(in srgb, var(--color-back) 68%, var(--color-ui));
-                }
-
             `);
-            deletables.push(materialPanelStyle);
+            const materialInstancesCompactStyle = window.LightManagerUI.addCompactPanelStyles('material_instance_manager');
+            const materialOverridesCompactStyle = window.LightManagerUI.addCompactPanelStyles('material_properties');
+            deletables.push(materialPanelStyle, materialInstancesCompactStyle, materialOverridesCompactStyle);
 
             deletables.push(material_properties);
 
@@ -21050,13 +21512,9 @@ ${stochasticAlpha
             renderModeSelector = undefined;
             material_instance_manager = undefined;
             material_properties = undefined;
-            cube_material_instance = undefined;
-            cube_material_instance_name = undefined;
-            cube_face_material_instance = undefined;
-            material_instance_properties_toolbar = undefined;
             create_material_instance = undefined;
             delete_material_instance = undefined;
-            global_material_instance_text = undefined;
+            activeMaterialOverrideScope = 'element';
         }
     });
 

--- a/studio_render.js
+++ b/studio_render.js
@@ -43,8 +43,10 @@
         bloom_emissive_strength: 1.35,
         bloom_occlusion: true,
         viewport_bloom_enabled: true,
-        viewport_bloom_fps: 24,
-        viewport_bloom_quality: 'balanced',
+        // 0 follows every viewport render. A numeric value is an optional cap.
+        viewport_bloom_fps: 0,
+        viewport_bloom_quality: 'adaptive',
+        viewport_composer_revision: 2,
         color_grading_enabled: false,
         exposure: 1.0,
         contrast: 1.0,
@@ -82,9 +84,10 @@
     const VIEWPORT_COMPOSER_STATE = new Map();
 
     const VIEWPORT_BLOOM_PROFILES = {
-        performance: { scale: 0.25, maxDimension: 640, displayDpr: 1 },
-        balanced: { scale: 0.4, maxDimension: 900, displayDpr: 1 },
-        high: { scale: 0.6, maxDimension: 1280, displayDpr: 1.5 }
+        adaptive: { scale: 0.42, minScale: 0.2, maxScale: 0.7, maxDimension: 1400, adaptive: true },
+        performance: { scale: 0.25, maxDimension: 720 },
+        balanced: { scale: 0.42, maxDimension: 1100 },
+        high: { scale: 0.7, maxDimension: 1600 }
     };
 
     function clamp(value, min, max) {
@@ -131,7 +134,7 @@
     }
 
     function getViewportBloomProfile(settings) {
-        return VIEWPORT_BLOOM_PROFILES[settings?.viewport_bloom_quality] || VIEWPORT_BLOOM_PROFILES.balanced;
+        return VIEWPORT_BLOOM_PROFILES[settings?.viewport_bloom_quality] || VIEWPORT_BLOOM_PROFILES.adaptive;
     }
 
     function truncateText(text, maxLength) {
@@ -350,8 +353,9 @@
             'studio_render.field.bloom_emissive_strength': 'Emissive Texture Bloom',
             'studio_render.field.bloom_occlusion': 'Block Bloom Behind Geometry',
             'studio_render.field.viewport_bloom_enabled': 'Preview Bloom in Viewport',
-            'studio_render.field.viewport_bloom_fps': 'Viewport Bloom Refresh',
+            'studio_render.field.viewport_bloom_fps': 'Bloom FPS Limit (0 = Sync)',
             'studio_render.field.viewport_bloom_quality': 'Viewport Bloom Quality',
+            'studio_render.option.viewport_bloom.adaptive': 'Adaptive',
             'studio_render.option.viewport_bloom.performance': 'Performance',
             'studio_render.option.viewport_bloom.balanced': 'Balanced',
             'studio_render.option.viewport_bloom.high': 'High',
@@ -466,8 +470,9 @@
             'studio_render.field.bloom_emissive_strength': 'Bloom de texturas emisivas',
             'studio_render.field.bloom_occlusion': 'Bloquear Bloom detrás de geometría',
             'studio_render.field.viewport_bloom_enabled': 'Previsualizar Bloom en viewport',
-            'studio_render.field.viewport_bloom_fps': 'Actualización de Bloom en viewport',
+            'studio_render.field.viewport_bloom_fps': 'Límite FPS de Bloom (0 = sincronizado)',
             'studio_render.field.viewport_bloom_quality': 'Calidad de Bloom en viewport',
+            'studio_render.option.viewport_bloom.adaptive': 'Adaptativa',
             'studio_render.option.viewport_bloom.performance': 'Rendimiento',
             'studio_render.option.viewport_bloom.balanced': 'Equilibrada',
             'studio_render.option.viewport_bloom.high': 'Alta',
@@ -544,6 +549,7 @@
 
     function loadSettings() {
         const stored = readJSON(STORAGE_KEY, {});
+        const legacyViewportComposer = toNumber(stored.viewport_composer_revision, 0) < 2;
         const settings = Object.assign({}, DEFAULT_SETTINGS, stored);
         if (!Array.isArray(settings.resolution)) {
             settings.resolution = DEFAULT_SETTINGS.resolution.slice();
@@ -569,10 +575,13 @@
         settings.bloom_emissive_strength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         settings.bloom_occlusion = settings.bloom_occlusion !== false;
         settings.viewport_bloom_enabled = settings.viewport_bloom_enabled !== false;
-        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 24), 5, 30);
+        settings.viewport_bloom_fps = legacyViewportComposer
+            ? 0
+            : clamp(toNumber(settings.viewport_bloom_fps, 0), 0, 144);
         settings.viewport_bloom_quality = VIEWPORT_BLOOM_PROFILES[settings.viewport_bloom_quality]
             ? settings.viewport_bloom_quality
-            : 'balanced';
+            : 'adaptive';
+        settings.viewport_composer_revision = 2;
         settings.color_grading_enabled = !!settings.color_grading_enabled;
         settings.exposure = clamp(toNumber(settings.exposure, 1), 0.1, 4);
         settings.contrast = clamp(toNumber(settings.contrast, 1), 0, 3);
@@ -875,10 +884,11 @@
         settings.bloom_emissive_strength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         settings.bloom_occlusion = settings.bloom_occlusion !== false;
         settings.viewport_bloom_enabled = settings.viewport_bloom_enabled !== false;
-        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 24), 5, 30);
+        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 0), 0, 144);
         settings.viewport_bloom_quality = VIEWPORT_BLOOM_PROFILES[settings.viewport_bloom_quality]
             ? settings.viewport_bloom_quality
-            : 'balanced';
+            : 'adaptive';
+        settings.viewport_composer_revision = 2;
         settings.color_grading_enabled = !!settings.color_grading_enabled;
         settings.exposure = clamp(toNumber(settings.exposure, 1), 0.1, 4);
         settings.contrast = clamp(toNumber(settings.contrast, 1), 0, 3);
@@ -1973,26 +1983,78 @@
         return canvas;
     }
 
+    function configureViewportPostTarget(target, width, height) {
+        if (!target) return;
+        if (target.width !== width || target.height !== height) target.setSize(width, height);
+        target.viewport?.set?.(0, 0, width, height);
+        target.scissor?.set?.(0, 0, width, height);
+        target.scissorTest = false;
+    }
+
+    function createViewportPostTarget(width, height, name, depthBuffer = false) {
+        const target = new THREE.WebGLRenderTarget(width, height, {
+            minFilter: THREE.LinearFilter,
+            magFilter: THREE.LinearFilter,
+            format: THREE.RGBAFormat,
+            type: THREE.UnsignedByteType,
+            depthBuffer,
+            stencilBuffer: false
+        });
+        target.texture.name = name;
+        target.texture.generateMipmaps = false;
+        configureViewportPostTarget(target, width, height);
+        return target;
+    }
+
+    function restoreViewportRendererState(renderer, snapshot) {
+        if (!renderer || !snapshot) return;
+        if (snapshot.target) {
+            if (snapshot.targetViewport && snapshot.target.viewport) snapshot.target.viewport.copy(snapshot.targetViewport);
+            if (snapshot.targetScissor && snapshot.target.scissor) snapshot.target.scissor.copy(snapshot.targetScissor);
+            snapshot.target.scissorTest = snapshot.targetScissorTest;
+            renderer.setRenderTarget?.(snapshot.target);
+        } else {
+            renderer.setRenderTarget?.(null);
+            if (snapshot.viewport) renderer.setViewport?.(snapshot.viewport);
+            if (snapshot.scissor) renderer.setScissor?.(snapshot.scissor);
+            renderer.setScissorTest?.(snapshot.scissorTest);
+        }
+        renderer.autoClear = snapshot.autoClear;
+        renderer.setClearColor?.(snapshot.clearColor, snapshot.clearAlpha);
+        if (renderer.shadowMap && snapshot.shadowAutoUpdate !== undefined) {
+            renderer.shadowMap.autoUpdate = snapshot.shadowAutoUpdate;
+        }
+    }
+
+    function snapshotViewportRendererState(renderer) {
+        const target = renderer.getRenderTarget?.() || null;
+        const clearColor = new THREE.Color();
+        renderer.getClearColor?.(clearColor);
+        return {
+            target,
+            targetViewport: target?.viewport?.clone?.() || null,
+            targetScissor: target?.scissor?.clone?.() || null,
+            targetScissorTest: target?.scissorTest ?? false,
+            viewport: renderer.getViewport?.(new THREE.Vector4()) || null,
+            currentViewport: renderer.getCurrentViewport?.(new THREE.Vector4()) || null,
+            scissor: renderer.getScissor?.(new THREE.Vector4()) || null,
+            scissorTest: renderer.getScissorTest?.() ?? false,
+            autoClear: renderer.autoClear,
+            clearColor,
+            clearAlpha: renderer.getClearAlpha?.() ?? 1,
+            shadowAutoUpdate: renderer.shadowMap?.autoUpdate
+        };
+    }
+
     function renderViewportBloomMask(preview, state, width, height) {
         const renderer = preview?.renderer;
         const scene = window.Canvas?.scene;
-        if (!renderer || !scene || !THREE.WebGLRenderTarget || typeof renderer.readRenderTargetPixels !== 'function') {
-            return false;
-        }
+        if (!renderer || !scene || !THREE.WebGLRenderTarget) return false;
 
         if (!state.maskTarget) {
-            state.maskTarget = new THREE.WebGLRenderTarget(width, height, {
-                minFilter: THREE.LinearFilter,
-                magFilter: THREE.LinearFilter,
-                format: THREE.RGBAFormat,
-                type: THREE.UnsignedByteType,
-                depthBuffer: true,
-                stencilBuffer: false
-            });
-            state.maskTarget.texture.name = 'Lightflow_ViewportBloomMask';
-            state.maskTarget.texture.generateMipmaps = false;
-        } else if (state.maskTarget.width !== width || state.maskTarget.height !== height) {
-            state.maskTarget.setSize(width, height);
+            state.maskTarget = createViewportPostTarget(width, height, 'Lightflow_ViewportBloomMask', true);
+        } else {
+            configureViewportPostTarget(state.maskTarget, width, height);
         }
 
         const hiddenVisibility = new Map();
@@ -2008,8 +2070,7 @@
             const original = object.material;
             const sourceMaterials = Array.isArray(original) ? original : [original];
             const replacements = sourceMaterials.map(source => {
-                const emissive = getMaterialEmissiveState(source).active;
-                return getBloomMaskMaterial(source, emissive);
+                return getBloomMaskMaterial(source, getMaterialEmissiveState(source).active);
             });
             materialChanges.push({ object, material: original });
             object.material = Array.isArray(original) ? replacements : replacements[0];
@@ -2017,23 +2078,20 @@
         if (typeof scene.traverseVisible === 'function') scene.traverseVisible(replaceMaterial);
         else scene.traverse(replaceMaterial);
 
-        const previousTarget = renderer.getRenderTarget?.();
-        const previousAutoClear = renderer.autoClear;
-        const previousShadowAutoUpdate = renderer.shadowMap?.autoUpdate;
-        const previousViewport = renderer.getViewport?.(new THREE.Vector4()) || null;
-        const previousScissor = renderer.getScissor?.(new THREE.Vector4()) || null;
-        const previousScissorTest = renderer.getScissorTest?.() ?? false;
-        const previousClearColor = new THREE.Color();
-        const previousClearAlpha = renderer.getClearAlpha?.() ?? 1;
-        renderer.getClearColor?.(previousClearColor);
-
+        const snapshot = snapshotViewportRendererState(renderer);
         let succeeded = false;
         try {
             renderer.autoClear = true;
             if (renderer.shadowMap) renderer.shadowMap.autoUpdate = false;
+            /*
+             * In Three r129 setViewport() always multiplies by renderer DPR,
+             * even when a render target is active. The target viewport is
+             * already expressed in physical target pixels, so calling it here
+             * produced the exact 1.25x offset seen with Windows scaling at 125%.
+             * setRenderTarget() consumes target.viewport without a second DPR.
+             */
+            configureViewportPostTarget(state.maskTarget, width, height);
             renderer.setRenderTarget(state.maskTarget);
-            renderer.setViewport?.(0, 0, width, height);
-            renderer.setScissorTest?.(false);
             renderer.setClearColor?.(0x000000, 0);
             renderer.clear?.(true, true, true);
             renderer.render(scene, preview.camera);
@@ -2041,172 +2099,375 @@
                 window.LightflowAtmosphere.composite(preview, { studio: true, bloomMask: true });
                 renderer.setRenderTarget(state.maskTarget);
             }
-
-            const pixelCount = width * height * 4;
-            if (!state.maskPixels || state.maskPixels.length !== pixelCount) {
-                state.maskPixels = new Uint8Array(pixelCount);
-            }
-            renderer.readRenderTargetPixels(state.maskTarget, 0, 0, width, height, state.maskPixels);
-
-            const context = state.maskCanvas.getContext('2d', { alpha: true });
-            const image = context.createImageData(width, height);
-            const rowLength = width * 4;
-            for (let row = 0; row < height; row++) {
-                const sourceOffset = (height - row - 1) * rowLength;
-                image.data.set(state.maskPixels.subarray(sourceOffset, sourceOffset + rowLength), row * rowLength);
-            }
-            context.putImageData(image, 0, 0);
             succeeded = true;
         } finally {
             for (let index = materialChanges.length - 1; index >= 0; index--) {
                 materialChanges[index].object.material = materialChanges[index].material;
             }
             hiddenVisibility.forEach((visible, object) => { object.visible = visible; });
-            renderer.setRenderTarget?.(previousTarget || null);
-            if (previousViewport) renderer.setViewport?.(previousViewport);
-            if (previousScissor) renderer.setScissor?.(previousScissor);
-            renderer.setScissorTest?.(previousScissorTest);
-            renderer.autoClear = previousAutoClear;
-            if (renderer.shadowMap && previousShadowAutoUpdate !== undefined) {
-                renderer.shadowMap.autoUpdate = previousShadowAutoUpdate;
-            }
-            renderer.setClearColor?.(previousClearColor, previousClearAlpha);
+            restoreViewportRendererState(renderer, snapshot);
         }
         return succeeded;
     }
 
+    function createViewportComposerResources(state) {
+        if (state.postScene) return;
+        state.postCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+        state.postScene = new THREE.Scene();
+        state.postGeometry = new THREE.PlaneGeometry(2, 2);
+
+        state.downsampleMaterial = new THREE.ShaderMaterial({
+            uniforms: {
+                tInput: { value: null },
+                uTexel: { value: new THREE.Vector2(1, 1) },
+                uOffset: { value: 1 },
+                uThreshold: { value: 0.72 },
+                uEmissiveStrength: { value: 1.35 },
+                uApplyThreshold: { value: true }
+            },
+            vertexShader: `
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = vec4(position.xy, 0.0, 1.0);
+                }
+            `,
+            fragmentShader: `
+                precision highp float;
+                uniform sampler2D tInput;
+                uniform vec2 uTexel;
+                uniform float uOffset;
+                uniform float uThreshold;
+                uniform float uEmissiveStrength;
+                uniform bool uApplyThreshold;
+                varying vec2 vUv;
+
+                vec3 bloomSample(vec2 uv) {
+                    vec3 color = texture2D(tInput, uv).rgb;
+                    if (!uApplyThreshold) return color;
+                    color *= uEmissiveStrength;
+                    float signal = max(color.r, max(color.g, color.b));
+                    float contribution = clamp((signal - uThreshold) / max(0.001, 1.0 - uThreshold), 0.0, 1.0);
+                    return color * contribution;
+                }
+
+                void main() {
+                    vec2 d = uTexel * uOffset;
+                    vec3 color = bloomSample(vUv) * 4.0;
+                    color += bloomSample(vUv + vec2( d.x, 0.0)) * 2.0;
+                    color += bloomSample(vUv + vec2(-d.x, 0.0)) * 2.0;
+                    color += bloomSample(vUv + vec2(0.0,  d.y)) * 2.0;
+                    color += bloomSample(vUv + vec2(0.0, -d.y)) * 2.0;
+                    color += bloomSample(vUv + vec2( d.x,  d.y));
+                    color += bloomSample(vUv + vec2(-d.x,  d.y));
+                    color += bloomSample(vUv + vec2( d.x, -d.y));
+                    color += bloomSample(vUv + vec2(-d.x, -d.y));
+                    gl_FragColor = vec4(color * 0.0625, 1.0);
+                }
+            `,
+            depthTest: false,
+            depthWrite: false,
+            transparent: false,
+            blending: THREE.NoBlending
+        });
+        state.downsampleMaterial.name = 'Lightflow_ViewportBloomDownsample';
+
+        state.compositeMaterial = new THREE.ShaderMaterial({
+            uniforms: {
+                tBeauty: { value: null },
+                tMask: { value: null },
+                tBloom0: { value: null },
+                tBloom1: { value: null },
+                tBloom2: { value: null },
+                uUseBeauty: { value: false },
+                uUseBloom: { value: true },
+                uUseColorGrade: { value: false },
+                uThreshold: { value: 0.72 },
+                uBloomStrength: { value: 0.8 },
+                uEmissiveStrength: { value: 1.35 },
+                uExposure: { value: 1 },
+                uContrast: { value: 1 },
+                uSaturation: { value: 1 },
+                uTemperature: { value: 0 },
+                uTint: { value: 0 },
+                uVignette: { value: 0 }
+            },
+            vertexShader: `
+                varying vec2 vUv;
+                void main() {
+                    vUv = uv;
+                    gl_Position = vec4(position.xy, 0.0, 1.0);
+                }
+            `,
+            fragmentShader: `
+                precision highp float;
+                uniform sampler2D tBeauty;
+                uniform sampler2D tMask;
+                uniform sampler2D tBloom0;
+                uniform sampler2D tBloom1;
+                uniform sampler2D tBloom2;
+                uniform bool uUseBeauty;
+                uniform bool uUseBloom;
+                uniform bool uUseColorGrade;
+                uniform float uThreshold;
+                uniform float uBloomStrength;
+                uniform float uEmissiveStrength;
+                uniform float uExposure;
+                uniform float uContrast;
+                uniform float uSaturation;
+                uniform float uTemperature;
+                uniform float uTint;
+                uniform float uVignette;
+                varying vec2 vUv;
+
+                vec3 extractCore(vec3 color) {
+                    color *= uEmissiveStrength;
+                    float signal = max(color.r, max(color.g, color.b));
+                    float contribution = clamp((signal - uThreshold) / max(0.001, 1.0 - uThreshold), 0.0, 1.0);
+                    return color * contribution;
+                }
+
+                vec3 colorGrade(vec3 color) {
+                    color *= uExposure;
+                    color = (color - 0.5) * uContrast + 0.5;
+                    float luminance = dot(color, vec3(0.2126, 0.7152, 0.0722));
+                    color = mix(vec3(luminance), color, uSaturation);
+                    color += vec3(uTemperature * 0.12 + uTint * 0.025, -abs(uTint) * 0.07, -uTemperature * 0.12 + uTint * 0.025);
+                    float edge = smoothstep(0.38, 0.78, length(vUv - 0.5));
+                    color *= 1.0 - edge * uVignette * 0.82;
+                    return max(color, vec3(0.0));
+                }
+
+                void main() {
+                    vec4 beauty = uUseBeauty ? texture2D(tBeauty, vUv) : vec4(0.0);
+                    vec3 bloom = vec3(0.0);
+                    if (uUseBloom) {
+                        bloom += extractCore(texture2D(tMask, vUv).rgb) * 0.10;
+                        bloom += texture2D(tBloom0, vUv).rgb * 0.42;
+                        bloom += texture2D(tBloom1, vUv).rgb * 0.30;
+                        bloom += texture2D(tBloom2, vUv).rgb * 0.18;
+                        bloom *= uBloomStrength;
+                    }
+                    vec3 color = beauty.rgb + bloom;
+                    if (uUseColorGrade) color = colorGrade(color);
+                    gl_FragColor = vec4(color, uUseBeauty ? beauty.a : 1.0);
+                }
+            `,
+            depthTest: false,
+            depthWrite: false,
+            transparent: true,
+            blending: THREE.AdditiveBlending
+        });
+        state.compositeMaterial.name = 'Lightflow_ViewportGPUComposer';
+        state.postQuad = new THREE.Mesh(state.postGeometry, state.downsampleMaterial);
+        state.postQuad.frustumCulled = false;
+        state.postScene.add(state.postQuad);
+    }
+
+    function ensureViewportBeautyTexture(state, renderer, snapshot, width, height) {
+        let needsInitialization = false;
+        if (!state.beautyTarget) {
+            state.beautyTarget = createViewportPostTarget(width, height, 'Lightflow_ViewportBeauty');
+            needsInitialization = true;
+        } else {
+            needsInitialization = state.beautyTarget.width !== width || state.beautyTarget.height !== height;
+            configureViewportPostTarget(state.beautyTarget, width, height);
+        }
+        // Initializing a WebGLRenderTarget gives r129 copyFramebufferToTexture
+        // a real GPU texture without allocating or reading a CPU-side image.
+        if (needsInitialization) {
+            renderer.setRenderTarget(state.beautyTarget);
+            restoreViewportRendererState(renderer, snapshot);
+        }
+        return state.beautyTarget.texture;
+    }
+
+    function renderViewportBloomPyramid(preview, state, maskWidth, maskHeight, viewWidth, viewHeight) {
+        const renderer = preview.renderer;
+        createViewportComposerResources(state);
+        const sizes = [2, 4, 8].map(divisor => ({
+            width: Math.max(2, Math.round(maskWidth / divisor)),
+            height: Math.max(2, Math.round(maskHeight / divisor))
+        }));
+        state.bloomTargets = state.bloomTargets || [];
+        sizes.forEach((size, index) => {
+            if (!state.bloomTargets[index]) {
+                state.bloomTargets[index] = createViewportPostTarget(
+                    size.width,
+                    size.height,
+                    'Lightflow_ViewportBloomMip' + index
+                );
+            } else {
+                configureViewportPostTarget(state.bloomTargets[index], size.width, size.height);
+            }
+        });
+
+        const material = state.downsampleMaterial;
+        const uniforms = material.uniforms;
+        const radiusInMaskPixels = clamp(toNumber(currentSettings.bloom_radius, 18), 1, 96) * maskWidth / Math.max(1, viewWidth);
+        state.postQuad.material = material;
+        renderer.autoClear = true;
+        renderer.setClearColor?.(0x000000, 0);
+
+        let input = state.maskTarget.texture;
+        let inputWidth = maskWidth;
+        let inputHeight = maskHeight;
+        for (let index = 0; index < state.bloomTargets.length; index++) {
+            const target = state.bloomTargets[index];
+            uniforms.tInput.value = input;
+            uniforms.uTexel.value.set(1 / Math.max(1, inputWidth), 1 / Math.max(1, inputHeight));
+            uniforms.uOffset.value = clamp(0.85 + radiusInMaskPixels * (0.055 + index * 0.035), 0.85, 5.5);
+            uniforms.uThreshold.value = clamp(toNumber(currentSettings.bloom_threshold, 0.72), 0, 1);
+            uniforms.uEmissiveStrength.value = clamp(toNumber(currentSettings.bloom_emissive_strength, 1.35), 0, 6);
+            uniforms.uApplyThreshold.value = index === 0;
+            renderer.setRenderTarget(target);
+            renderer.clear?.(true, false, false);
+            renderer.render(state.postScene, state.postCamera);
+            input = target.texture;
+            inputWidth = target.width;
+            inputHeight = target.height;
+        }
+        return state.bloomTargets;
+    }
+
+    function renderViewportGPUComposite(preview, state, snapshot, useBloom, useColorGrade) {
+        const renderer = preview.renderer;
+        createViewportComposerResources(state);
+        const material = state.compositeMaterial;
+        const uniforms = material.uniforms;
+        const fallback = state.maskTarget?.texture || state.beautyTarget?.texture;
+        uniforms.tBeauty.value = state.beautyTarget?.texture || fallback;
+        uniforms.tMask.value = state.maskTarget?.texture || fallback;
+        uniforms.tBloom0.value = state.bloomTargets?.[0]?.texture || fallback;
+        uniforms.tBloom1.value = state.bloomTargets?.[1]?.texture || uniforms.tBloom0.value;
+        uniforms.tBloom2.value = state.bloomTargets?.[2]?.texture || uniforms.tBloom1.value;
+        uniforms.uUseBeauty.value = !!useColorGrade;
+        uniforms.uUseBloom.value = !!useBloom;
+        uniforms.uUseColorGrade.value = !!useColorGrade;
+        uniforms.uThreshold.value = clamp(toNumber(currentSettings.bloom_threshold, 0.72), 0, 1);
+        uniforms.uBloomStrength.value = clamp(toNumber(currentSettings.bloom_strength, 0.8), 0, 3);
+        uniforms.uEmissiveStrength.value = clamp(toNumber(currentSettings.bloom_emissive_strength, 1.35), 0, 6);
+        uniforms.uExposure.value = clamp(toNumber(currentSettings.exposure, 1), 0.1, 4);
+        uniforms.uContrast.value = clamp(toNumber(currentSettings.contrast, 1), 0, 3);
+        uniforms.uSaturation.value = clamp(toNumber(currentSettings.saturation, 1), 0, 3);
+        uniforms.uTemperature.value = clamp(toNumber(currentSettings.temperature, 0), -1, 1);
+        uniforms.uTint.value = clamp(toNumber(currentSettings.tint, 0), -1, 1);
+        uniforms.uVignette.value = clamp(toNumber(currentSettings.vignette, 0), 0, 1);
+
+        state.postQuad.material = material;
+        material.transparent = !useColorGrade;
+        material.blending = useColorGrade ? THREE.NoBlending : THREE.AdditiveBlending;
+        renderer.setRenderTarget?.(null);
+        if (snapshot.viewport) renderer.setViewport?.(snapshot.viewport);
+        if (snapshot.scissor) renderer.setScissor?.(snapshot.scissor);
+        renderer.setScissorTest?.(snapshot.scissorTest);
+        renderer.autoClear = false;
+        renderer.render(state.postScene, state.postCamera);
+    }
+
     function getViewportComposerState(preview) {
-        if (!preview?.canvas || !preview.canvas.parentElement) return null;
+        if (!preview?.canvas || !preview.renderer) return null;
         let state = VIEWPORT_COMPOSER_STATE.get(preview);
         if (state) return state;
-
-        const overlay = document.createElement('canvas');
-        overlay.className = 'lightflow_scene_composer_overlay';
-        Object.assign(overlay.style, {
-            position: 'absolute',
-            pointerEvents: 'none',
-            zIndex: '4',
-            display: 'none'
-        });
-        const parent = preview.canvas.parentElement;
-        const previousParentPosition = parent.style.position;
-        if (getComputedStyle(parent).position === 'static') parent.style.position = 'relative';
-        parent.appendChild(overlay);
-
         state = {
             preview,
-            overlay,
-            parent,
-            previousParentPosition,
-            baseCanvas: document.createElement('canvas'),
-            maskCanvas: document.createElement('canvas'),
-            bloomWorkspace: {},
             maskTarget: null,
-            maskPixels: null,
+            bloomTargets: null,
+            beautyTarget: null,
+            copyPosition: new THREE.Vector2(),
+            postScene: null,
+            postCamera: null,
+            postQuad: null,
+            postGeometry: null,
+            downsampleMaterial: null,
+            compositeMaterial: null,
+            dynamicScale: VIEWPORT_BLOOM_PROFILES.adaptive.scale,
+            composerMs: 0,
+            adaptiveFrames: 0,
             lastRender: 0,
             rendering: false,
             scheduled: false,
-            scheduleHandle: null
+            disposed: false
         };
         VIEWPORT_COMPOSER_STATE.set(preview, state);
         return state;
     }
 
-    function positionViewportComposerOverlay(state) {
-        const source = state.preview.canvas;
-        const parentRect = state.parent.getBoundingClientRect();
-        const sourceRect = source.getBoundingClientRect();
-        state.overlay.style.left = (sourceRect.left - parentRect.left + state.parent.scrollLeft) + 'px';
-        state.overlay.style.top = (sourceRect.top - parentRect.top + state.parent.scrollTop) + 'px';
-        state.overlay.style.width = sourceRect.width + 'px';
-        state.overlay.style.height = sourceRect.height + 'px';
+    function hideViewportComposerOverlay() {
+        // GPU composition is drawn into the viewport framebuffer, so there is
+        // no persistent DOM overlay to hide or accidentally misalign.
     }
 
-    function hideViewportComposerOverlay(preview) {
-        const state = VIEWPORT_COMPOSER_STATE.get(preview);
-        if (state?.overlay) state.overlay.style.display = 'none';
+    function updateAdaptiveViewportBloom(state, elapsed, profile) {
+        if (!profile.adaptive) return;
+        state.composerMs = state.composerMs > 0 ? state.composerMs * 0.88 + elapsed * 0.12 : elapsed;
+        state.adaptiveFrames++;
+        if (state.adaptiveFrames < 24) return;
+        state.adaptiveFrames = 0;
+        const fpsLimit = clamp(toNumber(currentSettings.viewport_bloom_fps, 0), 0, 144);
+        const frameBudget = 1000 / Math.max(30, fpsLimit || 60);
+        if (state.composerMs > frameBudget * 0.46) {
+            state.dynamicScale = Math.max(profile.minScale, state.dynamicScale * 0.88);
+        } else if (state.composerMs < frameBudget * 0.22) {
+            state.dynamicScale = Math.min(profile.maxScale, state.dynamicScale * 1.06);
+        }
     }
 
     function renderViewportComposer(preview) {
-        if (!preview?.renderer || !preview.canvas || window.LightManagerStudioRenderSession || preview.sa_studio_render_active) {
-            hideViewportComposerOverlay(preview);
-            return;
-        }
-        if (!isLightflowRenderMode()) {
-            hideViewportComposerOverlay(preview);
-            return;
-        }
-        const active = (
-            currentSettings.viewport_bloom_enabled &&
-            currentSettings.bloom_enabled
-        ) || currentSettings.color_grading_enabled;
-        if (!active) {
-            hideViewportComposerOverlay(preview);
-            return;
-        }
+        if (!preview?.renderer || !preview.canvas || window.LightManagerStudioRenderSession || preview.sa_studio_render_active) return;
+        if (!isLightflowRenderMode()) return;
+        const useBloom = !!(currentSettings.viewport_bloom_enabled && currentSettings.bloom_enabled);
+        const useColorGrade = !!currentSettings.color_grading_enabled;
+        if (!useBloom && !useColorGrade) return;
 
         const state = getViewportComposerState(preview);
-        if (!state || state.rendering) return;
+        if (!state || state.rendering || state.disposed) return;
         const now = performance.now();
-        const interval = 1000 / clamp(toNumber(currentSettings.viewport_bloom_fps, 24), 5, 30);
-        if (now - state.lastRender < interval) {
-            // Keep the last completed post-process frame visible while the
-            // composer is throttled. Hiding it here would alternate between
-            // graded and ungraded frames on a faster viewport.
-            return;
-        }
+        const fpsLimit = clamp(toNumber(currentSettings.viewport_bloom_fps, 0), 0, 144);
+        const interval = fpsLimit > 0 ? 1000 / fpsLimit : 0;
+        if (interval > 0 && now - state.lastRender < interval) return;
 
-        const source = preview.canvas;
+        const renderer = preview.renderer;
+        const snapshot = snapshotViewportRendererState(renderer);
+        // The compositor is designed for the visible framebuffer. Nested
+        // Studio/SSR/AO render-target passes must finish before it runs.
+        if (snapshot.target) return;
+        const currentViewport = snapshot.currentViewport;
+        const drawingBuffer = renderer.getDrawingBufferSize?.(new THREE.Vector2()) || null;
+        const viewWidth = Math.max(1, Math.round(currentViewport?.z || drawingBuffer?.x || preview.canvas.width || 1));
+        const viewHeight = Math.max(1, Math.round(currentViewport?.w || drawingBuffer?.y || preview.canvas.height || 1));
         const profile = getViewportBloomProfile(currentSettings);
-        const width = Math.max(1, Math.min(
-            source.width || source.clientWidth || 1,
-            Math.round((source.clientWidth || source.width || 1) * profile.displayDpr)
-        ));
-        const height = Math.max(1, Math.min(
-            source.height || source.clientHeight || 1,
-            Math.round((source.clientHeight || source.height || 1) * profile.displayDpr)
-        ));
-        [state.baseCanvas, state.overlay].forEach(canvas => {
-            if (canvas.width !== width) canvas.width = width;
-            if (canvas.height !== height) canvas.height = height;
-        });
-        const bloomScale = Math.min(profile.scale, profile.maxDimension / Math.max(width, height));
-        const maskWidth = Math.max(2, Math.round(width * bloomScale));
-        const maskHeight = Math.max(2, Math.round(height * bloomScale));
-        if (state.maskCanvas.width !== maskWidth) state.maskCanvas.width = maskWidth;
-        if (state.maskCanvas.height !== maskHeight) state.maskCanvas.height = maskHeight;
-        positionViewportComposerOverlay(state);
+        const requestedScale = profile.adaptive ? state.dynamicScale : profile.scale;
+        const bloomScale = Math.min(requestedScale, profile.maxDimension / Math.max(viewWidth, viewHeight));
+        const maskWidth = Math.max(2, Math.round(viewWidth * bloomScale));
+        const maskHeight = Math.max(2, Math.round(viewHeight * bloomScale));
+        const started = performance.now();
 
         state.rendering = true;
-        state.lastRender = now;
         try {
-            const baseContext = state.baseCanvas.getContext('2d', { alpha: true });
-            baseContext.clearRect(0, 0, width, height);
-            baseContext.drawImage(source, 0, 0, width, height);
-
-            if (currentSettings.viewport_bloom_enabled && currentSettings.bloom_enabled) {
-                const maskContext = state.maskCanvas.getContext('2d', { alpha: true });
-                maskContext.clearRect(0, 0, maskWidth, maskHeight);
-                if (renderViewportBloomMask(preview, state, maskWidth, maskHeight)) {
-                    applyFinalBloom(state.baseCanvas, currentSettings, state.maskCanvas, {
-                        processingWidth: maskWidth,
-                        processingHeight: maskHeight,
-                        maxDimension: profile.maxDimension,
-                        emissiveOnly: true,
-                        workspace: state.bloomWorkspace
-                    });
-                }
+            if (useColorGrade) {
+                const beauty = ensureViewportBeautyTexture(state, renderer, snapshot, viewWidth, viewHeight);
+                if (!beauty || typeof renderer.copyFramebufferToTexture !== 'function') return;
+                const originX = Math.max(0, Math.round(currentViewport?.x || 0));
+                const originY = Math.max(0, Math.round(currentViewport?.y || 0));
+                renderer.copyFramebufferToTexture(state.copyPosition.set(originX, originY), beauty);
             }
-            applyFinalColorGrade(state.baseCanvas, currentSettings);
-
-            const overlayContext = state.overlay.getContext('2d', { alpha: true });
-            overlayContext.clearRect(0, 0, width, height);
-            overlayContext.drawImage(state.baseCanvas, 0, 0, width, height);
-            state.overlay.style.display = 'block';
+            let bloomReady = false;
+            if (useBloom && renderViewportBloomMask(preview, state, maskWidth, maskHeight)) {
+                renderViewportBloomPyramid(preview, state, maskWidth, maskHeight, viewWidth, viewHeight);
+                bloomReady = true;
+            }
+            renderViewportGPUComposite(preview, state, snapshot, bloomReady, useColorGrade);
+            state.lastRender = now;
         } catch (error) {
-            state.overlay.style.display = 'none';
+            if (!state.failureReported) {
+                state.failureReported = true;
+                console.warn('[Studio Render] realtime GPU composer failed', error);
+            }
         } finally {
+            restoreViewportRendererState(renderer, snapshot);
             state.rendering = false;
+            updateAdaptiveViewportBloom(state, performance.now() - started, profile);
         }
     }
 
@@ -2240,14 +2501,19 @@
         if (!state || state.scheduled) return;
         state.scheduled = true;
         const run = () => {
+            if (state.disposed) return;
             state.scheduled = false;
-            state.scheduleHandle = null;
             renderViewportComposer(preview);
         };
-        if (typeof requestAnimationFrame === 'function') {
-            state.scheduleHandle = requestAnimationFrame(run);
+        // A microtask runs after every synchronous preview wrapper (including
+        // AO and Atmosphere) but before the browser presents the frame. This
+        // avoids both the old AO load-order race and a one-frame Bloom lag.
+        if (typeof queueMicrotask === 'function') {
+            queueMicrotask(run);
+        } else if (typeof Promise !== 'undefined') {
+            Promise.resolve().then(run);
         } else {
-            state.scheduleHandle = setTimeout(run, 0);
+            setTimeout(run, 0);
         }
     }
 
@@ -2258,18 +2524,16 @@
     function disposeViewportComposers() {
         VIEWPORT_COMPOSER_STATE.forEach((state, preview) => {
             if (preview?.render === state.patchedRender) preview.render = state.originalRender;
+            state.disposed = true;
             state.maskTarget?.dispose?.();
-            if (state.scheduleHandle !== null) {
-                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(state.scheduleHandle);
-                else clearTimeout(state.scheduleHandle);
-            }
+            state.bloomTargets?.forEach?.(target => target?.dispose?.());
+            state.beautyTarget?.dispose?.();
+            state.downsampleMaterial?.dispose?.();
+            state.compositeMaterial?.dispose?.();
+            state.postGeometry?.dispose?.();
             state.maskTarget = null;
-            state.maskPixels = null;
-            state.bloomWorkspace = null;
-            state.overlay?.remove?.();
-            if (state.parent && state.previousParentPosition !== undefined) {
-                state.parent.style.position = state.previousParentPosition;
-            }
+            state.bloomTargets = null;
+            state.beautyTarget = null;
         });
         VIEWPORT_COMPOSER_STATE.clear();
     }
@@ -3156,9 +3420,9 @@
                 type: 'range',
                 label: 'studio_render.field.viewport_bloom_fps',
                 value: settings.viewport_bloom_fps,
-                min: 5,
-                max: 30,
-                step: 5,
+                min: 0,
+                max: 144,
+                step: 1,
                 condition: form => !!form.bloom_enabled && !!form.viewport_bloom_enabled && !!form.show_advanced
             },
             viewport_bloom_quality: {
@@ -3166,6 +3430,7 @@
                 label: 'studio_render.field.viewport_bloom_quality',
                 value: settings.viewport_bloom_quality,
                 options: {
+                    adaptive: 'studio_render.option.viewport_bloom.adaptive',
                     performance: 'studio_render.option.viewport_bloom.performance',
                     balanced: 'studio_render.option.viewport_bloom.balanced',
                     high: 'studio_render.option.viewport_bloom.high'
@@ -3264,9 +3529,9 @@
                 type: 'range',
                 label: 'studio_render.field.viewport_bloom_fps',
                 value: settings.viewport_bloom_fps,
-                min: 5,
-                max: 30,
-                step: 5,
+                min: 0,
+                max: 144,
+                step: 1,
                 condition: form => !!form.viewport_bloom_enabled
             },
             viewport_bloom_quality: {
@@ -3274,6 +3539,7 @@
                 label: 'studio_render.field.viewport_bloom_quality',
                 value: settings.viewport_bloom_quality,
                 options: {
+                    adaptive: 'studio_render.option.viewport_bloom.adaptive',
                     performance: 'studio_render.option.viewport_bloom.performance',
                     balanced: 'studio_render.option.viewport_bloom.balanced',
                     high: 'studio_render.option.viewport_bloom.high'
@@ -3448,6 +3714,7 @@
             viewport_bloom_quality: {
                 type: 'select', label: 'studio_render.field.viewport_bloom_quality', value: settings.viewport_bloom_quality,
                 options: {
+                    adaptive: 'studio_render.option.viewport_bloom.adaptive',
                     performance: 'studio_render.option.viewport_bloom.performance',
                     balanced: 'studio_render.option.viewport_bloom.balanced',
                     high: 'studio_render.option.viewport_bloom.high'
@@ -3456,7 +3723,7 @@
             },
             viewport_bloom_fps: {
                 type: 'range', label: 'studio_render.field.viewport_bloom_fps', value: settings.viewport_bloom_fps,
-                min: 5, max: 30, step: 5, condition: form => !!form.viewport_bloom_enabled
+                min: 0, max: 144, step: 1, condition: form => !!form.viewport_bloom_enabled
             },
             bloom_enabled: {
                 type: 'checkbox', label: 'studio_render.field.bloom_enabled', value: settings.bloom_enabled
@@ -3850,7 +4117,7 @@
         author: 'MidFord327',
         description: 'Export polished Blockbench studio renders with tiled supersampling, 4K/8K-safe output, transparency, GPU guidance, and an adjustable frame. Complements Light Manager and Shader Architect in the Lightflow suite.',
         tags: ['Lightflow', 'Rendering', 'Export', 'Screenshots', 'Studio', 'Presentation'],
-        version: '1.5.1',
+        version: '1.6.0',
         min_version: '4.9.0',
         variant: 'both',
         onload() {

--- a/studio_render.js
+++ b/studio_render.js
@@ -64,10 +64,7 @@
     let frameAction;
     let resetFrameAction;
     let sceneComposerAction;
-    let viewportBloomToggle;
-    let sceneBloomStrength;
     let sceneComposerPanel;
-    let sceneComposerToolbar;
     let sceneComposerProjectListener;
     let sceneComposerModeListener;
     let syncingSceneComposerPanel = false;
@@ -369,6 +366,7 @@
             'studio_render.field.vignette': 'Vignette',
             'studio_render.action.scene_composer': 'Scene Composer...',
             'studio_render.action.scene_composer.desc': 'Match realtime viewport post-processing to Studio Render and coordinate the Lightflow environment',
+            'studio_render.panel.composer': 'COMPOSER',
             'studio_render.field.zoom': 'Focal Length',
             'studio_render.field.gpu': 'GPU',
             'studio_render.field.gpu_renderer': 'Renderer',
@@ -486,6 +484,7 @@
             'studio_render.field.vignette': 'Viñeta',
             'studio_render.action.scene_composer': 'Compositor de escena...',
             'studio_render.action.scene_composer.desc': 'Iguala el postprocesado del viewport con Studio Render y coordina el entorno Lightflow',
+            'studio_render.panel.composer': 'COMPOSITOR',
             'studio_render.field.zoom': 'Distancia Focal',
             'studio_render.field.gpu': 'GPU',
             'studio_render.field.gpu_renderer': 'Renderer',
@@ -3748,18 +3747,6 @@
                 type: 'range', label: 'studio_render.field.bloom_strength', value: settings.bloom_strength,
                 min: 0, max: 3, step: 0.05, condition: form => !!form.bloom_enabled
             },
-            bloom_threshold: {
-                type: 'range', label: 'studio_render.field.bloom_threshold', value: settings.bloom_threshold,
-                min: 0, max: 1, step: 0.01, condition: form => !!form.bloom_enabled
-            },
-            bloom_radius: {
-                type: 'range', label: 'studio_render.field.bloom_radius', value: settings.bloom_radius,
-                min: 1, max: 96, step: 1, condition: form => !!form.bloom_enabled
-            },
-            bloom_emissive_strength: {
-                type: 'range', label: 'studio_render.field.bloom_emissive_strength', value: settings.bloom_emissive_strength,
-                min: 0, max: 6, step: 0.05, condition: form => !!form.bloom_enabled
-            },
             composer_advanced: {
                 type: 'buttons', buttons: ['studio_render.action.open_advanced'],
                 click() { openSceneComposerDialog(); }
@@ -3799,10 +3786,6 @@
             }
         }
 
-        if (viewportBloomToggle) {
-            viewportBloomToggle.value = !!currentSettings.viewport_bloom_enabled;
-            viewportBloomToggle.updateEnabledState?.();
-        }
         refreshSceneComposerPreviews();
     }
 
@@ -3871,6 +3854,9 @@
     }
 
     function addStyles() {
+        const palette = Array.isArray(globalThis.markerColors) ? globalThis.markerColors : [];
+        const previewColor = palette[0]?.pastel || '#A2EBFF';
+        const bloomColor = palette[8]?.pastel || '#FFA5D5';
         stylesheet = Blockbench.addCSS(`
             #studio_render_frame {
                 position: absolute;
@@ -4094,6 +4080,39 @@
                 background: rgba(72, 210, 125, 0.12);
                 box-shadow: inset 0 0 0 1px rgba(72, 210, 125, 0.24);
             }
+            #panel_lightflow_scene_composer_panel {
+                overflow-y: auto !important;
+                overflow-x: hidden;
+                background: var(--color-ui);
+            }
+            #panel_lightflow_scene_composer_panel .dialog_bar {
+                min-height: 27px;
+                margin: 0;
+                padding-top: 1px;
+                padding-bottom: 1px;
+                box-sizing: border-box;
+            }
+            #panel_lightflow_scene_composer_panel .form_bar_viewport_bloom_enabled,
+            #panel_lightflow_scene_composer_panel .form_bar_bloom_enabled {
+                border-left: 3px solid ${previewColor};
+                padding-left: 7px;
+            }
+            #panel_lightflow_scene_composer_panel .form_bar_bloom_enabled {
+                border-left-color: ${bloomColor};
+            }
+            #panel_lightflow_scene_composer_panel .form_bar_viewport_bloom_fps input[type="range"] {
+                --color-thumb: ${previewColor};
+            }
+            #panel_lightflow_scene_composer_panel .form_bar_bloom_strength input[type="range"] {
+                --color-thumb: ${bloomColor};
+            }
+            #panel_lightflow_scene_composer_panel::-webkit-scrollbar {
+                width: 6px;
+            }
+            #panel_lightflow_scene_composer_panel::-webkit-scrollbar-thumb {
+                background: var(--color-button);
+                border-radius: 3px;
+            }
         `);
     }
 
@@ -4112,9 +4131,6 @@
         if (frameAction) frameAction.delete();
         if (resetFrameAction) resetFrameAction.delete();
         if (sceneComposerAction) sceneComposerAction.delete();
-        if (viewportBloomToggle) viewportBloomToggle.delete();
-        if (sceneBloomStrength) sceneBloomStrength.delete();
-        if (sceneComposerToolbar) sceneComposerToolbar.delete();
         if (sceneComposerPanel) sceneComposerPanel.delete();
         if (sceneComposerProjectListener) sceneComposerProjectListener.delete?.();
         if (sceneComposerModeListener) sceneComposerModeListener.delete?.();
@@ -4193,50 +4209,8 @@
                 click: openSceneComposerDialog
             });
 
-            viewportBloomToggle = new Toggle('lightflow_viewport_bloom', {
-                name: 'studio_render.field.viewport_bloom_enabled',
-                icon: 'flare',
-                category: 'view',
-                condition: () => !!getPreview(),
-                value: !!currentSettings.viewport_bloom_enabled,
-                onChange(value) {
-                    currentSettings.viewport_bloom_enabled = !!value;
-                    saveSettings(normalizeForm(currentSettings));
-                    syncSceneComposerPanel();
-                    refreshSceneComposerPreviews();
-                }
-            });
-
-            sceneBloomStrength = new NumSlider('lightflow_scene_bloom_strength', {
-                name: 'studio_render.field.bloom_strength',
-                icon: 'blur_on',
-                category: 'view',
-                condition: () => !!getPreview(),
-                value: currentSettings.bloom_strength,
-                min: 0,
-                max: 3,
-                step: 0.05,
-                onChange() {
-                    currentSettings.bloom_strength = clamp(toNumber(this.value, 0.8), 0, 3);
-                    currentSettings.bloom_enabled = currentSettings.bloom_strength > 0;
-                    saveSettings(normalizeForm(currentSettings));
-                    syncSceneComposerPanel();
-                    refreshSceneComposerPreviews();
-                }
-            });
-
-            sceneComposerToolbar = new Toolbar({
-                id: 'lightflow_scene_composer_toolbar',
-                name: 'studio_render.action.scene_composer',
-                children: [
-                    'lightflow_scene_composer',
-                    'lightflow_viewport_bloom',
-                    'lightflow_scene_bloom_strength'
-                ]
-            });
-
             sceneComposerPanel = new Panel('lightflow_scene_composer_panel', {
-                name: 'studio_render.action.scene_composer',
+                name: 'studio_render.panel.composer',
                 icon: 'auto_fix_high',
                 growable: true,
                 resizable: true,
@@ -4245,8 +4219,8 @@
                 default_position: {
                     slot: 'right_bar',
                     float_position: [0, 0],
-                    float_size: [340, 420],
-                    height: 360,
+                    float_size: [314, 200],
+                    height: 200,
                     folded: false,
                     attached_to: window.Panels?.lightflow_environment_panel ? 'lightflow_environment_panel' : 'outliner',
                     attached_index: 2,
@@ -4255,7 +4229,7 @@
                 mode_positions: {
                     render: {
                         slot: 'right_bar',
-                        height: 360,
+                        height: 200,
                         folded: false,
                         attached_to: window.Panels?.lightflow_environment_panel ? 'lightflow_environment_panel' : 'outliner',
                         attached_index: 2,
@@ -4263,7 +4237,6 @@
                     }
                 },
                 insert_after: window.Panels?.lightflow_environment_panel ? 'lightflow_environment_panel' : 'outliner',
-                toolbars: [sceneComposerToolbar],
                 form: createSceneComposerPanelForm(currentSettings)
             });
 

--- a/studio_render.js
+++ b/studio_render.js
@@ -43,7 +43,8 @@
         bloom_emissive_strength: 1.35,
         bloom_occlusion: true,
         viewport_bloom_enabled: true,
-        viewport_bloom_fps: 30,
+        viewport_bloom_fps: 24,
+        viewport_bloom_quality: 'balanced',
         color_grading_enabled: false,
         exposure: 1.0,
         contrast: 1.0,
@@ -66,6 +67,8 @@
     let sceneComposerPanel;
     let sceneComposerToolbar;
     let sceneComposerProjectListener;
+    let sceneComposerModeListener;
+    let syncingSceneComposerPanel = false;
     let activeComposerDialog;
     let stylesheet;
     let activeDialog;
@@ -77,6 +80,12 @@
         resources: new Set()
     };
     const VIEWPORT_COMPOSER_STATE = new Map();
+
+    const VIEWPORT_BLOOM_PROFILES = {
+        performance: { scale: 0.25, maxDimension: 640, displayDpr: 1 },
+        balanced: { scale: 0.4, maxDimension: 900, displayDpr: 1 },
+        high: { scale: 0.6, maxDimension: 1280, displayDpr: 1.5 }
+    };
 
     function clamp(value, min, max) {
         return Math.max(min, Math.min(max, value));
@@ -114,6 +123,15 @@
         if (typeof tl !== 'function') return fallback || key;
         const value = tl(key);
         return value === key ? (fallback || key) : value;
+    }
+
+    function isLightflowRenderMode() {
+        const selected = window.Modes?.selected;
+        return !!selected && (selected.id === 'render' || selected === window.Modes?.render);
+    }
+
+    function getViewportBloomProfile(settings) {
+        return VIEWPORT_BLOOM_PROFILES[settings?.viewport_bloom_quality] || VIEWPORT_BLOOM_PROFILES.balanced;
     }
 
     function truncateText(text, maxLength) {
@@ -333,6 +351,11 @@
             'studio_render.field.bloom_occlusion': 'Block Bloom Behind Geometry',
             'studio_render.field.viewport_bloom_enabled': 'Preview Bloom in Viewport',
             'studio_render.field.viewport_bloom_fps': 'Viewport Bloom Refresh',
+            'studio_render.field.viewport_bloom_quality': 'Viewport Bloom Quality',
+            'studio_render.option.viewport_bloom.performance': 'Performance',
+            'studio_render.option.viewport_bloom.balanced': 'Balanced',
+            'studio_render.option.viewport_bloom.high': 'High',
+            'studio_render.action.open_advanced': 'Advanced Scene Composer...',
             'studio_render.field.color_grading_enabled': 'Color Grading',
             'studio_render.field.exposure': 'Exposure',
             'studio_render.field.contrast': 'Contrast',
@@ -444,6 +467,11 @@
             'studio_render.field.bloom_occlusion': 'Bloquear Bloom detrás de geometría',
             'studio_render.field.viewport_bloom_enabled': 'Previsualizar Bloom en viewport',
             'studio_render.field.viewport_bloom_fps': 'Actualización de Bloom en viewport',
+            'studio_render.field.viewport_bloom_quality': 'Calidad de Bloom en viewport',
+            'studio_render.option.viewport_bloom.performance': 'Rendimiento',
+            'studio_render.option.viewport_bloom.balanced': 'Equilibrada',
+            'studio_render.option.viewport_bloom.high': 'Alta',
+            'studio_render.action.open_advanced': 'Compositor de escena avanzado...',
             'studio_render.field.color_grading_enabled': 'Gradación de color',
             'studio_render.field.exposure': 'Exposición',
             'studio_render.field.contrast': 'Contraste',
@@ -541,7 +569,10 @@
         settings.bloom_emissive_strength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         settings.bloom_occlusion = settings.bloom_occlusion !== false;
         settings.viewport_bloom_enabled = settings.viewport_bloom_enabled !== false;
-        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 30), 5, 60);
+        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 24), 5, 30);
+        settings.viewport_bloom_quality = VIEWPORT_BLOOM_PROFILES[settings.viewport_bloom_quality]
+            ? settings.viewport_bloom_quality
+            : 'balanced';
         settings.color_grading_enabled = !!settings.color_grading_enabled;
         settings.exposure = clamp(toNumber(settings.exposure, 1), 0.1, 4);
         settings.contrast = clamp(toNumber(settings.contrast, 1), 0, 3);
@@ -844,7 +875,10 @@
         settings.bloom_emissive_strength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         settings.bloom_occlusion = settings.bloom_occlusion !== false;
         settings.viewport_bloom_enabled = settings.viewport_bloom_enabled !== false;
-        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 30), 5, 60);
+        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 24), 5, 30);
+        settings.viewport_bloom_quality = VIEWPORT_BLOOM_PROFILES[settings.viewport_bloom_quality]
+            ? settings.viewport_bloom_quality
+            : 'balanced';
         settings.color_grading_enabled = !!settings.color_grading_enabled;
         settings.exposure = clamp(toNumber(settings.exposure, 1), 0.1, 4);
         settings.contrast = clamp(toNumber(settings.contrast, 1), 0, 3);
@@ -1764,45 +1798,58 @@
         return true;
     }
 
-    function applyFinalBloom(canvas, settings, sourceMaskCanvas) {
+    function applyFinalBloom(canvas, settings, sourceMaskCanvas, options = {}) {
         if (!canvas || !settings?.bloom_enabled) return canvas;
 
-        const maxMaskDimension = 4096;
-        const scale = Math.min(
+        const sourceMask = sourceMaskCanvas || canvas;
+        const maxMaskDimension = Math.max(64, Number(options.maxDimension) || 4096);
+        const sourceScale = Math.min(
             1,
             maxMaskDimension / Math.max(canvas.width || 1, canvas.height || 1)
         );
-        const width = Math.max(1, Math.round(canvas.width * scale));
-        const height = Math.max(1, Math.round(canvas.height * scale));
+        const width = Math.max(1, Math.round(Number(options.processingWidth) || canvas.width * sourceScale));
+        const height = Math.max(1, Math.round(Number(options.processingHeight) || canvas.height * sourceScale));
+        const radiusScale = Math.min(width / Math.max(canvas.width || 1, 1), height / Math.max(canvas.height || 1, 1));
         const threshold = clamp(toNumber(settings.bloom_threshold, 0.72), 0, 1);
         const strength = clamp(toNumber(settings.bloom_strength, 0.8), 0, 3);
-        const radius = clamp(toNumber(settings.bloom_radius, 18), 1, 96) * scale;
+        const radius = clamp(toNumber(settings.bloom_radius, 18), 1, 96) * radiusScale;
         const hdrStrength = clamp(toNumber(settings.bloom_hdr_strength, 1), 0, 4);
         const emissiveStrength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         const useOcclusion = settings.bloom_occlusion !== false;
+        const includeSceneSignal = options.emissiveOnly !== true;
+        const workspace = options.workspace || null;
+        const getWorkingCanvas = key => {
+            let target = workspace?.[key];
+            if (!target) {
+                target = document.createElement('canvas');
+                if (workspace) workspace[key] = target;
+            }
+            if (target.width !== width) target.width = width;
+            if (target.height !== height) target.height = height;
+            return target;
+        };
 
-        const mask = document.createElement('canvas');
-        mask.width = width;
-        mask.height = height;
+        const mask = getWorkingCanvas('processingMask');
         const maskContext = mask.getContext('2d', { willReadFrequently: true });
-        maskContext.drawImage(sourceMaskCanvas || canvas, 0, 0, width, height);
+        maskContext.clearRect(0, 0, width, height);
+        maskContext.drawImage(sourceMask, 0, 0, width, height);
 
-        const sceneSample = document.createElement('canvas');
-        sceneSample.width = width;
-        sceneSample.height = height;
-        const sceneContext = sceneSample.getContext('2d', { willReadFrequently: true });
-        sceneContext.drawImage(canvas, 0, 0, width, height);
+        let sceneImage = null;
+        if (includeSceneSignal) {
+            const sceneSample = getWorkingCanvas('sceneSample');
+            const sceneContext = sceneSample.getContext('2d', { willReadFrequently: true });
+            sceneContext.clearRect(0, 0, width, height);
+            sceneContext.drawImage(canvas, 0, 0, width, height);
+            sceneImage = sceneContext.getImageData(0, 0, width, height);
+        }
 
-        const blocker = document.createElement('canvas');
-        blocker.width = width;
-        blocker.height = height;
+        const blocker = getWorkingCanvas('blocker');
         const blockerContext = blocker.getContext('2d', { willReadFrequently: true });
 
         const maskImage = maskContext.getImageData(0, 0, width, height);
-        const sceneImage = sceneContext.getImageData(0, 0, width, height);
         const blockerImage = blockerContext.createImageData(width, height);
         const pixels = maskImage.data;
-        const scenePixels = sceneImage.data;
+        const scenePixels = sceneImage?.data || null;
         const blockerPixels = blockerImage.data;
 
         for (let index = 0; index < pixels.length; index += 4) {
@@ -1810,9 +1857,9 @@
             const emissionR = pixels[index] / 255 * emissiveStrength;
             const emissionG = pixels[index + 1] / 255 * emissiveStrength;
             const emissionB = pixels[index + 2] / 255 * emissiveStrength;
-            const sceneR = scenePixels[index] / 255 * hdrStrength;
-            const sceneG = scenePixels[index + 1] / 255 * hdrStrength;
-            const sceneB = scenePixels[index + 2] / 255 * hdrStrength;
+            const sceneR = scenePixels ? scenePixels[index] / 255 * hdrStrength : 0;
+            const sceneG = scenePixels ? scenePixels[index + 1] / 255 * hdrStrength : 0;
+            const sceneB = scenePixels ? scenePixels[index + 2] / 255 * hdrStrength : 0;
 
             const hdrSignal = geometryAlpha > 0.001
                 ? Math.max(sceneR, sceneG, sceneB)
@@ -1844,16 +1891,15 @@
         maskContext.putImageData(maskImage, 0, 0);
         blockerContext.putImageData(blockerImage, 0, 0);
 
-        const bloomLayer = document.createElement('canvas');
-        bloomLayer.width = canvas.width;
-        bloomLayer.height = canvas.height;
+        const bloomLayer = getWorkingCanvas('bloomLayer');
         const bloomContext = bloomLayer.getContext('2d');
+        bloomContext.clearRect(0, 0, width, height);
         bloomContext.globalCompositeOperation = 'lighter';
 
         const drawBloomLayer = (blur, alpha) => {
             bloomContext.globalAlpha = clamp(alpha * strength, 0, 1);
             bloomContext.filter = `blur(${Math.max(0.5, blur)}px)`;
-            bloomContext.drawImage(mask, 0, 0, canvas.width, canvas.height);
+            bloomContext.drawImage(mask, 0, 0, width, height);
         };
 
         drawBloomLayer(radius * 2.4, 0.20);
@@ -1864,7 +1910,7 @@
             bloomContext.globalCompositeOperation = 'destination-out';
             bloomContext.globalAlpha = 1;
             bloomContext.filter = 'none';
-            bloomContext.drawImage(blocker, 0, 0, canvas.width, canvas.height);
+            bloomContext.drawImage(blocker, 0, 0, width, height);
         }
 
         const output = canvas.getContext('2d');
@@ -1872,7 +1918,7 @@
         output.globalCompositeOperation = 'lighter';
         output.globalAlpha = 1;
         output.filter = 'none';
-        output.drawImage(bloomLayer, 0, 0);
+        output.drawImage(bloomLayer, 0, 0, canvas.width, canvas.height);
         output.restore();
         return canvas;
     }
@@ -1927,6 +1973,108 @@
         return canvas;
     }
 
+    function renderViewportBloomMask(preview, state, width, height) {
+        const renderer = preview?.renderer;
+        const scene = window.Canvas?.scene;
+        if (!renderer || !scene || !THREE.WebGLRenderTarget || typeof renderer.readRenderTargetPixels !== 'function') {
+            return false;
+        }
+
+        if (!state.maskTarget) {
+            state.maskTarget = new THREE.WebGLRenderTarget(width, height, {
+                minFilter: THREE.LinearFilter,
+                magFilter: THREE.LinearFilter,
+                format: THREE.RGBAFormat,
+                type: THREE.UnsignedByteType,
+                depthBuffer: true,
+                stencilBuffer: false
+            });
+            state.maskTarget.texture.name = 'Lightflow_ViewportBloomMask';
+            state.maskTarget.texture.generateMipmaps = false;
+        } else if (state.maskTarget.width !== width || state.maskTarget.height !== height) {
+            state.maskTarget.setSize(width, height);
+        }
+
+        const hiddenVisibility = new Map();
+        collectStudioRenderHiddenObjects().forEach(object => {
+            if (!object || hiddenVisibility.has(object)) return;
+            hiddenVisibility.set(object, object.visible);
+            object.visible = false;
+        });
+
+        const materialChanges = [];
+        const replaceMaterial = object => {
+            if (!object?.visible || !(object.isMesh || object.isSprite) || !object.material) return;
+            const original = object.material;
+            const sourceMaterials = Array.isArray(original) ? original : [original];
+            const replacements = sourceMaterials.map(source => {
+                const emissive = getMaterialEmissiveState(source).active;
+                return getBloomMaskMaterial(source, emissive);
+            });
+            materialChanges.push({ object, material: original });
+            object.material = Array.isArray(original) ? replacements : replacements[0];
+        };
+        if (typeof scene.traverseVisible === 'function') scene.traverseVisible(replaceMaterial);
+        else scene.traverse(replaceMaterial);
+
+        const previousTarget = renderer.getRenderTarget?.();
+        const previousAutoClear = renderer.autoClear;
+        const previousShadowAutoUpdate = renderer.shadowMap?.autoUpdate;
+        const previousViewport = renderer.getViewport?.(new THREE.Vector4()) || null;
+        const previousScissor = renderer.getScissor?.(new THREE.Vector4()) || null;
+        const previousScissorTest = renderer.getScissorTest?.() ?? false;
+        const previousClearColor = new THREE.Color();
+        const previousClearAlpha = renderer.getClearAlpha?.() ?? 1;
+        renderer.getClearColor?.(previousClearColor);
+
+        let succeeded = false;
+        try {
+            renderer.autoClear = true;
+            if (renderer.shadowMap) renderer.shadowMap.autoUpdate = false;
+            renderer.setRenderTarget(state.maskTarget);
+            renderer.setViewport?.(0, 0, width, height);
+            renderer.setScissorTest?.(false);
+            renderer.setClearColor?.(0x000000, 0);
+            renderer.clear?.(true, true, true);
+            renderer.render(scene, preview.camera);
+            if (window.LightflowAtmosphere?.composite) {
+                window.LightflowAtmosphere.composite(preview, { studio: true, bloomMask: true });
+                renderer.setRenderTarget(state.maskTarget);
+            }
+
+            const pixelCount = width * height * 4;
+            if (!state.maskPixels || state.maskPixels.length !== pixelCount) {
+                state.maskPixels = new Uint8Array(pixelCount);
+            }
+            renderer.readRenderTargetPixels(state.maskTarget, 0, 0, width, height, state.maskPixels);
+
+            const context = state.maskCanvas.getContext('2d', { alpha: true });
+            const image = context.createImageData(width, height);
+            const rowLength = width * 4;
+            for (let row = 0; row < height; row++) {
+                const sourceOffset = (height - row - 1) * rowLength;
+                image.data.set(state.maskPixels.subarray(sourceOffset, sourceOffset + rowLength), row * rowLength);
+            }
+            context.putImageData(image, 0, 0);
+            succeeded = true;
+        } finally {
+            for (let index = materialChanges.length - 1; index >= 0; index--) {
+                materialChanges[index].object.material = materialChanges[index].material;
+            }
+            hiddenVisibility.forEach((visible, object) => { object.visible = visible; });
+            renderer.setRenderTarget?.(previousTarget || null);
+            if (previousViewport) renderer.setViewport?.(previousViewport);
+            if (previousScissor) renderer.setScissor?.(previousScissor);
+            renderer.setScissorTest?.(previousScissorTest);
+            renderer.autoClear = previousAutoClear;
+            if (renderer.shadowMap && previousShadowAutoUpdate !== undefined) {
+                renderer.shadowMap.autoUpdate = previousShadowAutoUpdate;
+            }
+            renderer.setClearColor?.(previousClearColor, previousClearAlpha);
+        }
+        return succeeded;
+    }
+
     function getViewportComposerState(preview) {
         if (!preview?.canvas || !preview.canvas.parentElement) return null;
         let state = VIEWPORT_COMPOSER_STATE.get(preview);
@@ -1952,8 +2100,13 @@
             previousParentPosition,
             baseCanvas: document.createElement('canvas'),
             maskCanvas: document.createElement('canvas'),
+            bloomWorkspace: {},
+            maskTarget: null,
+            maskPixels: null,
             lastRender: 0,
-            rendering: false
+            rendering: false,
+            scheduled: false,
+            scheduleHandle: null
         };
         VIEWPORT_COMPOSER_STATE.set(preview, state);
         return state;
@@ -1979,6 +2132,10 @@
             hideViewportComposerOverlay(preview);
             return;
         }
+        if (!isLightflowRenderMode()) {
+            hideViewportComposerOverlay(preview);
+            return;
+        }
         const active = (
             currentSettings.viewport_bloom_enabled &&
             currentSettings.bloom_enabled
@@ -1991,7 +2148,7 @@
         const state = getViewportComposerState(preview);
         if (!state || state.rendering) return;
         const now = performance.now();
-        const interval = 1000 / clamp(toNumber(currentSettings.viewport_bloom_fps, 30), 5, 60);
+        const interval = 1000 / clamp(toNumber(currentSettings.viewport_bloom_fps, 24), 5, 30);
         if (now - state.lastRender < interval) {
             // Keep the last completed post-process frame visible while the
             // composer is throttled. Hiding it here would alternate between
@@ -2000,12 +2157,24 @@
         }
 
         const source = preview.canvas;
-        const width = Math.max(1, source.width || source.clientWidth || 1);
-        const height = Math.max(1, source.height || source.clientHeight || 1);
-        [state.baseCanvas, state.maskCanvas, state.overlay].forEach(canvas => {
+        const profile = getViewportBloomProfile(currentSettings);
+        const width = Math.max(1, Math.min(
+            source.width || source.clientWidth || 1,
+            Math.round((source.clientWidth || source.width || 1) * profile.displayDpr)
+        ));
+        const height = Math.max(1, Math.min(
+            source.height || source.clientHeight || 1,
+            Math.round((source.clientHeight || source.height || 1) * profile.displayDpr)
+        ));
+        [state.baseCanvas, state.overlay].forEach(canvas => {
             if (canvas.width !== width) canvas.width = width;
             if (canvas.height !== height) canvas.height = height;
         });
+        const bloomScale = Math.min(profile.scale, profile.maxDimension / Math.max(width, height));
+        const maskWidth = Math.max(2, Math.round(width * bloomScale));
+        const maskHeight = Math.max(2, Math.round(height * bloomScale));
+        if (state.maskCanvas.width !== maskWidth) state.maskCanvas.width = maskWidth;
+        if (state.maskCanvas.height !== maskHeight) state.maskCanvas.height = maskHeight;
         positionViewportComposerOverlay(state);
 
         state.rendering = true;
@@ -2017,22 +2186,16 @@
 
             if (currentSettings.viewport_bloom_enabled && currentSettings.bloom_enabled) {
                 const maskContext = state.maskCanvas.getContext('2d', { alpha: true });
-                maskContext.clearRect(0, 0, width, height);
-                renderBloomMaskTile(preview, maskContext, {
-                    outputX: 0,
-                    outputY: 0,
-                    outputWidth: width,
-                    outputHeight: height,
-                    sampleWidth: width,
-                    sampleHeight: height,
-                    renderWidth: width,
-                    renderHeight: height,
-                    cropX: 0,
-                    cropY: 0,
-                    cropRight: 0,
-                    cropBottom: 0
-                }, 1);
-                applyFinalBloom(state.baseCanvas, currentSettings, state.maskCanvas);
+                maskContext.clearRect(0, 0, maskWidth, maskHeight);
+                if (renderViewportBloomMask(preview, state, maskWidth, maskHeight)) {
+                    applyFinalBloom(state.baseCanvas, currentSettings, state.maskCanvas, {
+                        processingWidth: maskWidth,
+                        processingHeight: maskHeight,
+                        maxDimension: profile.maxDimension,
+                        emissiveOnly: true,
+                        workspace: state.bloomWorkspace
+                    });
+                }
             }
             applyFinalColorGrade(state.baseCanvas, currentSettings);
 
@@ -2062,7 +2225,7 @@
         const originalRender = preview.render;
         const patchedRender = function lightflowSceneComposerRender() {
             const result = originalRender.apply(this, arguments);
-            renderViewportComposer(this);
+            scheduleViewportComposer(this);
             return result;
         };
         const state = getViewportComposerState(preview);
@@ -2072,6 +2235,22 @@
         preview.render = patchedRender;
     }
 
+    function scheduleViewportComposer(preview) {
+        const state = getViewportComposerState(preview);
+        if (!state || state.scheduled) return;
+        state.scheduled = true;
+        const run = () => {
+            state.scheduled = false;
+            state.scheduleHandle = null;
+            renderViewportComposer(preview);
+        };
+        if (typeof requestAnimationFrame === 'function') {
+            state.scheduleHandle = requestAnimationFrame(run);
+        } else {
+            state.scheduleHandle = setTimeout(run, 0);
+        }
+    }
+
     function patchAllViewportComposers() {
         collectStudioRenderPreviews().forEach(patchViewportComposer);
     }
@@ -2079,6 +2258,14 @@
     function disposeViewportComposers() {
         VIEWPORT_COMPOSER_STATE.forEach((state, preview) => {
             if (preview?.render === state.patchedRender) preview.render = state.originalRender;
+            state.maskTarget?.dispose?.();
+            if (state.scheduleHandle !== null) {
+                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(state.scheduleHandle);
+                else clearTimeout(state.scheduleHandle);
+            }
+            state.maskTarget = null;
+            state.maskPixels = null;
+            state.bloomWorkspace = null;
             state.overlay?.remove?.();
             if (state.parent && state.previousParentPosition !== undefined) {
                 state.parent.style.position = state.previousParentPosition;
@@ -2970,8 +3157,19 @@
                 label: 'studio_render.field.viewport_bloom_fps',
                 value: settings.viewport_bloom_fps,
                 min: 5,
-                max: 60,
+                max: 30,
                 step: 5,
+                condition: form => !!form.bloom_enabled && !!form.viewport_bloom_enabled && !!form.show_advanced
+            },
+            viewport_bloom_quality: {
+                type: 'select',
+                label: 'studio_render.field.viewport_bloom_quality',
+                value: settings.viewport_bloom_quality,
+                options: {
+                    performance: 'studio_render.option.viewport_bloom.performance',
+                    balanced: 'studio_render.option.viewport_bloom.balanced',
+                    high: 'studio_render.option.viewport_bloom.high'
+                },
                 condition: form => !!form.bloom_enabled && !!form.viewport_bloom_enabled && !!form.show_advanced
             },
             color_grading_enabled: {
@@ -3067,8 +3265,19 @@
                 label: 'studio_render.field.viewport_bloom_fps',
                 value: settings.viewport_bloom_fps,
                 min: 5,
-                max: 60,
+                max: 30,
                 step: 5,
+                condition: form => !!form.viewport_bloom_enabled
+            },
+            viewport_bloom_quality: {
+                type: 'select',
+                label: 'studio_render.field.viewport_bloom_quality',
+                value: settings.viewport_bloom_quality,
+                options: {
+                    performance: 'studio_render.option.viewport_bloom.performance',
+                    balanced: 'studio_render.option.viewport_bloom.balanced',
+                    high: 'studio_render.option.viewport_bloom.high'
+                },
                 condition: form => !!form.viewport_bloom_enabled
             },
             _bloom: '_',
@@ -3231,6 +3440,58 @@
         collectStudioRenderPreviews().forEach(preview => preview?.render?.());
     }
 
+    function createSceneComposerPanelForm(settings) {
+        return {
+            viewport_bloom_enabled: {
+                type: 'checkbox', label: 'studio_render.field.viewport_bloom_enabled', value: settings.viewport_bloom_enabled
+            },
+            viewport_bloom_quality: {
+                type: 'select', label: 'studio_render.field.viewport_bloom_quality', value: settings.viewport_bloom_quality,
+                options: {
+                    performance: 'studio_render.option.viewport_bloom.performance',
+                    balanced: 'studio_render.option.viewport_bloom.balanced',
+                    high: 'studio_render.option.viewport_bloom.high'
+                },
+                condition: form => !!form.viewport_bloom_enabled
+            },
+            viewport_bloom_fps: {
+                type: 'range', label: 'studio_render.field.viewport_bloom_fps', value: settings.viewport_bloom_fps,
+                min: 5, max: 30, step: 5, condition: form => !!form.viewport_bloom_enabled
+            },
+            bloom_enabled: {
+                type: 'checkbox', label: 'studio_render.field.bloom_enabled', value: settings.bloom_enabled
+            },
+            bloom_strength: {
+                type: 'range', label: 'studio_render.field.bloom_strength', value: settings.bloom_strength,
+                min: 0, max: 3, step: 0.05, condition: form => !!form.bloom_enabled
+            },
+            bloom_threshold: {
+                type: 'range', label: 'studio_render.field.bloom_threshold', value: settings.bloom_threshold,
+                min: 0, max: 1, step: 0.01, condition: form => !!form.bloom_enabled
+            },
+            bloom_radius: {
+                type: 'range', label: 'studio_render.field.bloom_radius', value: settings.bloom_radius,
+                min: 1, max: 96, step: 1, condition: form => !!form.bloom_enabled
+            },
+            bloom_emissive_strength: {
+                type: 'range', label: 'studio_render.field.bloom_emissive_strength', value: settings.bloom_emissive_strength,
+                min: 0, max: 6, step: 0.05, condition: form => !!form.bloom_enabled
+            },
+            composer_advanced: {
+                type: 'buttons', buttons: ['studio_render.action.open_advanced'],
+                click() { openSceneComposerDialog(); }
+            }
+        };
+    }
+
+    function syncSceneComposerPanel() {
+        if (!sceneComposerPanel?.form || syncingSceneComposerPanel) return;
+        syncingSceneComposerPanel = true;
+        sceneComposerPanel.form.form_config = createSceneComposerPanelForm(currentSettings);
+        sceneComposerPanel.form.buildForm();
+        syncingSceneComposerPanel = false;
+    }
+
     function applySceneComposerForm(form, persist) {
         const next = Object.assign({}, currentSettings, form || {});
         delete next.environment_enabled;
@@ -3241,16 +3502,18 @@
         if (persist) saveSettings(currentSettings);
 
         if (window.LightflowEnvironment && form) {
-            window.LightflowEnvironment.setSettings({
-                enabled: form.environment_enabled,
-                preset: form.environment_preset,
-                time: form.environment_time,
-                environment_strength: form.environment_strength
-            }, {
-                cause: 'scene_composer',
-                render: false,
-                forceShadow: false
-            });
+            const environmentSettings = {};
+            if (Object.prototype.hasOwnProperty.call(form, 'environment_enabled')) environmentSettings.enabled = form.environment_enabled;
+            if (Object.prototype.hasOwnProperty.call(form, 'environment_preset')) environmentSettings.preset = form.environment_preset;
+            if (Object.prototype.hasOwnProperty.call(form, 'environment_time')) environmentSettings.time = form.environment_time;
+            if (Object.prototype.hasOwnProperty.call(form, 'environment_strength')) environmentSettings.environment_strength = form.environment_strength;
+            if (Object.keys(environmentSettings).length) {
+                window.LightflowEnvironment.setSettings(environmentSettings, {
+                    cause: 'scene_composer',
+                    render: false,
+                    forceShadow: false
+                });
+            }
         }
 
         if (viewportBloomToggle) {
@@ -3571,6 +3834,7 @@
         if (sceneComposerToolbar) sceneComposerToolbar.delete();
         if (sceneComposerPanel) sceneComposerPanel.delete();
         if (sceneComposerProjectListener) sceneComposerProjectListener.delete?.();
+        if (sceneComposerModeListener) sceneComposerModeListener.delete?.();
         disposeViewportComposers();
         if (stylesheet && typeof stylesheet.delete === 'function') stylesheet.delete();
         BLOOM_MASK_STATE.resources.forEach(resource => resource?.dispose?.());
@@ -3586,7 +3850,7 @@
         author: 'MidFord327',
         description: 'Export polished Blockbench studio renders with tiled supersampling, 4K/8K-safe output, transparency, GPU guidance, and an adjustable frame. Complements Light Manager and Shader Architect in the Lightflow suite.',
         tags: ['Lightflow', 'Rendering', 'Export', 'Screenshots', 'Studio', 'Presentation'],
-        version: '1.5.0',
+        version: '1.5.1',
         min_version: '4.9.0',
         variant: 'both',
         onload() {
@@ -3655,6 +3919,7 @@
                 onChange(value) {
                     currentSettings.viewport_bloom_enabled = !!value;
                     saveSettings(normalizeForm(currentSettings));
+                    syncSceneComposerPanel();
                     refreshSceneComposerPreviews();
                 }
             });
@@ -3672,6 +3937,7 @@
                     currentSettings.bloom_strength = clamp(toNumber(this.value, 0.8), 0, 3);
                     currentSettings.bloom_enabled = currentSettings.bloom_strength > 0;
                     saveSettings(normalizeForm(currentSettings));
+                    syncSceneComposerPanel();
                     refreshSceneComposerPreviews();
                 }
             });
@@ -3689,13 +3955,38 @@
             sceneComposerPanel = new Panel('lightflow_scene_composer_panel', {
                 name: 'studio_render.action.scene_composer',
                 icon: 'auto_fix_high',
-                condition: () => !!window.Project,
+                growable: true,
+                resizable: true,
+                expand_button: true,
+                condition: { modes: ['render'], project: true },
                 default_position: {
                     slot: 'right_bar',
-                    height: 58,
-                    folded: false
+                    float_position: [0, 0],
+                    float_size: [340, 420],
+                    height: 360,
+                    folded: false,
+                    attached_to: window.Panels?.lightflow_environment_panel ? 'lightflow_environment_panel' : 'outliner',
+                    attached_index: 2,
+                    sidebar_index: 2
                 },
-                toolbars: [sceneComposerToolbar]
+                mode_positions: {
+                    render: {
+                        slot: 'right_bar',
+                        height: 360,
+                        folded: false,
+                        attached_to: window.Panels?.lightflow_environment_panel ? 'lightflow_environment_panel' : 'outliner',
+                        attached_index: 2,
+                        sidebar_index: 2
+                    }
+                },
+                insert_after: window.Panels?.lightflow_environment_panel ? 'lightflow_environment_panel' : 'outliner',
+                toolbars: [sceneComposerToolbar],
+                form: createSceneComposerPanelForm(currentSettings)
+            });
+
+            sceneComposerPanel.form.on('change', ({ result }) => {
+                if (syncingSceneComposerPanel) return;
+                applySceneComposerForm(result, true);
             });
 
             MenuBar.addAction(exportAction, 'file.export');
@@ -3709,7 +4000,11 @@
             patchAllViewportComposers();
             sceneComposerProjectListener = Blockbench.on('select_project', () => {
                 currentSettings = loadSettings();
+                syncSceneComposerPanel();
                 patchAllViewportComposers();
+                refreshSceneComposerPreviews();
+            });
+            sceneComposerModeListener = Blockbench.on('select_mode', () => {
                 refreshSceneComposerPreviews();
             });
 
@@ -3723,6 +4018,7 @@
                 setComposerSettings(next) {
                     currentSettings = normalizeForm(Object.assign({}, currentSettings, next || {}));
                     saveSettings(currentSettings);
+                    syncSceneComposerPanel();
                     refreshSceneComposerPreviews();
                     return Object.assign({}, currentSettings);
                 },

--- a/studio_render.js
+++ b/studio_render.js
@@ -2356,7 +2356,23 @@
 
         state.postQuad.material = material;
         material.transparent = !useColorGrade;
-        material.blending = useColorGrade ? THREE.NoBlending : THREE.AdditiveBlending;
+        if (useColorGrade) {
+            material.blending = THREE.NoBlending;
+        } else {
+            /*
+             * Add Bloom to RGB without touching the destination alpha. The
+             * Blockbench checkerboard is CSS behind a transparent WebGL
+             * canvas; ordinary AdditiveBlending also adds source alpha and
+             * turns those transparent pixels opaque black.
+             */
+            material.blending = THREE.CustomBlending;
+            material.blendEquation = THREE.AddEquation;
+            material.blendSrc = THREE.OneFactor;
+            material.blendDst = THREE.OneFactor;
+            material.blendEquationAlpha = THREE.AddEquation;
+            material.blendSrcAlpha = THREE.ZeroFactor;
+            material.blendDstAlpha = THREE.OneFactor;
+        }
         renderer.setRenderTarget?.(null);
         if (snapshot.viewport) renderer.setViewport?.(snapshot.viewport);
         if (snapshot.scissor) renderer.setScissor?.(snapshot.scissor);
@@ -4117,7 +4133,7 @@
         author: 'MidFord327',
         description: 'Export polished Blockbench studio renders with tiled supersampling, 4K/8K-safe output, transparency, GPU guidance, and an adjustable frame. Complements Light Manager and Shader Architect in the Lightflow suite.',
         tags: ['Lightflow', 'Rendering', 'Export', 'Screenshots', 'Studio', 'Presentation'],
-        version: '1.6.0',
+        version: '1.6.1',
         min_version: '4.9.0',
         variant: 'both',
         onload() {

--- a/studio_render.js
+++ b/studio_render.js
@@ -42,6 +42,15 @@
         bloom_hdr_strength: 1.0,
         bloom_emissive_strength: 1.35,
         bloom_occlusion: true,
+        viewport_bloom_enabled: true,
+        viewport_bloom_fps: 30,
+        color_grading_enabled: false,
+        exposure: 1.0,
+        contrast: 1.0,
+        saturation: 1.0,
+        temperature: 0.0,
+        tint: 0.0,
+        vignette: 0.0,
         zoom: null,
         destination: 'preview',
         file_name: 'studio_render'
@@ -51,6 +60,13 @@
     let quickRenderAction;
     let frameAction;
     let resetFrameAction;
+    let sceneComposerAction;
+    let viewportBloomToggle;
+    let sceneBloomStrength;
+    let sceneComposerPanel;
+    let sceneComposerToolbar;
+    let sceneComposerProjectListener;
+    let activeComposerDialog;
     let stylesheet;
     let activeDialog;
     let currentSettings = Object.assign({}, DEFAULT_SETTINGS);
@@ -60,6 +76,7 @@
         occluderMaterials: new WeakMap(),
         resources: new Set()
     };
+    const VIEWPORT_COMPOSER_STATE = new Map();
 
     function clamp(value, min, max) {
         return Math.max(min, Math.min(max, value));
@@ -314,6 +331,17 @@
             'studio_render.field.bloom_hdr_strength': 'Bright Surface Bloom',
             'studio_render.field.bloom_emissive_strength': 'Emissive Texture Bloom',
             'studio_render.field.bloom_occlusion': 'Block Bloom Behind Geometry',
+            'studio_render.field.viewport_bloom_enabled': 'Preview Bloom in Viewport',
+            'studio_render.field.viewport_bloom_fps': 'Viewport Bloom Refresh',
+            'studio_render.field.color_grading_enabled': 'Color Grading',
+            'studio_render.field.exposure': 'Exposure',
+            'studio_render.field.contrast': 'Contrast',
+            'studio_render.field.saturation': 'Saturation',
+            'studio_render.field.temperature': 'Temperature',
+            'studio_render.field.tint': 'Tint',
+            'studio_render.field.vignette': 'Vignette',
+            'studio_render.action.scene_composer': 'Scene Composer...',
+            'studio_render.action.scene_composer.desc': 'Match realtime viewport post-processing to Studio Render and coordinate the Lightflow environment',
             'studio_render.field.zoom': 'Focal Length',
             'studio_render.field.gpu': 'GPU',
             'studio_render.field.gpu_renderer': 'Renderer',
@@ -414,6 +442,17 @@
             'studio_render.field.bloom_hdr_strength': 'Bloom de superficies brillantes',
             'studio_render.field.bloom_emissive_strength': 'Bloom de texturas emisivas',
             'studio_render.field.bloom_occlusion': 'Bloquear Bloom detrás de geometría',
+            'studio_render.field.viewport_bloom_enabled': 'Previsualizar Bloom en viewport',
+            'studio_render.field.viewport_bloom_fps': 'Actualización de Bloom en viewport',
+            'studio_render.field.color_grading_enabled': 'Gradación de color',
+            'studio_render.field.exposure': 'Exposición',
+            'studio_render.field.contrast': 'Contraste',
+            'studio_render.field.saturation': 'Saturación',
+            'studio_render.field.temperature': 'Temperatura',
+            'studio_render.field.tint': 'Tinte',
+            'studio_render.field.vignette': 'Viñeta',
+            'studio_render.action.scene_composer': 'Compositor de escena...',
+            'studio_render.action.scene_composer.desc': 'Iguala el postprocesado del viewport con Studio Render y coordina el entorno Lightflow',
             'studio_render.field.zoom': 'Distancia Focal',
             'studio_render.field.gpu': 'GPU',
             'studio_render.field.gpu_renderer': 'Renderer',
@@ -501,6 +540,15 @@
         settings.bloom_hdr_strength = clamp(toNumber(settings.bloom_hdr_strength, 1), 0, 4);
         settings.bloom_emissive_strength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         settings.bloom_occlusion = settings.bloom_occlusion !== false;
+        settings.viewport_bloom_enabled = settings.viewport_bloom_enabled !== false;
+        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 30), 5, 60);
+        settings.color_grading_enabled = !!settings.color_grading_enabled;
+        settings.exposure = clamp(toNumber(settings.exposure, 1), 0.1, 4);
+        settings.contrast = clamp(toNumber(settings.contrast, 1), 0, 3);
+        settings.saturation = clamp(toNumber(settings.saturation, 1), 0, 3);
+        settings.temperature = clamp(toNumber(settings.temperature, 0), -1, 1);
+        settings.tint = clamp(toNumber(settings.tint, 0), -1, 1);
+        settings.vignette = clamp(toNumber(settings.vignette, 0), 0, 1);
         delete settings.gpu_status;
         return settings;
     }
@@ -795,6 +843,15 @@
         settings.bloom_hdr_strength = clamp(toNumber(settings.bloom_hdr_strength, 1), 0, 4);
         settings.bloom_emissive_strength = clamp(toNumber(settings.bloom_emissive_strength, 1.35), 0, 6);
         settings.bloom_occlusion = settings.bloom_occlusion !== false;
+        settings.viewport_bloom_enabled = settings.viewport_bloom_enabled !== false;
+        settings.viewport_bloom_fps = clamp(toNumber(settings.viewport_bloom_fps, 30), 5, 60);
+        settings.color_grading_enabled = !!settings.color_grading_enabled;
+        settings.exposure = clamp(toNumber(settings.exposure, 1), 0.1, 4);
+        settings.contrast = clamp(toNumber(settings.contrast, 1), 0, 3);
+        settings.saturation = clamp(toNumber(settings.saturation, 1), 0, 3);
+        settings.temperature = clamp(toNumber(settings.temperature, 0), -1, 1);
+        settings.tint = clamp(toNumber(settings.tint, 0), -1, 1);
+        settings.vignette = clamp(toNumber(settings.vignette, 0), 0, 1);
         settings.zoom = settings.zoom === null || settings.zoom === undefined || settings.zoom === ''
             ? null
             : toNumber(settings.zoom, DEFAULT_ZOOM);
@@ -1820,6 +1877,216 @@
         return canvas;
     }
 
+    function applyFinalColorGrade(canvas, settings) {
+        if (!canvas || !settings?.color_grading_enabled) return canvas;
+        const width = canvas.width || 1;
+        const height = canvas.height || 1;
+        const source = document.createElement('canvas');
+        source.width = width;
+        source.height = height;
+        source.getContext('2d').drawImage(canvas, 0, 0);
+
+        const context = canvas.getContext('2d');
+        context.save();
+        context.clearRect(0, 0, width, height);
+        context.filter = [
+            'brightness(' + clamp(toNumber(settings.exposure, 1), 0.1, 4) + ')',
+            'contrast(' + clamp(toNumber(settings.contrast, 1), 0, 3) + ')',
+            'saturate(' + clamp(toNumber(settings.saturation, 1), 0, 3) + ')'
+        ].join(' ');
+        context.drawImage(source, 0, 0);
+        context.filter = 'none';
+
+        const temperature = clamp(toNumber(settings.temperature, 0), -1, 1);
+        const tint = clamp(toNumber(settings.tint, 0), -1, 1);
+        if (Math.abs(temperature) > 0.001 || Math.abs(tint) > 0.001) {
+            context.globalCompositeOperation = 'soft-light';
+            context.globalAlpha = Math.min(0.42, (Math.abs(temperature) + Math.abs(tint)) * 0.24);
+            const red = clamp(128 + temperature * 127 + tint * 26, 0, 255);
+            const green = clamp(128 - Math.abs(tint) * 92, 0, 255);
+            const blue = clamp(128 - temperature * 127 + tint * 26, 0, 255);
+            context.fillStyle = 'rgb(' + Math.round(red) + ', ' + Math.round(green) + ', ' + Math.round(blue) + ')';
+            context.fillRect(0, 0, width, height);
+        }
+
+        const vignette = clamp(toNumber(settings.vignette, 0), 0, 1);
+        if (vignette > 0.001) {
+            const gradient = context.createRadialGradient(
+                width * 0.5, height * 0.5, Math.min(width, height) * 0.18,
+                width * 0.5, height * 0.5, Math.max(width, height) * 0.72
+            );
+            gradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
+            gradient.addColorStop(0.62, 'rgba(0, 0, 0, 0)');
+            gradient.addColorStop(1, 'rgba(0, 0, 0, ' + (vignette * 0.82) + ')');
+            context.globalCompositeOperation = 'source-over';
+            context.globalAlpha = 1;
+            context.fillStyle = gradient;
+            context.fillRect(0, 0, width, height);
+        }
+        context.restore();
+        return canvas;
+    }
+
+    function getViewportComposerState(preview) {
+        if (!preview?.canvas || !preview.canvas.parentElement) return null;
+        let state = VIEWPORT_COMPOSER_STATE.get(preview);
+        if (state) return state;
+
+        const overlay = document.createElement('canvas');
+        overlay.className = 'lightflow_scene_composer_overlay';
+        Object.assign(overlay.style, {
+            position: 'absolute',
+            pointerEvents: 'none',
+            zIndex: '4',
+            display: 'none'
+        });
+        const parent = preview.canvas.parentElement;
+        const previousParentPosition = parent.style.position;
+        if (getComputedStyle(parent).position === 'static') parent.style.position = 'relative';
+        parent.appendChild(overlay);
+
+        state = {
+            preview,
+            overlay,
+            parent,
+            previousParentPosition,
+            baseCanvas: document.createElement('canvas'),
+            maskCanvas: document.createElement('canvas'),
+            lastRender: 0,
+            rendering: false
+        };
+        VIEWPORT_COMPOSER_STATE.set(preview, state);
+        return state;
+    }
+
+    function positionViewportComposerOverlay(state) {
+        const source = state.preview.canvas;
+        const parentRect = state.parent.getBoundingClientRect();
+        const sourceRect = source.getBoundingClientRect();
+        state.overlay.style.left = (sourceRect.left - parentRect.left + state.parent.scrollLeft) + 'px';
+        state.overlay.style.top = (sourceRect.top - parentRect.top + state.parent.scrollTop) + 'px';
+        state.overlay.style.width = sourceRect.width + 'px';
+        state.overlay.style.height = sourceRect.height + 'px';
+    }
+
+    function hideViewportComposerOverlay(preview) {
+        const state = VIEWPORT_COMPOSER_STATE.get(preview);
+        if (state?.overlay) state.overlay.style.display = 'none';
+    }
+
+    function renderViewportComposer(preview) {
+        if (!preview?.renderer || !preview.canvas || window.LightManagerStudioRenderSession || preview.sa_studio_render_active) {
+            hideViewportComposerOverlay(preview);
+            return;
+        }
+        const active = (
+            currentSettings.viewport_bloom_enabled &&
+            currentSettings.bloom_enabled
+        ) || currentSettings.color_grading_enabled;
+        if (!active) {
+            hideViewportComposerOverlay(preview);
+            return;
+        }
+
+        const state = getViewportComposerState(preview);
+        if (!state || state.rendering) return;
+        const now = performance.now();
+        const interval = 1000 / clamp(toNumber(currentSettings.viewport_bloom_fps, 30), 5, 60);
+        if (now - state.lastRender < interval) {
+            // Keep the last completed post-process frame visible while the
+            // composer is throttled. Hiding it here would alternate between
+            // graded and ungraded frames on a faster viewport.
+            return;
+        }
+
+        const source = preview.canvas;
+        const width = Math.max(1, source.width || source.clientWidth || 1);
+        const height = Math.max(1, source.height || source.clientHeight || 1);
+        [state.baseCanvas, state.maskCanvas, state.overlay].forEach(canvas => {
+            if (canvas.width !== width) canvas.width = width;
+            if (canvas.height !== height) canvas.height = height;
+        });
+        positionViewportComposerOverlay(state);
+
+        state.rendering = true;
+        state.lastRender = now;
+        try {
+            const baseContext = state.baseCanvas.getContext('2d', { alpha: true });
+            baseContext.clearRect(0, 0, width, height);
+            baseContext.drawImage(source, 0, 0, width, height);
+
+            if (currentSettings.viewport_bloom_enabled && currentSettings.bloom_enabled) {
+                const maskContext = state.maskCanvas.getContext('2d', { alpha: true });
+                maskContext.clearRect(0, 0, width, height);
+                renderBloomMaskTile(preview, maskContext, {
+                    outputX: 0,
+                    outputY: 0,
+                    outputWidth: width,
+                    outputHeight: height,
+                    sampleWidth: width,
+                    sampleHeight: height,
+                    renderWidth: width,
+                    renderHeight: height,
+                    cropX: 0,
+                    cropY: 0,
+                    cropRight: 0,
+                    cropBottom: 0
+                }, 1);
+                applyFinalBloom(state.baseCanvas, currentSettings, state.maskCanvas);
+            }
+            applyFinalColorGrade(state.baseCanvas, currentSettings);
+
+            const overlayContext = state.overlay.getContext('2d', { alpha: true });
+            overlayContext.clearRect(0, 0, width, height);
+            overlayContext.drawImage(state.baseCanvas, 0, 0, width, height);
+            state.overlay.style.display = 'block';
+        } catch (error) {
+            state.overlay.style.display = 'none';
+        } finally {
+            state.rendering = false;
+        }
+    }
+
+    function collectStudioRenderPreviews() {
+        const previews = new Set();
+        if (window.Preview?.selected) previews.add(Preview.selected);
+        if (Array.isArray(window.Preview?.all)) Preview.all.forEach(preview => previews.add(preview));
+        [window.main_preview, window.MediaPreview, window.Screencam?.NoAAPreview].forEach(preview => {
+            if (preview) previews.add(preview);
+        });
+        return previews;
+    }
+
+    function patchViewportComposer(preview) {
+        if (!preview?.renderer || typeof preview.render !== 'function' || VIEWPORT_COMPOSER_STATE.has(preview)) return;
+        const originalRender = preview.render;
+        const patchedRender = function lightflowSceneComposerRender() {
+            const result = originalRender.apply(this, arguments);
+            renderViewportComposer(this);
+            return result;
+        };
+        const state = getViewportComposerState(preview);
+        if (!state) return;
+        state.originalRender = originalRender;
+        state.patchedRender = patchedRender;
+        preview.render = patchedRender;
+    }
+
+    function patchAllViewportComposers() {
+        collectStudioRenderPreviews().forEach(patchViewportComposer);
+    }
+
+    function disposeViewportComposers() {
+        VIEWPORT_COMPOSER_STATE.forEach((state, preview) => {
+            if (preview?.render === state.patchedRender) preview.render = state.originalRender;
+            state.overlay?.remove?.();
+            if (state.parent && state.previousParentPosition !== undefined) {
+                state.parent.style.position = state.previousParentPosition;
+            }
+        });
+        VIEWPORT_COMPOSER_STATE.clear();
+    }
+
     async function deliverRender(dataUrl, size, settings) {
         const name = settings.file_name.replace(/[\\/:*?"<>|]+/g, '_') || DEFAULT_SETTINGS.file_name;
         if (settings.destination === 'save') {
@@ -1981,6 +2248,7 @@
 
             Blockbench.setStatusBarText(translate('studio_render.status.downsample', 'Compositing final image...'));
             applyFinalBloom(canvas, normalized, bloomMaskCanvas);
+            applyFinalColorGrade(canvas, normalized);
             const dataUrl = canvas.toDataURL('image/png');
             await deliverRender(dataUrl, outputSize, normalized);
         } catch (error) {
@@ -2691,6 +2959,80 @@
                 value: settings.bloom_occlusion,
                 condition: form => !!form.bloom_enabled && !!form.show_advanced
             },
+            viewport_bloom_enabled: {
+                type: 'checkbox',
+                label: 'studio_render.field.viewport_bloom_enabled',
+                value: settings.viewport_bloom_enabled,
+                condition: form => !!form.bloom_enabled
+            },
+            viewport_bloom_fps: {
+                type: 'range',
+                label: 'studio_render.field.viewport_bloom_fps',
+                value: settings.viewport_bloom_fps,
+                min: 5,
+                max: 60,
+                step: 5,
+                condition: form => !!form.bloom_enabled && !!form.viewport_bloom_enabled && !!form.show_advanced
+            },
+            color_grading_enabled: {
+                type: 'checkbox',
+                label: 'studio_render.field.color_grading_enabled',
+                value: settings.color_grading_enabled
+            },
+            exposure: {
+                type: 'range',
+                label: 'studio_render.field.exposure',
+                value: settings.exposure,
+                min: 0.1,
+                max: 4,
+                step: 0.05,
+                condition: form => !!form.color_grading_enabled
+            },
+            contrast: {
+                type: 'range',
+                label: 'studio_render.field.contrast',
+                value: settings.contrast,
+                min: 0,
+                max: 3,
+                step: 0.05,
+                condition: form => !!form.color_grading_enabled
+            },
+            saturation: {
+                type: 'range',
+                label: 'studio_render.field.saturation',
+                value: settings.saturation,
+                min: 0,
+                max: 3,
+                step: 0.05,
+                condition: form => !!form.color_grading_enabled
+            },
+            temperature: {
+                type: 'range',
+                label: 'studio_render.field.temperature',
+                value: settings.temperature,
+                min: -1,
+                max: 1,
+                step: 0.02,
+                condition: form => !!form.color_grading_enabled && !!form.show_advanced
+            },
+            tint: {
+                type: 'range',
+                label: 'studio_render.field.tint',
+                value: settings.tint,
+                min: -1,
+                max: 1,
+                step: 0.02,
+                condition: form => !!form.color_grading_enabled && !!form.show_advanced
+            },
+            vignette: {
+                type: 'range',
+                label: 'studio_render.field.vignette',
+                value: settings.vignette,
+                min: 0,
+                max: 1,
+                step: 0.02,
+                condition: form => !!form.color_grading_enabled
+            },
             _export: '_',
             destination: {
                 type: 'select',
@@ -2711,6 +3053,243 @@
         };
     }
 
+    function createSceneComposerForm(settings) {
+        const environment = window.LightflowEnvironment?.settings || {};
+        return {
+            _realtime: '_',
+            viewport_bloom_enabled: {
+                type: 'checkbox',
+                label: 'studio_render.field.viewport_bloom_enabled',
+                value: settings.viewport_bloom_enabled
+            },
+            viewport_bloom_fps: {
+                type: 'range',
+                label: 'studio_render.field.viewport_bloom_fps',
+                value: settings.viewport_bloom_fps,
+                min: 5,
+                max: 60,
+                step: 5,
+                condition: form => !!form.viewport_bloom_enabled
+            },
+            _bloom: '_',
+            bloom_enabled: {
+                type: 'checkbox',
+                label: 'studio_render.field.bloom_enabled',
+                value: settings.bloom_enabled
+            },
+            bloom_threshold: {
+                type: 'range',
+                label: 'studio_render.field.bloom_threshold',
+                value: settings.bloom_threshold,
+                min: 0,
+                max: 1,
+                step: 0.01,
+                condition: form => !!form.bloom_enabled
+            },
+            bloom_strength: {
+                type: 'range',
+                label: 'studio_render.field.bloom_strength',
+                value: settings.bloom_strength,
+                min: 0,
+                max: 3,
+                step: 0.05,
+                condition: form => !!form.bloom_enabled
+            },
+            bloom_radius: {
+                type: 'range',
+                label: 'studio_render.field.bloom_radius',
+                value: settings.bloom_radius,
+                min: 1,
+                max: 96,
+                step: 1,
+                condition: form => !!form.bloom_enabled
+            },
+            bloom_hdr_strength: {
+                type: 'range',
+                label: 'studio_render.field.bloom_hdr_strength',
+                value: settings.bloom_hdr_strength,
+                min: 0,
+                max: 4,
+                step: 0.05,
+                condition: form => !!form.bloom_enabled
+            },
+            bloom_emissive_strength: {
+                type: 'range',
+                label: 'studio_render.field.bloom_emissive_strength',
+                value: settings.bloom_emissive_strength,
+                min: 0,
+                max: 6,
+                step: 0.05,
+                condition: form => !!form.bloom_enabled
+            },
+            bloom_occlusion: {
+                type: 'checkbox',
+                label: 'studio_render.field.bloom_occlusion',
+                value: settings.bloom_occlusion,
+                condition: form => !!form.bloom_enabled
+            },
+            _grade: '_',
+            color_grading_enabled: {
+                type: 'checkbox',
+                label: 'studio_render.field.color_grading_enabled',
+                value: settings.color_grading_enabled
+            },
+            exposure: {
+                type: 'range',
+                label: 'studio_render.field.exposure',
+                value: settings.exposure,
+                min: 0.1,
+                max: 4,
+                step: 0.05,
+                condition: form => !!form.color_grading_enabled
+            },
+            contrast: {
+                type: 'range',
+                label: 'studio_render.field.contrast',
+                value: settings.contrast,
+                min: 0,
+                max: 3,
+                step: 0.05,
+                condition: form => !!form.color_grading_enabled
+            },
+            saturation: {
+                type: 'range',
+                label: 'studio_render.field.saturation',
+                value: settings.saturation,
+                min: 0,
+                max: 3,
+                step: 0.05,
+                condition: form => !!form.color_grading_enabled
+            },
+            temperature: {
+                type: 'range',
+                label: 'studio_render.field.temperature',
+                value: settings.temperature,
+                min: -1,
+                max: 1,
+                step: 0.02,
+                condition: form => !!form.color_grading_enabled
+            },
+            tint: {
+                type: 'range',
+                label: 'studio_render.field.tint',
+                value: settings.tint,
+                min: -1,
+                max: 1,
+                step: 0.02,
+                condition: form => !!form.color_grading_enabled
+            },
+            vignette: {
+                type: 'range',
+                label: 'studio_render.field.vignette',
+                value: settings.vignette,
+                min: 0,
+                max: 1,
+                step: 0.02,
+                condition: form => !!form.color_grading_enabled
+            },
+            _environment: '_',
+            environment_enabled: {
+                type: 'checkbox',
+                label: 'lightflow_environment.field.enabled',
+                value: environment.enabled !== false,
+                condition: () => !!window.LightflowEnvironment
+            },
+            environment_preset: {
+                type: 'select',
+                label: 'lightflow_environment.field.preset',
+                value: environment.preset || 'vanilla',
+                options: {
+                    vanilla: 'Minecraft Vanilla',
+                    vibrant_visuals: 'Minecraft Vibrant Visuals'
+                },
+                condition: () => !!window.LightflowEnvironment
+            },
+            environment_time: {
+                type: 'range',
+                label: 'lightflow_environment.field.time',
+                value: Number(environment.time) || 6000,
+                min: 0,
+                max: 23999,
+                step: 100,
+                condition: () => !!window.LightflowEnvironment
+            },
+            environment_strength: {
+                type: 'range',
+                label: 'lightflow_environment.field.environment',
+                value: Number(environment.environment_strength) || 0.75,
+                min: 0,
+                max: 4,
+                step: 0.05,
+                condition: () => !!window.LightflowEnvironment
+            }
+        };
+    }
+
+    function refreshSceneComposerPreviews() {
+        patchAllViewportComposers();
+        collectStudioRenderPreviews().forEach(preview => preview?.render?.());
+    }
+
+    function applySceneComposerForm(form, persist) {
+        const next = Object.assign({}, currentSettings, form || {});
+        delete next.environment_enabled;
+        delete next.environment_preset;
+        delete next.environment_time;
+        delete next.environment_strength;
+        currentSettings = normalizeForm(next);
+        if (persist) saveSettings(currentSettings);
+
+        if (window.LightflowEnvironment && form) {
+            window.LightflowEnvironment.setSettings({
+                enabled: form.environment_enabled,
+                preset: form.environment_preset,
+                time: form.environment_time,
+                environment_strength: form.environment_strength
+            }, {
+                cause: 'scene_composer',
+                render: false,
+                forceShadow: false
+            });
+        }
+
+        if (viewportBloomToggle) {
+            viewportBloomToggle.value = !!currentSettings.viewport_bloom_enabled;
+            viewportBloomToggle.updateEnabledState?.();
+        }
+        refreshSceneComposerPreviews();
+    }
+
+    function openSceneComposerDialog() {
+        currentSettings = loadSettings();
+        const initialEnvironment = window.LightflowEnvironment?.settings || null;
+        activeComposerDialog = new Dialog('lightflow_scene_composer_dialog', {
+            title: 'studio_render.action.scene_composer',
+            width: 680,
+            form: createSceneComposerForm(currentSettings),
+            onFormChange(form) {
+                applySceneComposerForm(form, false);
+            },
+            onConfirm(form) {
+                applySceneComposerForm(form, true);
+                activeComposerDialog = null;
+            },
+            onCancel() {
+                currentSettings = loadSettings();
+                if (initialEnvironment && window.LightflowEnvironment) {
+                    window.LightflowEnvironment.setSettings(initialEnvironment, {
+                        cause: 'scene_composer_cancel',
+                        render: false,
+                        forceShadow: true
+                    });
+                }
+                refreshSceneComposerPreviews();
+                activeComposerDialog = null;
+            }
+        });
+        activeComposerDialog.show();
+    }
+
     function openStudioRenderDialog() {
         currentSettings = loadSettings();
         activeDialog = new Dialog({
@@ -2726,6 +3305,7 @@
                 }
                 currentSettings = next;
                 StudioRenderFrame.updateNode();
+                refreshSceneComposerPreviews();
             },
             onConfirm(form) {
                 const settings = normalizeForm(form);
@@ -2737,6 +3317,7 @@
             onCancel() {
                 currentSettings = loadSettings();
                 StudioRenderFrame.updateNode();
+                refreshSceneComposerPreviews();
                 activeDialog = null;
             }
         });
@@ -2976,10 +3557,21 @@
             activeDialog.hide();
             activeDialog = null;
         }
+        if (activeComposerDialog) {
+            activeComposerDialog.hide();
+            activeComposerDialog = null;
+        }
         if (exportAction) exportAction.delete();
         if (quickRenderAction) quickRenderAction.delete();
         if (frameAction) frameAction.delete();
         if (resetFrameAction) resetFrameAction.delete();
+        if (sceneComposerAction) sceneComposerAction.delete();
+        if (viewportBloomToggle) viewportBloomToggle.delete();
+        if (sceneBloomStrength) sceneBloomStrength.delete();
+        if (sceneComposerToolbar) sceneComposerToolbar.delete();
+        if (sceneComposerPanel) sceneComposerPanel.delete();
+        if (sceneComposerProjectListener) sceneComposerProjectListener.delete?.();
+        disposeViewportComposers();
         if (stylesheet && typeof stylesheet.delete === 'function') stylesheet.delete();
         BLOOM_MASK_STATE.resources.forEach(resource => resource?.dispose?.());
         BLOOM_MASK_STATE.resources.clear();
@@ -2994,7 +3586,7 @@
         author: 'MidFord327',
         description: 'Export polished Blockbench studio renders with tiled supersampling, 4K/8K-safe output, transparency, GPU guidance, and an adjustable frame. Complements Light Manager and Shader Architect in the Lightflow suite.',
         tags: ['Lightflow', 'Rendering', 'Export', 'Screenshots', 'Studio', 'Presentation'],
-        version: '1.4.2',
+        version: '1.5.0',
         min_version: '4.9.0',
         variant: 'both',
         onload() {
@@ -3045,17 +3637,95 @@
                 }
             });
 
+            sceneComposerAction = new Action('lightflow_scene_composer', {
+                name: 'studio_render.action.scene_composer',
+                description: 'studio_render.action.scene_composer.desc',
+                icon: 'auto_fix_high',
+                category: 'view',
+                condition: () => !!getPreview(),
+                click: openSceneComposerDialog
+            });
+
+            viewportBloomToggle = new Toggle('lightflow_viewport_bloom', {
+                name: 'studio_render.field.viewport_bloom_enabled',
+                icon: 'flare',
+                category: 'view',
+                condition: () => !!getPreview(),
+                value: !!currentSettings.viewport_bloom_enabled,
+                onChange(value) {
+                    currentSettings.viewport_bloom_enabled = !!value;
+                    saveSettings(normalizeForm(currentSettings));
+                    refreshSceneComposerPreviews();
+                }
+            });
+
+            sceneBloomStrength = new NumSlider('lightflow_scene_bloom_strength', {
+                name: 'studio_render.field.bloom_strength',
+                icon: 'blur_on',
+                category: 'view',
+                condition: () => !!getPreview(),
+                value: currentSettings.bloom_strength,
+                min: 0,
+                max: 3,
+                step: 0.05,
+                onChange() {
+                    currentSettings.bloom_strength = clamp(toNumber(this.value, 0.8), 0, 3);
+                    currentSettings.bloom_enabled = currentSettings.bloom_strength > 0;
+                    saveSettings(normalizeForm(currentSettings));
+                    refreshSceneComposerPreviews();
+                }
+            });
+
+            sceneComposerToolbar = new Toolbar({
+                id: 'lightflow_scene_composer_toolbar',
+                name: 'studio_render.action.scene_composer',
+                children: [
+                    'lightflow_scene_composer',
+                    'lightflow_viewport_bloom',
+                    'lightflow_scene_bloom_strength'
+                ]
+            });
+
+            sceneComposerPanel = new Panel('lightflow_scene_composer_panel', {
+                name: 'studio_render.action.scene_composer',
+                icon: 'auto_fix_high',
+                condition: () => !!window.Project,
+                default_position: {
+                    slot: 'right_bar',
+                    height: 58,
+                    folded: false
+                },
+                toolbars: [sceneComposerToolbar]
+            });
+
             MenuBar.addAction(exportAction, 'file.export');
             MenuBar.addAction(quickRenderAction, 'file.export');
             MenuBar.addAction(exportAction, 'view');
             MenuBar.addAction(quickRenderAction, 'view');
             MenuBar.addAction(frameAction, 'view');
             MenuBar.addAction(resetFrameAction, 'view');
+            MenuBar.addAction(sceneComposerAction, 'view');
+
+            patchAllViewportComposers();
+            sceneComposerProjectListener = Blockbench.on('select_project', () => {
+                currentSettings = loadSettings();
+                patchAllViewportComposers();
+                refreshSceneComposerPreviews();
+            });
 
             window.StudioRender = {
                 open: openStudioRenderDialog,
                 render: renderWithSettings,
                 quickRender: quickStudioRender,
+                openComposer: openSceneComposerDialog,
+                refreshComposer: refreshSceneComposerPreviews,
+                get settings() { return Object.assign({}, currentSettings); },
+                setComposerSettings(next) {
+                    currentSettings = normalizeForm(Object.assign({}, currentSettings, next || {}));
+                    saveSettings(currentSettings);
+                    refreshSceneComposerPreviews();
+                    return Object.assign({}, currentSettings);
+                },
                 showFrame: () => StudioRenderFrame.show(getPreview(), currentSettings),
                 hideFrame: () => StudioRenderFrame.remove(true),
                 resetFrame: () => StudioRenderFrame.reset(getPreview(), currentSettings)

--- a/studio_render.js
+++ b/studio_render.js
@@ -67,6 +67,10 @@
     let sceneComposerPanel;
     let sceneComposerProjectListener;
     let sceneComposerModeListener;
+    let sceneComposerCloseListener;
+    let sceneComposerLifecycleHydrator;
+    let sceneComposerRefreshFrame = null;
+    let sceneComposerRevision = 0;
     let syncingSceneComposerPanel = false;
     let activeComposerDialog;
     let stylesheet;
@@ -1784,10 +1788,6 @@
             await waitForFrame();
             window.LightManagerPrepareRender(sourcePreview, { force: true, studio: false });
             sourcePreview.render();
-
-            await waitForFrame();
-            window.LightManagerPrepareRender(sourcePreview, { force: true, studio: false });
-            sourcePreview.render();
         }
     }
 
@@ -2515,9 +2515,14 @@
         const state = getViewportComposerState(preview);
         if (!state || state.scheduled) return;
         state.scheduled = true;
+        const scheduledRevision = sceneComposerRevision;
+        const scheduledProject = window.Project || null;
         const run = () => {
-            if (state.disposed) return;
             state.scheduled = false;
+            if (state.disposed) return;
+            if (scheduledRevision !== sceneComposerRevision || scheduledProject !== (window.Project || null)) return;
+            const activePreview = getPreview();
+            if (activePreview && preview !== activePreview) return;
             renderViewportComposer(preview);
         };
         // A microtask runs after every synchronous preview wrapper (including
@@ -2534,6 +2539,17 @@
 
     function patchAllViewportComposers() {
         collectStudioRenderPreviews().forEach(patchViewportComposer);
+    }
+
+    function resetSceneComposerLifecycle() {
+        sceneComposerRevision += 1;
+        if (typeof sceneComposerRefreshFrame === 'number' && typeof cancelAnimationFrame === 'function') {
+            cancelAnimationFrame(sceneComposerRefreshFrame);
+        }
+        sceneComposerRefreshFrame = null;
+        VIEWPORT_COMPOSER_STATE.forEach(state => {
+            state.scheduled = false;
+        });
     }
 
     function disposeViewportComposers() {
@@ -3717,8 +3733,24 @@
     }
 
     function refreshSceneComposerPreviews() {
-        patchAllViewportComposers();
-        collectStudioRenderPreviews().forEach(preview => preview?.render?.());
+        const preview = getPreview();
+        if (!preview) return;
+        patchViewportComposer(preview);
+        if (sceneComposerRefreshFrame !== null) return;
+        const revision = sceneComposerRevision;
+        const project = window.Project || null;
+        const render = () => {
+            sceneComposerRefreshFrame = null;
+            if (revision !== sceneComposerRevision || project !== (window.Project || null)) return;
+            const activePreview = getPreview();
+            activePreview?.render?.();
+        };
+        if (typeof requestAnimationFrame === 'function') {
+            sceneComposerRefreshFrame = requestAnimationFrame(render);
+        } else {
+            sceneComposerRefreshFrame = 'microtask';
+            queueMicrotask(render);
+        }
     }
 
     function createSceneComposerPanelForm(settings) {
@@ -4134,6 +4166,9 @@
         if (sceneComposerPanel) sceneComposerPanel.delete();
         if (sceneComposerProjectListener) sceneComposerProjectListener.delete?.();
         if (sceneComposerModeListener) sceneComposerModeListener.delete?.();
+        if (sceneComposerCloseListener) sceneComposerCloseListener.delete?.();
+        if (sceneComposerLifecycleHydrator) sceneComposerLifecycleHydrator.delete?.();
+        resetSceneComposerLifecycle();
         disposeViewportComposers();
         if (stylesheet && typeof stylesheet.delete === 'function') stylesheet.delete();
         BLOOM_MASK_STATE.resources.forEach(resource => resource?.dispose?.());
@@ -4149,7 +4184,7 @@
         author: 'MidFord327',
         description: 'Export polished Blockbench studio renders with tiled supersampling, 4K/8K-safe output, transparency, GPU guidance, and an adjustable frame. Complements Light Manager and Shader Architect in the Lightflow suite.',
         tags: ['Lightflow', 'Rendering', 'Export', 'Screenshots', 'Studio', 'Presentation'],
-        version: '1.6.1',
+        version: '1.7.0',
         min_version: '4.9.0',
         variant: 'both',
         onload() {
@@ -4254,12 +4289,25 @@
             MenuBar.addAction(sceneComposerAction, 'view');
 
             patchAllViewportComposers();
-            sceneComposerProjectListener = Blockbench.on('select_project', () => {
-                currentSettings = loadSettings();
-                syncSceneComposerPanel();
-                patchAllViewportComposers();
-                refreshSceneComposerPreviews();
-            });
+            sceneComposerLifecycleHydrator = window.LightflowLifecycle?.registerHydrator?.(
+                'studio_render',
+                ({ project, deferred }) => {
+                    resetSceneComposerLifecycle();
+                    if (deferred || !project) return;
+                    currentSettings = loadSettings();
+                    syncSceneComposerPanel();
+                    refreshSceneComposerPreviews();
+                }
+            );
+            if (!sceneComposerLifecycleHydrator) {
+                sceneComposerProjectListener = Blockbench.on('select_project', () => {
+                    resetSceneComposerLifecycle();
+                    currentSettings = loadSettings();
+                    syncSceneComposerPanel();
+                    refreshSceneComposerPreviews();
+                });
+                sceneComposerCloseListener = Blockbench.on('close_project', resetSceneComposerLifecycle);
+            }
             sceneComposerModeListener = Blockbench.on('select_mode', () => {
                 refreshSceneComposerPreviews();
             });

--- a/tests/release_candidate.test.js
+++ b/tests/release_candidate.test.js
@@ -25,17 +25,108 @@ test('all independently loadable plugins parse as JavaScript', () => {
 
 test('release candidate versions stay synchronized with the README', () => {
     const expected = {
-        'light_manager.js': '1.6.5',
-        'shader_architect.js': '2.8.0',
-        'lightflow_atmosphere.js': '1.1.0',
-        'lightflow_environment.js': '1.2.0',
-        'studio_render.js': '1.6.1'
+        'light_manager.js': '1.7.0',
+        'shader_architect.js': '2.9.0',
+        'lightflow_atmosphere.js': '1.2.0',
+        'lightflow_environment.js': '1.3.0',
+        'studio_render.js': '1.7.0'
     };
     const readme = read('README.md');
     Object.entries(expected).forEach(([file, version]) => {
         assert.match(read(file), new RegExp(`version:\\s*['\"]${version.replaceAll('.', '\\.')}['\"]|PLUGIN_VERSION\\s*=\\s*['\"]${version.replaceAll('.', '\\.')}['\"]`));
         assert.ok(readme.includes(`\`${version}\``), `${version} is missing from README.md`);
     });
+});
+
+test('Light Manager registers custom project types before cosmetic icon work', () => {
+    const source = read('light_manager.js');
+    const synchronousRegistration = source.lastIndexOf('initialize_light_plugin();');
+    const deferredIcons = source.lastIndexOf('load_textures().catch');
+    assert.ok(synchronousRegistration >= 0, 'Light Manager registration call is missing');
+    assert.ok(deferredIcons > synchronousRegistration, 'icon generation must run after plugin registration');
+    assert.match(source, /requestIdleCallback\(callback, \{ timeout: 1800 \}\)/);
+    assert.match(source, /await Promise\.all\(specs\.map/);
+    assert.doesNotMatch(source, /load_textures\(\)[\s\S]{0,240}\.then\(\(\) => \{\s*initialize_light_plugin\(\)/);
+    ['shader_architect.js', 'lightflow_environment.js', 'lightflow_atmosphere.js'].forEach(file => {
+        assert.doesNotMatch(read(file), /waitFor(?:Plugin)?LightManager/);
+    });
+});
+
+test('late plugin startup rehydrates every persisted Lightflow project feature', () => {
+    const lights = read('light_manager.js');
+    const environment = read('lightflow_environment.js');
+    const atmosphere = read('lightflow_atmosphere.js');
+    const shaders = read('shader_architect.js');
+
+    assert.match(lights, /function createLightflowLifecycleRuntime\(\)/);
+    assert.match(lights, /Blockbench\.on\('load_project',[\s\S]{0,260}event\?\.model[\s\S]{0,160}deferHydration: true/);
+    assert.match(lights, /Codecs\?\.project\?\.on\?\.\('parsed'/);
+    assert.match(lights, /Blockbench\.read\(\[path\], \{ errorbox: false \}/);
+    const closeLifecycleStart = lights.indexOf("Blockbench.on('close_project'");
+    const closeLifecycleEnd = lights.indexOf('const parsedListener', closeLifecycleStart);
+    const closeLifecycle = lights.slice(closeLifecycleStart, closeLifecycleEnd);
+    assert.match(closeLifecycle, /deferHydration: true/);
+    assert.match(closeLifecycle, /close_project_ready/);
+    assert.match(lights, /attachOwner\(\)[\s\S]{0,180}releaseOwner\(\)/);
+    assert.match(lights, /restoreCustomElements\(model, 'light', LightElement\)/);
+    assert.match(atmosphere, /restoreCustomElements\(model, 'lightflow_volume', VolumeElement\)/);
+    assert.match(environment, /typeof model\?\.\[PROJECT_PROPERTY\] === 'string'/);
+    assert.match(shaders, /model\?\.\[PROJECT_MATERIAL_INSTANCES_PROP\]/);
+    assert.match(shaders, /const rawByUuid = new Map/);
+    assert.match(shaders, /FACE_MATERIAL_INSTANCES_PROP/);
+});
+
+test('project generations reject stale Lightflow render and material work', () => {
+    const environment = read('lightflow_environment.js');
+    const atmosphere = read('lightflow_atmosphere.js');
+    const shaders = read('shader_architect.js');
+    const studio = read('studio_render.js');
+
+    assert.match(environment, /revision !== environmentRevision[\s\S]{0,120}project !== environmentProject/);
+    assert.match(atmosphere, /revision !== atmosphereRevision[\s\S]{0,120}project !== atmosphereProject/);
+    assert.match(shaders, /scheduledRevision !== this\.projectRevision[\s\S]{0,180}scheduledProject !== this\.activeProject/);
+    assert.match(shaders, /beginProjectLifecycle\(project\)[\s\S]{0,260}cancelPendingSceneUpdate\(\)/);
+    assert.match(studio, /scheduledRevision !== sceneComposerRevision \|\| scheduledProject !== \(window\.Project \|\| null\)/);
+    assert.match(studio, /resetSceneComposerLifecycle\(\)/);
+});
+
+test('light and shadow hot paths stay partial and change-driven', () => {
+    const lights = read('light_manager.js');
+    const environment = read('lightflow_environment.js');
+
+    assert.match(lights, /renderer\.shadowMap\.autoUpdate = false/);
+    assert.match(lights, /renderer\.shadowMap\.autoUpdate = true/);
+    assert.match(lights, /const targetLights = updateOptions\.elements/);
+    assert.match(lights, /elements: \[light\],[\s\S]{0,80}cleanup: false/);
+    assert.match(lights, /if \(light\?\.userData\?\.lightflowEnvironmentVirtual\) continue/);
+    assert.match(lights, /Blockbench\.on\('finish_edit',[\s\S]{0,600}scene: false/);
+    assert.match(lights, /element_aspects: \{ transform: true \}/);
+    assert.doesNotMatch(lights, /element_aspects: \{ transform: true, geometry: true \}/);
+
+    assert.match(environment, /const configSignature =/);
+    assert.match(environment, /shadow\.map\?\.setSize/);
+    assert.match(environment, /directionAngle >= THREE\.MathUtils\.degToRad\(0\.35\)/);
+    assert.match(environment, /now - lastSunShadowRefresh >= 100/);
+    assert.match(environment, /sunLight\.visible = true/);
+    assert.match(environment, /sunLight\.intensity = activeSun \? state\.sunIntensity : 0/);
+    assert.match(environment, /if \(shadowChanged && typeof window\.LightManagerPrepareRender/);
+});
+
+test('Scene Composer refreshes only the active preview and coalesces UI changes', () => {
+    const source = read('studio_render.js');
+    const scheduleStart = source.indexOf('function scheduleViewportComposer');
+    const scheduleEnd = source.indexOf('function patchAllViewportComposers', scheduleStart);
+    const refreshStart = source.indexOf('function refreshSceneComposerPreviews');
+    const refreshEnd = source.indexOf('function createSceneComposerPanelForm', refreshStart);
+    const schedule = source.slice(scheduleStart, scheduleEnd);
+    const refresh = source.slice(refreshStart, refreshEnd);
+
+    assert.match(schedule, /const activePreview = getPreview\(\)/);
+    assert.match(schedule, /if \(activePreview && preview !== activePreview\) return/);
+    assert.match(refresh, /if \(sceneComposerRefreshFrame !== null\) return/);
+    assert.match(refresh, /const activePreview = getPreview\(\)/);
+    assert.match(refresh, /activePreview\?\.render\?\.\(\)/);
+    assert.doesNotMatch(refresh, /collectStudioRenderPreviews/);
 });
 
 test('Shader Architect covers Cube, Mesh, and TextureMesh lifecycle paths', () => {
@@ -131,7 +222,8 @@ test('Scene Composer keeps realtime Bloom GPU-resident, DPI-safe, and AO-order-s
     assert.match(source, /viewport_bloom_fps: 0/);
     assert.match(source, /max: 144/);
     assert.match(source, /adaptive: \{ scale:/);
-    assert.match(source, /id: 'lightflow_scene_composer_toolbar'/);
+    assert.match(source, /new Panel\('lightflow_scene_composer_panel'/);
+    assert.doesNotMatch(source, /id: 'lightflow_scene_composer_toolbar'/);
     assert.match(source, /viewport_bloom_fps/);
     assert.match(source, /new THREE\.WebGLRenderTarget\(width, height/);
     assert.doesNotMatch(source, /renderer\.readRenderTargetPixels\(state\.maskTarget/);
@@ -179,10 +271,12 @@ test('light updates and environment animation are coalesced without redundant sc
     const environment = read('lightflow_environment.js');
     assert.match(lights, /activeUuids: new Set\(\)/);
     assert.match(lights, /worldPosition: new THREE\.Vector3\(\)/);
-    assert.match(lights, /update_light_element_callback\?\.\(\{ shadows: true, scene: false, gizmos: true \}\)/);
+    assert.match(lights, /elements: \[light\],[\s\S]{0,80}cleanup: false/);
+    assert.match(lights, /sceneTopologyChanged/);
     assert.match(environment, /requestLightUniformUpdate\('environment_update', \{ render: false \}\)/);
     assert.match(environment, /if \(previewRenderFrame !== null\) return/);
     assert.match(environment, /const preview = window\.Preview\?\.selected \|\| window\.main_preview/);
+    assert.match(environment, /updateScene\(\{ forceShadow: false, animation: true \}\)/);
 });
 
 test('Minecraft environment drives sky, time, ambient response, sun shadows, and project persistence', () => {
@@ -191,7 +285,7 @@ test('Minecraft environment drives sky, time, ambient response, sun shadows, and
     assert.match(source, /vibrant_visuals:/);
     assert.match(source, /function getLightingState\(\)/);
     assert.match(source, /new THREE\.DirectionalLight/);
-    assert.match(source, /shadow\.camera\.left/);
+    assert.match(source, /const cameraValues = \{\s*left: -area, right: area, top: area, bottom: -area/);
     assert.match(source, /pixelated_shadows/);
     assert.match(source, /lightflow_environment_settings/);
     assert.match(source, /getVirtualLight/);
@@ -203,7 +297,7 @@ test('Minecraft environment drives sky, time, ambient response, sun shadows, and
     assert.match(source, /Generated Vanilla-style Texture/);
     assert.match(source, /condition: \{ modes: \['render'\], project: true \}/);
     assert.match(source, /attached_to: 'outliner'/);
-    assert.match(source, /updateScene\(\{ forceShadow: false \}\);\s*dispatchChanged\('animation'\)/);
+    assert.match(source, /updateScene\(\{ forceShadow: false, animation: true \}\);\s*dispatchChanged\('animation'\)/);
     assert.equal((source.match(/\.join\('\\n'\)/g) || []).length, 2);
     assert.doesNotMatch(source, /\.join\('\\\\n'\)/);
 });
@@ -233,9 +327,11 @@ test('Vibrant Visuals PBR uses native MER semantics, environment lighting, SSR f
     assert.match(source, /uSAEnvironmentAmbient/);
     assert.match(source, /"uSAEnvironmentEnabled": \{ type: "int", value: 0, expose: false \}/);
     assert.match(source, /saSSRSampleEnvironment/);
-    assert.match(source, /uPixelatedShadows/);
-    assert.match(source, /uniform bool PIXELATED_SHADOWS/);
-    assert.match(source, /\/\* Lightflow lights \*\/[\s\S]*?uniform int uLightCastShadow\[16\];[\s\S]*?uniform int uLightShadowIndex\[16\];/);
+    assert.match(source, /uLFPixelatedShadowsEnabled/);
+    assert.match(source, /uniform bool uLFPixelatedShadowsEnabled/);
+    assert.match(source, /\/\* Lightflow lights \*\//);
+    assert.match(source, /uniform int uLightCastShadow\[16\];/);
+    assert.match(source, /uniform int uLightShadowIndex\[16\];/);
 });
 
 test('Three r129 punctual-light compatibility stays local to custom shaders', () => {
@@ -244,7 +340,7 @@ test('Three r129 punctual-light compatibility stays local to custom shaders', ()
     assert.doesNotMatch(lights, /ShaderChunk\.common\s*\+=/);
     assert.doesNotMatch(lights, /float punctualLightIntensityToIrradianceFactor/);
     assert.match(shaders, /const LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT/);
-    assert.equal((shaders.match(/\$\{LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT\}/g) || []).length, 5);
+    assert.ok((shaders.match(/\$\{LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT\}/g) || []).length >= 5);
 });
 
 test('SSR capture never samples the render target currently being written', () => {
@@ -265,7 +361,7 @@ test('supporting modules include Mesh and TextureMesh render elements', () => {
     assert.match(lights, /TextureMesh\.selected/);
 });
 
-test('Atmosphere 1.0 keeps volume targets DPI-safe and shadowed God Rays transparent', () => {
+test('Atmosphere 1.2 keeps volume targets DPI-safe and shadowed God Rays transparent', () => {
     const source = read('lightflow_atmosphere.js');
     assert.match(source, /function configureRenderTarget\(target, width, height\)/);
     assert.match(source, /configureRenderTarget\(state\.volumeTarget, volumeWidth, volumeHeight\)/);
@@ -285,7 +381,7 @@ test('Atmosphere 1.0 keeps volume targets DPI-safe and shadowed God Rays transpa
     assert.match(lightManager, /suppressElementShadows \|\| object\.userData\?\.lightflowNoShadow/);
 });
 
-test('Atmosphere 1.0 skips redundant realtime volume work', () => {
+test('Atmosphere 1.2 skips redundant realtime volume work', () => {
     const source = read('lightflow_atmosphere.js');
     assert.match(source, /frustum\.intersectsSphere/);
     assert.match(source, /computeFrameSignature\(state, preview, volumes, studio\)/);

--- a/tests/release_candidate.test.js
+++ b/tests/release_candidate.test.js
@@ -25,11 +25,11 @@ test('all independently loadable plugins parse as JavaScript', () => {
 
 test('release candidate versions stay synchronized with the README', () => {
     const expected = {
-        'light_manager.js': '1.6.3',
+        'light_manager.js': '1.6.4',
         'shader_architect.js': '2.7.1',
-        'lightflow_atmosphere.js': '1.0.0',
+        'lightflow_atmosphere.js': '1.0.1',
         'lightflow_environment.js': '1.1.0',
-        'studio_render.js': '1.5.1'
+        'studio_render.js': '1.6.0'
     };
     const readme = read('README.md');
     Object.entries(expected).forEach(([file, version]) => {
@@ -114,24 +114,41 @@ test('Bloom uses transparent depth-only texels to occlude hidden emitters withou
     assert.doesNotMatch(source, /if \(energy <= 0\.0005\) discard;/);
 });
 
-test('Scene Composer reuses the final Bloom and color-grade functions in realtime', () => {
+test('Scene Composer keeps realtime Bloom GPU-resident, DPI-safe, and AO-order-safe', () => {
     const source = read('studio_render.js');
     assert.match(source, /function renderViewportComposer\(preview\)/);
     assert.match(source, /function scheduleViewportComposer\(preview\)/);
     assert.match(source, /const result = originalRender\.apply\(this, arguments\);\s*scheduleViewportComposer\(this\);/);
     assert.match(source, /renderViewportBloomMask\(preview, state, maskWidth, maskHeight\)/);
-    assert.match(source, /applyFinalBloom\(state\.baseCanvas, currentSettings, state\.maskCanvas, \{/);
-    assert.match(source, /applyFinalColorGrade\(state\.baseCanvas, currentSettings\)/);
+    assert.match(source, /renderViewportBloomPyramid\(preview, state, maskWidth, maskHeight, viewWidth, viewHeight\)/);
+    assert.match(source, /renderViewportGPUComposite\(preview, state, snapshot, bloomReady, useColorGrade\)/);
+    assert.match(source, /renderer\.copyFramebufferToTexture\(state\.copyPosition\.set\(originX, originY\), beauty\)/);
+    assert.match(source, /renderer\.getCurrentViewport\?\.\(new THREE\.Vector4\(\)\)/);
+    assert.match(source, /state\.bloomTargets\[index\] = createViewportPostTarget/);
+    assert.match(source, /Lightflow_ViewportBloomDownsample/);
+    assert.match(source, /Lightflow_ViewportGPUComposer/);
+    assert.match(source, /queueMicrotask\(run\)/);
+    assert.match(source, /viewport_bloom_fps: 0/);
+    assert.match(source, /max: 144/);
+    assert.match(source, /adaptive: \{ scale:/);
     assert.match(source, /id: 'lightflow_scene_composer_toolbar'/);
     assert.match(source, /viewport_bloom_fps/);
-    assert.match(source, /emissiveOnly: true/);
     assert.match(source, /new THREE\.WebGLRenderTarget\(width, height/);
-    assert.match(source, /renderer\.readRenderTargetPixels\(state\.maskTarget/);
+    assert.doesNotMatch(source, /renderer\.readRenderTargetPixels\(state\.maskTarget/);
+    assert.doesNotMatch(source, /lightflow_scene_composer_overlay/);
+    assert.doesNotMatch(source, /state\.maskPixels/);
     assert.match(source, /collectStudioRenderHiddenObjects\(\)\.forEach/);
     assert.match(source, /if \(!isLightflowRenderMode\(\)\)/);
     assert.match(source, /condition: \{ modes: \['render'\], project: true \}/);
     assert.match(source, /attached_to: window\.Panels\?\.lightflow_environment_panel \? 'lightflow_environment_panel' : 'outliner'/);
-    assert.doesNotMatch(source, /now - state\.lastRender < interval\) \{\s*state\.overlay\.style\.display = 'none'/);
+    assert.match(source, /applyFinalBloom\(canvas, normalized, bloomMaskCanvas\)/);
+    assert.match(source, /applyFinalColorGrade\(canvas, normalized\)/);
+    const maskSection = source.slice(
+        source.indexOf('function renderViewportBloomMask'),
+        source.indexOf('function createViewportComposerResources')
+    );
+    assert.match(maskSection, /configureViewportPostTarget\(state\.maskTarget, width, height\);\s*renderer\.setRenderTarget\(state\.maskTarget\)/);
+    assert.doesNotMatch(maskSection, /renderer\.setViewport/);
 });
 
 test('Minecraft environment drives sky, time, ambient response, sun shadows, and project persistence', () => {
@@ -225,6 +242,13 @@ test('Atmosphere 1.0 keeps volume targets DPI-safe and shadowed God Rays transpa
     assert.match(source, /if \(!lightShaft\) extinctionColor \+= sigmaS \+ sigmaA/);
     assert.match(source, /accumulated \+= transmittance \* scatteringSource \* stepLength/);
     assert.match(source, /const legacyGodRays =/);
+    assert.match(source, /previousTargetViewport = previousTarget\?\.viewport\?\.clone/);
+    assert.match(source, /if \(previousTarget\) \{[\s\S]{0,500}renderer\.setRenderTarget\?\.\(previousTarget\);[\s\S]{0,120}\} else \{/);
+    assert.match(source, /proxy\.userData\.lightflowNoShadow = true/);
+    assert.match(source, /proxy\.castShadow = false/);
+    const lightManager = read('light_manager.js');
+    assert.match(lightManager, /const suppressElementShadows = element\.type === 'lightflow_volume'/);
+    assert.match(lightManager, /suppressElementShadows \|\| object\.userData\?\.lightflowNoShadow/);
 });
 
 test('Atmosphere 1.0 skips redundant realtime volume work', () => {

--- a/tests/release_candidate.test.js
+++ b/tests/release_candidate.test.js
@@ -25,10 +25,10 @@ test('all independently loadable plugins parse as JavaScript', () => {
 
 test('release candidate versions stay synchronized with the README', () => {
     const expected = {
-        'light_manager.js': '1.6.2',
-        'shader_architect.js': '2.7.0',
+        'light_manager.js': '1.6.3',
+        'shader_architect.js': '2.7.1',
         'lightflow_atmosphere.js': '1.0.0',
-        'lightflow_environment.js': '1.0.0',
+        'lightflow_environment.js': '1.0.1',
         'studio_render.js': '1.5.0'
     };
     const readme = read('README.md');
@@ -135,6 +135,22 @@ test('Minecraft environment drives sky, time, ambient response, sun shadows, and
     assert.match(source, /pixelated_shadows/);
     assert.match(source, /lightflow_environment_settings/);
     assert.match(source, /getVirtualLight/);
+    assert.equal((source.match(/\.join\('\\n'\)/g) || []).length, 2);
+    assert.doesNotMatch(source, /\.join\('\\\\n'\)/);
+});
+
+test('environment sky shaders assemble with real line breaks', () => {
+    const source = read('lightflow_environment.js');
+    const start = source.indexOf('const SKY_VERTEX =');
+    const end = source.indexOf('function createSky()', start);
+    assert.ok(start >= 0 && end > start);
+
+    const buildShaders = new Function(`${source.slice(start, end)}\nreturn { SKY_VERTEX, SKY_FRAGMENT };`);
+    const { SKY_VERTEX, SKY_FRAGMENT } = buildShaders();
+    [SKY_VERTEX, SKY_FRAGMENT].forEach(shader => {
+        assert.match(shader, /\nvoid main\(\)/);
+        assert.doesNotMatch(shader, /\\\\n/);
+    });
 });
 
 test('Vibrant Visuals PBR uses native MER semantics, environment lighting, SSR fallback, and switchable pixel shadows', () => {
@@ -146,12 +162,25 @@ test('Vibrant Visuals PBR uses native MER semantics, environment lighting, SSR f
     assert.match(source, /saSSRSampleEnvironment/);
     assert.match(source, /uPixelatedShadows/);
     assert.match(source, /uniform bool PIXELATED_SHADOWS/);
+    assert.match(source, /\/\* Lightflow lights \*\/[\s\S]*?uniform int uLightCastShadow\[16\];[\s\S]*?uniform int uLightShadowIndex\[16\];/);
 });
 
-test('Light Manager does not duplicate Three r129 punctual-light helpers', () => {
-    const source = read('light_manager.js');
-    assert.match(source, /lightManagerHasNativePunctualHelper/);
-    assert.match(source, /ShaderChunk\.lights_pars_begin\.includes\('punctualLightIntensityToIrradianceFactor'\)/);
+test('Three r129 punctual-light compatibility stays local to custom shaders', () => {
+    const lights = read('light_manager.js');
+    const shaders = read('shader_architect.js');
+    assert.doesNotMatch(lights, /ShaderChunk\.common\s*\+=/);
+    assert.doesNotMatch(lights, /float punctualLightIntensityToIrradianceFactor/);
+    assert.match(shaders, /const LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT/);
+    assert.equal((shaders.match(/\$\{LIGHTFLOW_PUNCTUAL_LIGHT_COMPAT\}/g) || []).length, 5);
+});
+
+test('SSR capture never samples the render target currently being written', () => {
+    const source = read('shader_architect.js');
+    const suspend = source.indexOf('material.uniforms.uSA_SSRScene.value = fallbackTexture');
+    const bind = source.indexOf('renderer.setRenderTarget(state.captureTarget)', suspend);
+    assert.ok(suspend >= 0 && bind > suspend);
+    assert.match(source, /material\.uniforms\.uSA_SSRDepth\.value = fallbackTexture/);
+    assert.match(source, /material\.uniforms\.uSA_SSRHasDepth\.value = 0/);
 });
 
 test('supporting modules include Mesh and TextureMesh render elements', () => {

--- a/tests/release_candidate.test.js
+++ b/tests/release_candidate.test.js
@@ -11,6 +11,7 @@ const pluginFiles = [
     'light_manager.js',
     'shader_architect.js',
     'lightflow_atmosphere.js',
+    'lightflow_environment.js',
     'studio_render.js'
 ];
 
@@ -24,10 +25,11 @@ test('all independently loadable plugins parse as JavaScript', () => {
 
 test('release candidate versions stay synchronized with the README', () => {
     const expected = {
-        'light_manager.js': '1.6.1',
-        'shader_architect.js': '2.6.0',
+        'light_manager.js': '1.6.2',
+        'shader_architect.js': '2.7.0',
         'lightflow_atmosphere.js': '1.0.0',
-        'studio_render.js': '1.4.2'
+        'lightflow_environment.js': '1.0.0',
+        'studio_render.js': '1.5.0'
     };
     const readme = read('README.md');
     Object.entries(expected).forEach(([file, version]) => {
@@ -110,6 +112,46 @@ test('Bloom uses transparent depth-only texels to occlude hidden emitters withou
     assert.match(source, /gl_FragColor = vec4\(max\(emission, vec3\(0\.0\)\), clamp\(energy, 0\.0, 1\.0\)\);/);
     assert.match(source, /depthWrite: true/);
     assert.doesNotMatch(source, /if \(energy <= 0\.0005\) discard;/);
+});
+
+test('Scene Composer reuses the final Bloom and color-grade functions in realtime', () => {
+    const source = read('studio_render.js');
+    assert.match(source, /function renderViewportComposer\(preview\)/);
+    assert.match(source, /renderBloomMaskTile\(preview, maskContext/);
+    assert.match(source, /applyFinalBloom\(state\.baseCanvas, currentSettings, state\.maskCanvas\)/);
+    assert.match(source, /applyFinalColorGrade\(state\.baseCanvas, currentSettings\)/);
+    assert.match(source, /id: 'lightflow_scene_composer_toolbar'/);
+    assert.match(source, /viewport_bloom_fps/);
+    assert.doesNotMatch(source, /now - state\.lastRender < interval\) \{\s*state\.overlay\.style\.display = 'none'/);
+});
+
+test('Minecraft environment drives sky, time, ambient response, sun shadows, and project persistence', () => {
+    const source = read('lightflow_environment.js');
+    assert.match(source, /preset: 'vanilla'/);
+    assert.match(source, /vibrant_visuals:/);
+    assert.match(source, /function getLightingState\(\)/);
+    assert.match(source, /new THREE\.DirectionalLight/);
+    assert.match(source, /shadow\.camera\.left/);
+    assert.match(source, /pixelated_shadows/);
+    assert.match(source, /lightflow_environment_settings/);
+    assert.match(source, /getVirtualLight/);
+});
+
+test('Vibrant Visuals PBR uses native MER semantics, environment lighting, SSR fallback, and switchable pixel shadows', () => {
+    const source = read('shader_architect.js');
+    assert.match(source, /id: 'vibrant_visuals_pbr'/);
+    assert.match(source, /uUseBlockbenchMERMap/);
+    assert.match(source, /uSAEnvironmentAmbient/);
+    assert.match(source, /"uSAEnvironmentEnabled": \{ type: "int", value: 0, expose: false \}/);
+    assert.match(source, /saSSRSampleEnvironment/);
+    assert.match(source, /uPixelatedShadows/);
+    assert.match(source, /uniform bool PIXELATED_SHADOWS/);
+});
+
+test('Light Manager does not duplicate Three r129 punctual-light helpers', () => {
+    const source = read('light_manager.js');
+    assert.match(source, /lightManagerHasNativePunctualHelper/);
+    assert.match(source, /ShaderChunk\.lights_pars_begin\.includes\('punctualLightIntensityToIrradianceFactor'\)/);
 });
 
 test('supporting modules include Mesh and TextureMesh render elements', () => {

--- a/tests/release_candidate.test.js
+++ b/tests/release_candidate.test.js
@@ -28,8 +28,8 @@ test('release candidate versions stay synchronized with the README', () => {
         'light_manager.js': '1.6.3',
         'shader_architect.js': '2.7.1',
         'lightflow_atmosphere.js': '1.0.0',
-        'lightflow_environment.js': '1.0.1',
-        'studio_render.js': '1.5.0'
+        'lightflow_environment.js': '1.1.0',
+        'studio_render.js': '1.5.1'
     };
     const readme = read('README.md');
     Object.entries(expected).forEach(([file, version]) => {
@@ -117,11 +117,20 @@ test('Bloom uses transparent depth-only texels to occlude hidden emitters withou
 test('Scene Composer reuses the final Bloom and color-grade functions in realtime', () => {
     const source = read('studio_render.js');
     assert.match(source, /function renderViewportComposer\(preview\)/);
-    assert.match(source, /renderBloomMaskTile\(preview, maskContext/);
-    assert.match(source, /applyFinalBloom\(state\.baseCanvas, currentSettings, state\.maskCanvas\)/);
+    assert.match(source, /function scheduleViewportComposer\(preview\)/);
+    assert.match(source, /const result = originalRender\.apply\(this, arguments\);\s*scheduleViewportComposer\(this\);/);
+    assert.match(source, /renderViewportBloomMask\(preview, state, maskWidth, maskHeight\)/);
+    assert.match(source, /applyFinalBloom\(state\.baseCanvas, currentSettings, state\.maskCanvas, \{/);
     assert.match(source, /applyFinalColorGrade\(state\.baseCanvas, currentSettings\)/);
     assert.match(source, /id: 'lightflow_scene_composer_toolbar'/);
     assert.match(source, /viewport_bloom_fps/);
+    assert.match(source, /emissiveOnly: true/);
+    assert.match(source, /new THREE\.WebGLRenderTarget\(width, height/);
+    assert.match(source, /renderer\.readRenderTargetPixels\(state\.maskTarget/);
+    assert.match(source, /collectStudioRenderHiddenObjects\(\)\.forEach/);
+    assert.match(source, /if \(!isLightflowRenderMode\(\)\)/);
+    assert.match(source, /condition: \{ modes: \['render'\], project: true \}/);
+    assert.match(source, /attached_to: window\.Panels\?\.lightflow_environment_panel \? 'lightflow_environment_panel' : 'outliner'/);
     assert.doesNotMatch(source, /now - state\.lastRender < interval\) \{\s*state\.overlay\.style\.display = 'none'/);
 });
 
@@ -135,6 +144,15 @@ test('Minecraft environment drives sky, time, ambient response, sun shadows, and
     assert.match(source, /pixelated_shadows/);
     assert.match(source, /lightflow_environment_settings/);
     assert.match(source, /getVirtualLight/);
+    assert.match(source, /palette_mode: 'preset'/);
+    assert.match(source, /cloud_mode: 'vanilla'/);
+    assert.match(source, /sun_texture_uuid/);
+    assert.match(source, /moon_texture_uuid/);
+    assert.match(source, /cloud_texture_uuid/);
+    assert.match(source, /Generated Vanilla-style Texture/);
+    assert.match(source, /condition: \{ modes: \['render'\], project: true \}/);
+    assert.match(source, /attached_to: 'outliner'/);
+    assert.match(source, /updateScene\(\{ forceShadow: false \}\);\s*dispatchChanged\('animation'\)/);
     assert.equal((source.match(/\.join\('\\n'\)/g) || []).length, 2);
     assert.doesNotMatch(source, /\.join\('\\\\n'\)/);
 });
@@ -151,6 +169,10 @@ test('environment sky shaders assemble with real line breaks', () => {
         assert.match(shader, /\nvoid main\(\)/);
         assert.doesNotMatch(shader, /\\\\n/);
     });
+    assert.match(SKY_FRAGMENT, /uniform sampler2D uSunTexture;/);
+    assert.match(SKY_FRAGMENT, /uniform sampler2D uMoonTexture;/);
+    assert.match(SKY_FRAGMENT, /uniform sampler2D uCloudTexture;/);
+    assert.match(SKY_FRAGMENT, /uniform int uCloudMode;/);
 });
 
 test('Vibrant Visuals PBR uses native MER semantics, environment lighting, SSR fallback, and switchable pixel shadows', () => {

--- a/tests/release_candidate.test.js
+++ b/tests/release_candidate.test.js
@@ -25,11 +25,11 @@ test('all independently loadable plugins parse as JavaScript', () => {
 
 test('release candidate versions stay synchronized with the README', () => {
     const expected = {
-        'light_manager.js': '1.6.4',
-        'shader_architect.js': '2.7.1',
-        'lightflow_atmosphere.js': '1.0.1',
-        'lightflow_environment.js': '1.1.0',
-        'studio_render.js': '1.6.0'
+        'light_manager.js': '1.6.5',
+        'shader_architect.js': '2.8.0',
+        'lightflow_atmosphere.js': '1.1.0',
+        'lightflow_environment.js': '1.2.0',
+        'studio_render.js': '1.6.1'
     };
     const readme = read('README.md');
     Object.entries(expected).forEach(([file, version]) => {
@@ -149,6 +149,40 @@ test('Scene Composer keeps realtime Bloom GPU-resident, DPI-safe, and AO-order-s
     );
     assert.match(maskSection, /configureViewportPostTarget\(state\.maskTarget, width, height\);\s*renderer\.setRenderTarget\(state\.maskTarget\)/);
     assert.doesNotMatch(maskSection, /renderer\.setViewport/);
+    assert.match(source, /material\.blending = THREE\.CustomBlending/);
+    assert.match(source, /material\.blendSrcAlpha = THREE\.ZeroFactor/);
+    assert.match(source, /material\.blendDstAlpha = THREE\.OneFactor/);
+});
+
+test('interactive transforms avoid global lighting and material rebuild work', () => {
+    const source = read('shader_architect.js');
+    assert.doesNotMatch(source, /Blockbench\.on\('update_transform',[\s\S]{0,160}requestLightUniformUpdate/);
+    assert.match(source, /const changedElement = event\?\.element \|\| event\?\.object \|\| event\?\.cube/);
+    assert.match(source, /\{ partial: true, cubes: changedElements \}/);
+    assert.match(source, /getLightUniformScratch\(MAX_LIGHTS\)/);
+    assert.match(source, /'uLightShadowIndex', 'uSAEnvironmentEnabled'/);
+    const lightUpdateStart = source.indexOf('updateLightUniforms(cause =');
+    const lightUpdateEnd = source.indexOf('\n        }\n    };', lightUpdateStart);
+    const lightUpdate = source.slice(lightUpdateStart, lightUpdateEnd);
+    assert.doesNotMatch(lightUpdate, /window\.LightManagerPrepareRender\s*\(/);
+    assert.match(source, /const preview =[\s\S]{0,180}Preview\.selected/);
+    const previewRequestStart = source.indexOf('requestPreviewRender(options = {})');
+    const previewRequestEnd = source.indexOf('cancelPendingPreviewRender()', previewRequestStart);
+    assert.doesNotMatch(
+        source.slice(previewRequestStart, previewRequestEnd),
+        /Preview\.all\.forEach\(preview => \{[\s\S]{0,100}preview\.render/
+    );
+});
+
+test('light updates and environment animation are coalesced without redundant scene work', () => {
+    const lights = read('light_manager.js');
+    const environment = read('lightflow_environment.js');
+    assert.match(lights, /activeUuids: new Set\(\)/);
+    assert.match(lights, /worldPosition: new THREE\.Vector3\(\)/);
+    assert.match(lights, /update_light_element_callback\?\.\(\{ shadows: true, scene: false, gizmos: true \}\)/);
+    assert.match(environment, /requestLightUniformUpdate\('environment_update', \{ render: false \}\)/);
+    assert.match(environment, /if \(previewRenderFrame !== null\) return/);
+    assert.match(environment, /const preview = window\.Preview\?\.selected \|\| window\.main_preview/);
 });
 
 test('Minecraft environment drives sky, time, ambient response, sun shadows, and project persistence', () => {
@@ -261,6 +295,13 @@ test('Atmosphere 1.0 skips redundant realtime volume work', () => {
     assert.match(source, /useDepthOnlyCubeMaterials\(\)/);
     assert.match(source, /findFreshSharedDepthSources/);
     assert.match(source, /performance\(\) \{/);
+    assert.match(source, /computeDepthSignature\(state, preview, studio\)/);
+    assert.match(source, /state\.lastDepthSignature === depthSignature/);
+    assert.match(source, /sharedDepth \|\| cachedDepth \|\| this\.captureDepth/);
+    assert.match(source, /invalidateDepthCache\(\)/);
+    assert.match(source, /invalidateVolumeCache\(\)/);
+    assert.match(source, /const selectionListener = Blockbench\.on\('update_selection', \(\) => syncAtmospherePanel\(\)\)/);
+    assert.match(source, /lightElementByUuid: new Map\(\)/);
 });
 
 test('renderer documentation does not misrepresent WebGL as hardware RTX', () => {


### PR DESCRIPTION
## RC6: Project Hydration and Interaction Latency

### Diagnosis

Light Manager was delaying `Plugin.register` and the registration of custom types until it finished generating three icons. If Blockbench opened a scene during this wait, it interpreted unknown lights and volumes as cubes and discarded unregistered properties. Consequently, materials, lights, environment, and volumes were not restored until the project was closed and reopened.

Additionally, several interactions globally traversed all lights, meshes, or previews, unnecessarily rebuilding shadow or shader states and leaving pending asynchronous work behind when switching or closing projects.

### Changes

- Synchronous registration of Light Manager using provisional SVG icons; high-quality icons are generated in the background and replaced without blocking.
- Project-versioned, shared lifecycle to hydrate already open projects and discard obsolete tasks.
- Late-arrival recovery of lights, atmospheric volumes, Environment, and materials/instances directly from the original model.
- Complete cleanup upon closing/switching scenes—including projects with no lights—preventing leaked THREE objects between tabs.
- Partial updates for lights and shadows: changing type, color, intensity, range, transforms, or bias no longer performs a global traversal of the entire scene.
- Manually invalidated shadows and in-place resizing of render targets.
- Stable Environment sun topology to prevent shader recompilations when toggling Environment or Sun.
- Scene Composer limited to the active preview, with renders and UI refreshes batched per frame and canceled upon project switching.
- Equivalent protections implemented for Shader Architect and Atmosphere, preserving AO, SSR, DPI, alpha, and GPU Bloom.

### Versions

- Light Manager 1.7.0
- Environment 1.3.0
- Shader Architect 2.9.0
- Atmosphere 1.2.0
- Studio Render 1.7.0

### Expected Impact

Scenes opened before plugins finish loading are successfully hydrated without requiring a second close/reopen cycle. Global traversals and rebuilds are eliminated for the specified interactions, and background work from a previous scene is prevented from affecting the next one.

### Validation

- `npm run validate`
- Syntax: 5/5
- Regressions: 26/26
- `git diff --check`: clean
- Published tree and blobs verified against the local commit

A manual pass in Blockbench with a real GPU is recommended: open a scene before plugins load, toggle type/shadows/Environment/Scene Composer, and repeatedly switch or close tabs.