### PR TITLE
Rebuild Lightflow documentation for the first artist preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,170 +1,80 @@
 # Changelog
 
-All notable changes to Lightflow for Blockbench will be documented in this file.
+All notable changes to Lightflow for Blockbench are documented here.
 
-Lightflow uses a suite release version for public downloads. Individual plugins also keep their own internal versions because they can evolve at different speeds.
+Lightflow currently uses a **suite development milestone** plus independent module versions. Until the first public release, entries may describe release candidates and matched development builds rather than strict semantic-versioned packages.
 
 ## [Unreleased]
 
-### RC 6 startup, project hydration, and interaction latency
+### Documentation and first stable development preview
 
-- **Light Manager 1.7.0:** registers the plugin and its custom `light` outliner type synchronously. Material-icon generation now runs later during idle time and can no longer delay `.bbmodel` parsing.
-- Added a shared, generation-guarded Lightflow project lifecycle. If the suite becomes available after a scene is already open, it reads the current project model and restores saved lights, Volume Domains, Environment settings, material assignments, face assignments, and material instances without requiring the project to be closed and reopened.
-- Project close and tab switching now cancel stale queued scene, light-uniform, Environment, Atmosphere, and Scene Composer work. A full light-registry pass also removes lights belonging to the previous project, including when the next project contains no lights.
-- Light edits now update only the affected light. Type, color, intensity, range, shadow bias, animation, and viewport-drag paths no longer rescan every Lightflow light, every preview, and every scene mesh on each input step.
-- Viewport shadow maps now use explicit invalidation. Ordinary Cube and Group transforms update the shadow image without rewalking all caster/receiver meshes, and finishing an edit performs a lightweight light cleanup instead of a full scene traversal.
-- **Lightflow Environment 1.3.0:** keeps the directional-light topology stable while Environment or Sun is toggled, updates shadow projection and targets only when their signature changes, and limits animated sun-shadow refreshes while keeping sky and light uniforms fluid.
-- **Shader Architect 2.9.0:** isolates queued material and uniform work by project revision and hydrates saved root, element, and face material state when loaded late.
-- **Lightflow Atmosphere 1.2.0:** restores late-loaded Volume Domains and prevents a queued volume render from crossing a project transition.
-- **Studio Render 1.7.0:** coalesces Scene Composer refreshes, composites only the active viewport, discards stale work after close/switch, and removes the redundant second preview/shadow recovery render after Studio Render.
-- Added regression coverage for synchronous registration, late hydration, project isolation, partial light updates, manual shadow invalidation, stable Environment topology, and active-preview-only Scene Composer refreshes.
+- Repositioned Lightflow as the first stable development version intended for real artist testing while clearly documenting that it is not feature-complete, not a final public release, and not yet available in the Blockbench Plugin Marketplace.
+- Rebuilt the README around the artist workflow, project purpose, current limitations, manual installation, first-render path, honest renderer boundaries, feedback requirements, and Marketplace roadmap.
+- Added dedicated guides for installation, the first render, module responsibilities, practical workflows, performance/troubleshooting, and development status.
+- Documented the matched supplied module versions: Light Manager 1.7.0, Environment 1.5.1, Shader Architect 2.9.1, Atmosphere 1.2.0, and Studio Render 1.9.0.
+- Clarified that the repository currently has no license file and therefore should not present an MIT badge or imply redistribution rights.
 
-### RC 5 interactive performance and transparency
+### Environment 1.5.1
 
-- **Studio Render 1.6.1:** preserves the destination alpha during additive viewport Bloom, so Blockbench's transparent checkerboard remains visible instead of becoming an opaque black background.
-- **Shader Architect 2.8.0:** removes the full light/shadow preparation accidentally triggered by uniform-only updates and no longer treats ordinary Cube transforms as lighting changes.
-- Geometry, face, and UV events now rebuild only the affected render element; light arrays, vectors, shadow-index maps, and active-preview rendering are reused or coalesced instead of recreated for every slider step.
-- **Light Manager 1.6.5:** light transforms explicitly skip scene shadow-mesh traversal and reuse update scratch objects rather than allocating world-space vectors for every light and frame.
-- **Lightflow Atmosphere 1.1.0:** separates depth and volume signatures. Light/color/intensity changes reuse the unchanged scene depth and rerun only the volumetric lighting pass; optical volume edits also retain depth, while actual geometry transforms invalidate it without rebuilding the scene partition.
-- Atmosphere selection updates no longer invalidate volumetric rendering, preview requests are frame-coalesced, and light-element lookup no longer performs a repeated linear search inside the raymarch setup.
-- **Lightflow Environment 1.2.0:** coalesces environment uniform updates and renders only the active preview, avoiding a second full render of every Blockbench preview during time animation and live panel edits.
-- These changes target high-refresh interactive editing, but the achieved frame rate still depends on GPU, viewport size, shadow resolution, volume quality, scene complexity, and Blockbench itself.
+- Expanded the Minecraft-inspired environment implementation with deterministic Vanilla star geometry, textured sun/moon atlas handling, project texture overrides, richer cloud rendering, ambient response, reflections, and directional-shadow controls.
+- Updated Environment metadata and documentation to reflect the current matched development build.
 
-### RC 4 native GPU viewport composition
+### Shader Architect 2.9.1
 
-- **Studio Render 1.6.0:** replaced the realtime CPU readback/Canvas2D overlay with a GPU-resident emissive mask, three-level downsample Bloom pyramid, and direct framebuffer composition.
-- Fixed the 1.25× Bloom scale/offset on Windows display scaling by never passing physical render-target dimensions through Three r129's DPR-multiplying `setViewport()` path.
-- Added Adaptive quality, automatic internal-resolution hysteresis, synchronized uncapped viewport updates, and optional FPS caps from 1–144.
-- Moved Scene Composer scheduling to a coalesced microtask after AO/Atmosphere wrappers but before browser presentation, removing the extra frame of latency.
-- **Lightflow Atmosphere 1.0.1:** preserves target-local viewport/scissor state when Atmosphere is composed into Bloom or other offscreen targets.
-- **Light Manager 1.6.4:** Volume Domain selection proxies are explicitly excluded from shadow casting and receiving.
-- Volume Domain proxy meshes now carry their own no-shadow marker and continuously enforce `castShadow = false`, preventing the invisible editing cube from occluding its contents or projecting a solid box shadow.
+- Updated the material system documentation for the current build, including Lightflow material presets, advanced PBR layers, native Blockbench texture semantics, material instances, per-element/per-face assignment, editable GLSL, AO, SSR, SSS, outlines, rim lighting, and pixelated shadows.
 
-### RC 3 viewport and environment workflow
+### Studio Render 1.9.0
 
-- **Studio Render 1.5.1:** moved Scene Composer into a resizable panel attached inside **Lightflow Render** instead of occupying a generic Blockbench sidebar slot.
-- Replaced the realtime full-resolution visible-canvas Bloom capture with a reduced offscreen WebGL mask, reusable processing canvases, DPI-aware quality profiles, and a 30 FPS safety cap.
-- Realtime Bloom now preserves the Shader Architect AO-composited base frame, excludes Blockbench helpers/gizmos from its mask, and only runs in Lightflow Render mode.
-- **Lightflow Environment 1.1.0:** replaced the toolbar-only panel with an attached, resizable Lightflow Render panel and a complete advanced composer.
-- Added custom day, sunrise, night, lower-sky, sun, moon, and cloud colors plus gradient, stars, cloud appearance, motion, and contrast controls.
-- Added generated Vanilla-style cloud textures and project-texture selection for clouds, sun, and moon without bundling game assets.
-- Stopped the animated day cycle from disposing and recreating the directional shadow map on every update.
+- Updated documentation for the current Scene Composer and Studio Render workflow, including GPU Bloom, color grading, camera presets, adjustable framing, tiled supersampling, transparency, and high-resolution output.
 
-### RC 2 shader hotfixes
+### RC 6 — startup, project hydration, and interaction latency
 
-- **Lightflow Environment 1.0.1:** fixed sky vertex/fragment assembly so array lines are joined with real newline characters instead of emitting literal `\\n` tokens into GLSL.
-- **Shader Architect 2.7.1:** added punctual-light compatibility overloads locally to custom shaders that include `<lights_pars_begin>` without Three's `<bsdfs>` chunk.
-- Added the missing custom shadow-index uniforms to Pixelated Lightflow.
-- Suspended SSR capture samplers while their render target is bound, preventing framebuffer/texture feedback loops.
-- **Light Manager 1.6.3:** removed global mutation of `THREE.ShaderChunk.common`; stock Lambert/Phong shaders now retain Three r129's single native punctual helper.
+- **Light Manager 1.7.0:** registers the plugin and its custom `light` outliner type synchronously. Material-icon generation runs later and no longer delays `.bbmodel` parsing.
+- Added a shared, generation-guarded project lifecycle. When the suite becomes available after a scene is open, it can restore saved lights, Volume Domains, Environment settings, material assignments, face assignments, and Material Instances without requiring a close/reopen cycle.
+- Project close and tab switching cancel stale queued scene, uniform, Environment, Atmosphere, and Scene Composer work.
+- Light edits update only the affected light instead of rescanning all Lightflow lights, previews, and meshes on every input step.
+- Viewport shadow maps use explicit invalidation; ordinary transforms update shadow content without globally rebuilding all caster/receiver state.
+- Environment keeps directional-light topology stable during common toggles and updates shadow projection only when its signature changes.
+- Shader Architect isolates queued material/uniform work by project revision and hydrates saved root, element, and face material state when loaded late.
+- Atmosphere restores late-loaded Volume Domains and prevents queued volume rendering from crossing project transitions.
+- Studio Render coalesces Scene Composer refreshes, composites only the active viewport, discards stale work after close/switch, and removes redundant recovery rendering.
+- Added regression coverage for synchronous registration, late hydration, project isolation, partial light updates, manual shadow invalidation, stable Environment topology, and active-preview-only composition.
 
-### Lightflow Environment 1.0.0
+### RC 5 — interactive performance and transparency
 
-- Added a separately loadable procedural environment module with Minecraft time (`0`–`23999`), controllable day length, realtime playback, sun azimuth, moon phases, stars, and block-shaped clouds.
-- Added independent **Vanilla** and **Vibrant Visuals** presets for sky gradients, sunset/night transitions, celestial bodies, cloud response, and ambient palettes.
-- Added directional sun and moon lighting with artist-controlled shadow area, near/far range, resolution, bias, normal bias, and pixelated-shadow settings.
-- Exposed a stable environment API and project-persisted lighting state for Shader Architect, Studio Render, and future Lightflow modules.
+- Studio Render 1.6.1 preserved destination alpha during additive viewport Bloom.
+- Shader Architect 2.8.0 removed full light/shadow preparation from uniform-only updates and stopped treating ordinary Cube transforms as lighting changes.
+- Geometry, face, and UV events rebuilt only affected render elements while reusing/coalescing light arrays, shadow maps, and active-preview rendering.
+- Light Manager 1.6.5 removed scene shadow-mesh traversal from light transforms and reused hot-path scratch objects.
+- Atmosphere 1.1.0 separated depth and volume signatures so lighting/optical edits could reuse unchanged scene depth.
+- Environment 1.2.0 coalesced uniform updates and rendered only the active preview.
 
-### Shader Architect 2.7.0
+### RC 4 — native GPU viewport composition
 
-- Added environment ambient uniforms so sky, horizon, and ground light can tint compatible Lightflow materials in realtime.
-- Extended depth-aware SSR with a world-space procedural environment fallback—including sky gradient, sun/moon, and clouds—when a reflection ray misses visible screen geometry.
-- Added **Vibrant Visuals PBR**, a complete PBR starting preset with environment response, SSR, and pixel-shadow defaults.
-- Added a switchable pixelated-shadow path with adjustable quantization steps and pixel scale to Pixelated Lightflow and Vibrant Visuals PBR.
-- Added the Environment sun/moon as a synthetic Lightflow light source, including dynamic direction, color, strength, and shadow settings.
+- Studio Render 1.6.0 replaced realtime CPU readback/Canvas2D overlay with a GPU emissive mask, multilevel Bloom pyramid, and direct framebuffer composition.
+- Fixed the 1.25× Bloom scale/offset on Windows display scaling through target-local physical viewport handling.
+- Added Adaptive quality, internal-resolution hysteresis, synchronized uncapped updates, and optional FPS caps.
+- Atmosphere 1.0.1 preserved target-local viewport/scissor state when composed into offscreen targets.
+- Light Manager 1.6.4 excluded Volume Domain proxies from shadow casting and receiving.
 
-### Studio Render 1.5.0
+### RC 3 — viewport and environment workflow
 
-- Added **Scene Composer** with realtime viewport Bloom, Bloom preview FPS, exposure, contrast, saturation, temperature, tint, vignette, and integrated environment controls.
-- Reused the final renderer's emissive/atmosphere Bloom masks, geometry occlusion, threshold, multiscale blur, radius, and strength in the realtime viewport preview.
-- Added one shared color-grade implementation for realtime preview and final tiled output.
-- Added a persistent Scene Composer panel plus quick viewport-Bloom and strength controls.
+- Moved Scene Composer and Environment into attached, resizable Lightflow Render panels.
+- Added reduced-resolution realtime Bloom, DPI-aware quality profiles, helper exclusion, and AO-compatible composition.
+- Expanded Environment with editable sky colors, stars, clouds, texture selection, and stable animated sun shadows.
 
-### Light Manager 1.6.2
+### RC 2 — shader hotfixes
 
-- Fixed the Three.js r129 compatibility path so Light Manager no longer injects a second `punctualLightIntensityToIrradianceFactor` body when Blockbench already provides it.
+- Fixed Environment shader source assembly.
+- Added punctual-light compatibility for custom Three.js shader chunks.
+- Added missing pixelated-shadow uniforms.
+- Prevented SSR framebuffer/texture feedback loops.
+- Removed unsafe global mutation of Three.js shader chunks.
 
-### Release-candidate validation
+### Initial Environment, material, and composer milestones
 
-- Extended syntax/version coverage to all five modules and added regression guards for Scene Composer parity, environment integration, Vibrant Visuals PBR, SSR environment fallback, and pixelated shadows.
-
-### Shader Architect 2.6.0
-
-- Added lossless Cube material-slot collapsing: six equivalent face slots now render as one material batch while genuinely different textures, render modes, transparency states, and face overrides remain independent.
-- Added a content-validated material pool across Cubes, reusing identical compiled GPU materials while keeping per-object transforms correct through draw-time uniforms.
-- Moved world-normal synchronization to the per-draw boundary, eliminating full-scene matrix walks on every animation frame while remaining correct for transforms and shared render passes.
-- Shared time, viewport-lighting, ambient, and Light Manager uniform objects across materials, reducing per-frame and light-update work from per-material array copies to constant-time updates.
-- Added cached AO receiver partitions and cached SSR material/mesh discovery instead of scanning every Cube on every preview render.
-- Added a lightweight alpha-aware AO depth-only material pass so AO receiver depth no longer evaluates complete Lightflow/PBR lighting shaders.
-- Removed redundant shader/material reconstruction on selection-only changes.
-- Added `LightflowPerformance()` diagnostics for live element, material-batch, saved-batch, AO, draw-call, and triangle counters.
-
-- Fixed the Windows/DPI viewport and picking mismatch when AO was enabled without any shadow-casting lights. AO render targets now own physical-pixel viewports and no longer mutate Blockbench's logical viewport.
-- Prevented AO captures from redundantly refreshing shadow maps, making AO behavior and cost independent of whether a light casts shadows.
-- Calibrated Principled PBR direct radiance to Light Manager's artist-facing intensity scale so intensity `1` matches Lightflow much more closely while retaining the energy-conserving BRDF.
-
-- Renamed **Luma Forge** to **Cinematic Craft** and tuned its defaults toward polished Minecraft-trailer-style hero renders.
-- Kept the legacy `luma_forge` ID as a hidden compatibility alias for existing projects and material files.
-- Added quick Material Override presets: Balanced, Trailer Hero, Soft Daylight, Night Drama, and Clean Product.
-- Extended material assignment, persistence, selection tools, context menus, uniform updates, AO, SSR, promotional silhouettes, and geometry refresh events to Cube, Mesh, and Texture Mesh elements.
-- Replaced the fixed 24-vertex UV attribute path with dynamic geometry-sized attributes and arbitrary indexed/non-indexed UV processing.
-- Added zero-thickness Cube resolution for coincident faces, transparent opposite faces, correct two-sided interaction, and z-fighting prevention.
-- Added texture alpha profiling, per-material-slot depth/distance shadow textures, proportional stochastic shadows for semitransparent texels, and cleanup of replaced shadow resources.
-- Preserved native material slots and source texture lookup for Mesh and Texture Mesh objects.
-
-### Light Manager 1.6.1
-
-- Raised automatic normal bias from `0.72` to `4.4` shadow texels to eliminate voxel shadow acne at practical bounds and resolutions.
-- Added migration recognition for values generated by the old automatic formula, preserving deliberate manual overrides while upgrading previous automatic values.
-
-- Added Texture Mesh selection support to light fitting.
-- Made Render-mode panel routing aware of Cube, Mesh, and Texture Mesh selections.
-
-### Lightflow Atmosphere 1.0.0
-
-- Promoted Atmosphere from its experimental series to the first stable release.
-- Fixed the high-DPI viewport displacement by moving physical-pixel viewport and scissor state onto Atmosphere render targets instead of applying device-pixel ratio twice.
-- Added separate Physical Medium and Additive Light Shafts composition. God Rays now contribute only illuminated in-scattering, so fully shadowed regions remain transparent instead of producing black volume.
-- Migrated existing God Rays-style domains to the additive model without changing ordinary fog and cloud projects.
-- Added an artist-facing multiple-scattering fill approximation for fog and cloud shadow softness.
-- Added the Cinematic Dust quick setup and exposed rendering model and shadow fill in the volume UI with English and Spanish translations.
-- Added conservative camera-frustum culling before volume upload and ray marching.
-- Added static-frame signature caching that skips unchanged depth capture, light upload, and ray marching while preserving animated clouds, temporal jitter, camera movement, edits, shadows, and Studio Render tiles.
-- Reused Shader Architect AO scene and receiver depth even when editor helpers are visible, eliminating redundant full-scene captures in the standard Lightflow pipeline.
-- Added cached scene partitions and lightweight alpha-aware depth-only materials for standalone Atmosphere depth capture.
-- Removed per-frame Matrix4, Vector3, Quaternion, light-entry, and active-volume allocations from hot paths.
-- Added `LightflowAtmosphere.performance()` counters for raymarches, cache hits, depth captures, and cache-hit rate.
-- Generalized depth occluder collection, shared-depth validation, and volume fitting from Cubes to Cube, Mesh, and Texture Mesh render elements.
-
-### Studio Render 1.4.2
-
-- Fixed Bloom leaking through foreground geometry when emissive and non-emissive texels share one material or texture atlas. Non-emissive fragments now remain depth-writing occluders in the GPU pass instead of being discarded.
-- Kept those depth-only fragments transparent in the final mask, preventing the screen-space blocker from erasing all visible Bloom in geometry-filled close-up renders.
-- Restored emission-weighted mask alpha for visible emitters while preserving nearest-surface depth rejection.
-
-- Generalized selection-highlight suppression to every supported render-element type.
-
-### Project quality
-
-- Added a dependency-free Node validation harness for plugin syntax, version metadata, renderer coverage, migration compatibility, flat-surface handling, and transparency guards.
-- Added an explicit renderer capability document that distinguishes the supported WebGL raster path from future colored-transmittance and ray-tracing research.
-
-## [0.1.0-alpha] - 2026-07-07
-
-### Added
-
-- **Light Manager 1.3.0** with point, spot, and directional lights; animation support; shadow controls; lighting profiles; viewport gizmos; and separate Studio Render shadow resolution.
-- **Shader Architect 2.0.0** with global, per-element, and per-face shader materials; reusable material instances; editable GLSL; `.samat` import/export; exposed uniforms; stylized lighting; bevels; outlines; rim lighting; ambient occlusion; shadows; and reflections.
-- **Studio Render 1.0.0** with adjustable render framing, transparent or solid backgrounds, tiled high-resolution output, supersampling, GPU diagnostics, and PNG export destinations.
-- A modular Lightflow workflow built around lighting, materials, and studio-quality output inside Blockbench.
-- Initial Open Alpha documentation, issue forms, release tooling, contribution guidance, and release notes.
-
-### Known alpha limitations
-
-- Behavior and visual output can vary across GPUs, graphics drivers, WebGL implementations, and Blockbench versions.
-- Shader Architect material overrides should be saved in `.bbmodel` projects to preserve them reliably.
-- The API hooks used by advanced rendering plugins can require compatibility updates after future Blockbench releases.
-- High-quality shadows and high supersampling output can be demanding on integrated GPUs and complex scenes.
-
-[Unreleased]: https://github.com/MidFord/lightflow-blockbench/compare/v0.1.0-alpha...HEAD
-[0.1.0-alpha]: https://github.com/MidFord/lightflow-blockbench/releases/tag/v0.1.0-alpha
+- Added the procedural Minecraft-time environment, Vanilla and Vibrant Visuals presets, sun/moon lights, stars, clouds, ambient palettes, and project persistence.
+- Added environment ambient uniforms and procedural fallback reflections to Shader Architect.
+- Added Vibrant Visuals PBR and configurable pixelated shadows.
+- Added Scene Composer with realtime Bloom and shared color grading for viewport and final tiled output.
+- Added the first stable Lightflow Atmosphere 1.0 with local fog, additive shafts, procedural clouds, depth occlusion, caching, culling, and quality profiles.

--- a/README.md
+++ b/README.md
@@ -1,605 +1,168 @@
 # Lightflow for Blockbench
 
-> **A production-oriented rendering suite for Blockbench** — animatable lights, advanced shader materials, and studio-quality image exports without leaving the editor.
+> **Light, shape, atmosphere, and final renders — without leaving Blockbench.**
 
-**Status:** Release Candidate / final compatibility testing  
-**Minimum Blockbench version:** `4.9.0`  
-**Recommended environment:** Blockbench Desktop with a WebGL-capable dedicated GPU
+[![Development Preview](https://img.shields.io/badge/status-stable%20development%20preview-f59e0b)](#project-status)
+[![Blockbench 4.9+](https://img.shields.io/badge/Blockbench-4.9%2B-1e88e5)](#requirements)
+[![Plugin Marketplace](https://img.shields.io/badge/Marketplace-not%20published%20yet-6b7280)](#installation)
 
-Lightflow is a modular suite for artists who want more control over how Blockbench scenes look before they are shown, shared, or exported. It is designed around a simple pipeline:
+Lightflow is the rendering toolkit I always wanted inside Blockbench.
 
-1. **Light Manager** creates and animates the lighting.
-2. **Lightflow Environment** creates a controllable Minecraft-inspired sky, sun, moon, and ambient light.
-3. **Shader Architect** gives the scene a material and stylized surface response.
-4. **Lightflow Atmosphere** adds local fog, God Rays, and procedural cloud volumes.
-5. **Studio Render** previews the final post-process stack and captures a polished, high-resolution image.
+I built it for artists who want to take a model from a normal viewport to a deliberate final image: place real lights, shape shadows, build materials, create a Minecraft-inspired sky, add fog and light shafts, compose the shot, and export a high-resolution render — all in the same editor where the model was created.
 
-The plugins work independently where possible, but they are designed to be used together.
+Lightflow is already usable as my **first stable development version**, but it is **not finished, not a final public release, and not yet available in the Blockbench Plugin Marketplace**. Interfaces, presets, compatibility details, and project data may still change while I prepare the first public release.
 
----
+## What Lightflow brings to Blockbench
 
-## Contents
+| Module | What it does |
+| --- | --- |
+| **Light Manager** | Point, spot, and directional lights; viewport gizmos; animation; adaptive shadows; final-render shadow quality. |
+| **Lightflow Environment** | Minecraft-style time, sky, stars, sun, moon, clouds, ambient response, reflections, and environment shadows. |
+| **Shader Architect** | Artist-facing materials, PBR and stylized presets, material instances, per-element/per-face overrides, editable GLSL, AO, SSR, SSS, rim light, outlines, and pixelated shadows. |
+| **Lightflow Atmosphere** | Local fog, height fog, volumetric clouds, cinematic dust, and occluded light shafts. |
+| **Studio Render** | Realtime Scene Composer, Bloom, color grading, camera presets, framing, transparent output, tiled supersampling, and high-resolution still exports. |
 
-- [What Lightflow includes](#what-lightflow-includes)
-- [Requirements](#requirements)
-- [Installation](#installation)
-- [Quick start](#quick-start)
-- [Plugin guide](#plugin-guide)
-- [Shader Architect presets](#shader-architect-presets)
-- [Recommended workflows](#recommended-workflows)
-- [Saving and compatibility](#saving-and-compatibility)
-- [Performance and quality](#performance-and-quality)
-- [Troubleshooting](#troubleshooting)
-- [Project structure](#project-structure)
-- [Contributing and feedback](#contributing-and-feedback)
-- [Roadmap](#roadmap)
-- [License](#license)
+Together, the five modules form one workflow:
 
----
+```text
+MODEL → LIGHT → ENVIRONMENT → MATERIAL → ATMOSPHERE → COMPOSE → RENDER
+```
 
-## What Lightflow includes
+## Why I am building it
 
-| Plugin | Current version | Purpose | Dependency |
-| --- | ---: | --- | --- |
-| **Light Manager** | `1.7.0` | Adds production-oriented point, spot, and directional lights with adaptive shadows, gizmos, animation support, and lighting profiles. | None |
-| **Lightflow Environment** | `1.3.0` | Adds editable Vanilla and Vibrant Visuals skies, custom gradients and project textures, Minecraft time, sun/moon lighting, ambient influence, and controlled shadow coverage. | **Light Manager recommended**; integrates with Shader Architect |
-| **Shader Architect** | `2.9.0` | Builds and assigns advanced materials with PBR controls, environment lighting, SSR fallback reflections, Vibrant Visuals PBR, pixel-shadow controls, editable GLSL, and material instances. | **Light Manager required** |
-| **Lightflow Atmosphere** | `1.2.0` | Adds production-ready local fog, correctly occluded additive light shafts, height fog, and procedural cloud domains with render-element depth occlusion. | **Light Manager recommended**; integrates with Shader Architect and Studio Render |
-| **Studio Render** | `1.7.0` | Adds an attached GPU Scene Composer, AO-safe realtime Bloom, color grading, tiled supersampling, transparency, and 4K/8K-safe exports. | Works alone; integrates with the other Lightflow modules |
+Blockbench is one of the fastest and most approachable tools for creating stylized and Minecraft-oriented assets. But presenting those assets often means leaving the editor, rebuilding the scene elsewhere, or accepting a basic viewport screenshot.
 
-### Why Lightflow exists
+Lightflow is my attempt to close that gap without turning Blockbench into something it is not. The goal is not to imitate an offline ray tracer with fake labels. The goal is a fast, readable, artist-controlled renderer that respects Blockbench projects and makes polished visual presentation accessible to beginners while retaining deep controls for technical artists.
 
-Blockbench is fast and approachable, but a showcase render often needs more control than a screenshot: lighting that can be placed and animated, materials that can react to that light, clean edge treatment, and a reliable high-resolution export path. Lightflow brings those pieces together inside the Blockbench workflow.
+## Project status
 
-Lightflow is **not** a replacement for an offline ray tracer or a game engine. It is a real-time, artist-oriented rendering toolkit built around Blockbench and WebGL. Results depend on your GPU, model complexity, texture setup, material settings, and the current Blockbench version.
+**Current milestone: stable development preview / pre-release.**
 
----
+- The complete five-module workflow is functional and can produce polished still images.
+- This is the first version I consider stable enough for real artist testing.
+- It is still under active development and should not be treated as feature-complete.
+- Lightflow is not yet published in the official Blockbench Plugin Marketplace.
+- Installation is currently manual.
+- Some UI, defaults, presets, persistence formats, and compatibility behavior may change before the first public release.
+- Back up important `.bbmodel` files before testing new builds.
+
+The repository is currently being prepared for a wider public release. Feedback from real projects is especially valuable during this phase.
 
 ## Requirements
 
-- Blockbench **4.9.0 or newer**.
-- A WebGL-capable GPU. A dedicated GPU is strongly recommended for high-resolution Studio Render output.
-- The five plugin files from the same Lightflow release.
-- Save working scenes as **`.bbmodel`** when you need Shader Architect material assignments and material instances to persist.
-
-> **Important:** Shader Architect requires Light Manager. Install and enable Light Manager first.
-
----
+- **Blockbench 4.9.0 or newer**.
+- Blockbench Desktop is strongly recommended.
+- A WebGL-capable GPU; a dedicated GPU is recommended for Atmosphere, realtime Bloom, high-resolution shadows, and 4K/8K exports.
+- All Lightflow modules should come from the same build.
+- Use `.bbmodel` for working files that need Lightflow project data to persist.
 
 ## Installation
 
-### Manual installation from a release
+Lightflow is **not in the Plugin Marketplace yet**. Install it manually:
 
-1. Download the five JavaScript files from the latest Lightflow release:
-   - `light_manager.js`
-   - `lightflow_environment.js`
-   - `shader_architect.js`
-   - `lightflow_atmosphere.js`
-   - `studio_render.js`
-2. Open Blockbench.
-3. Open the Plugin menu and load each local plugin file, or drag the JavaScript files into Blockbench.
-4. Load them in this order:
-   1. **Light Manager**
-   2. **Lightflow Environment**
-   3. **Shader Architect**
-   4. **Lightflow Atmosphere**
-   5. **Studio Render**
-5. Reload Blockbench or reload plugins after an update. During development, Blockbench can reload plugins with `Ctrl/Cmd + J`.
+1. Download or clone this repository.
+2. In Blockbench, open **File → Plugins**.
+3. Choose **Load Plugin from File**.
+4. Load the modules in this order:
+   1. `light_manager.js`
+   2. `lightflow_environment.js`
+   3. `shader_architect.js`
+   4. `lightflow_atmosphere.js`
+   5. `studio_render.js`
+5. Restart Blockbench or reload the plugins after updating them.
 
-### Recommended release layout
+> **Important:** Light Manager is the foundation module. Environment, Shader Architect, and Atmosphere depend on it.
 
-```text
-lightflow-blockbench/
-├─ plugins/
-│  ├─ light_manager/
-│  │  └─ light_manager.js
-│  ├─ lightflow_environment/
-│  │  └─ lightflow_environment.js
-│  ├─ shader_architect/
-│  │  └─ shader_architect.js
-│  ├─ lightflow_atmosphere/
-│  │  └─ lightflow_atmosphere.js
-│  └─ studio_render/
-│     └─ studio_render.js
-├─ docs/
-│  ├─ screenshots/
-│  ├─ workflows/
-│  └─ troubleshooting.md
-├─ examples/
-├─ README.md
-├─ CHANGELOG.md
-└─ LICENSE
+For update instructions, common installation problems, and development builds, see **[Installation Guide](docs/INSTALLATION.md)**.
+
+## Your first Lightflow render
+
+1. Open a model and switch to **Lightflow Render** mode.
+2. Add a directional light with **Light Manager** and aim it at the model.
+3. Open **Environment Composer** and choose a sky preset or time of day.
+4. Open **Material Studio**, choose a Lightflow material, and apply it globally.
+5. Add a **Volume Domain** only when the shot benefits from mist, clouds, dust, or light shafts.
+6. Open **Scene Composer** and adjust Bloom and color grading.
+7. Open **Studio Render**, choose a resolution and samples, then render to preview or save.
+
+The full guided walkthrough is in **[Your First Render](docs/FIRST_RENDER.md)**.
+
+## A renderer designed around artists
+
+Lightflow exposes complex rendering systems through controls that describe the visual result rather than the implementation whenever possible:
+
+- place and aim lights directly in the viewport;
+- use separate preview and final shadow quality;
+- start from materials and lighting profiles instead of writing shaders;
+- override one object or one cube face without rebuilding the entire material;
+- fit lights, shadow bounds, atmospheres, and render framing to selected content;
+- keep expensive effects at interactive preview quality, then raise them for Studio Render;
+- preserve transparent pixels, emissive textures, additive textures, layered textures, Meshes, Texture Meshes, and zero-thickness cubes.
+
+Advanced users can still edit GLSL, import/export `.samat` materials, inspect performance counters, and build reusable material instances.
+
+## Documentation
+
+- **[Installation Guide](docs/INSTALLATION.md)** — install, update, remove, and verify the suite.
+- **[Your First Render](docs/FIRST_RENDER.md)** — a practical beginner tutorial from model to final image.
+- **[Module Guide](docs/MODULES.md)** — where every tool lives and when to use it.
+- **[Workflows](docs/WORKFLOWS.md)** — product renders, cinematic Minecraft scenes, transparent exports, and performance-first iteration.
+- **[Performance & Troubleshooting](docs/TROUBLESHOOTING.md)** — common problems, quality costs, and safe starting settings.
+- **[Development Status](docs/DEVELOPMENT_STATUS.md)** — what is stable today, what is still changing, and what is planned.
+
+## Compatibility and honest boundaries
+
+Lightflow currently runs through Blockbench's Three.js/WebGL rendering environment. It uses optimized raster lighting, shadow maps, screen-space effects, volumetric composition, and supersampled still rendering.
+
+It does **not** currently provide hardware ray tracing, path tracing, or a cosmetic “RTX” switch. Colored transmissive shadows are also not part of the current stable path. I would rather document a real limitation than advertise a feature the host renderer cannot genuinely provide.
+
+Lightflow is not a replacement for Blender, a game engine, or an offline renderer. It is a focused presentation and rendering workflow built specifically for Blockbench artists.
+
+## Development and validation
+
+The repository includes syntax and regression validation for the independently loadable modules:
+
+```bash
+npm install
+npm run validate
 ```
 
-### Future Plugin Store installation
+The validation harness requires Node.js 18 or newer. Automated checks do not replace manual testing inside Blockbench with a real GPU.
 
-Once Lightflow is accepted into the Blockbench Plugin Store, install each module from **File → Plugins**. Until then, use the manual installation workflow above.
+## Feedback and bug reports
 
----
+When reporting a problem, include:
 
-## Quick start
+- your Blockbench version and operating system;
+- GPU model and display scaling;
+- the Lightflow module versions;
+- a minimal `.bbmodel` or reproducible scene when possible;
+- exact steps to reproduce;
+- screenshots or a short recording;
+- browser console errors from **View → Developer Tools**.
 
-This first workflow creates a clean, lit presentation render from a normal Blockbench model.
-
-### 1. Prepare a model
-
-Open or create your model in Blockbench. Verify that your texture assignments, UVs, transparent pixels, and cube hierarchy are already correct.
-
-### 2. Add a light
-
-With **Light Manager** enabled:
-
-1. Add a **Point**, **Spot**, or **Directional** light from the Light Manager actions or toolbar.
-2. Select the light in the outliner.
-3. Use the Light Properties panel to adjust color, intensity, distance, cone angle, penumbra, and shadow settings.
-4. Start with a directional key light for broad shape definition, then add a soft point or spot fill light only where it helps.
-
-### 3. Set the environment (optional)
-
-With **Lightflow Environment** enabled:
-
-1. Open **Environment Composer** and choose **Vanilla** or **Vibrant Visuals**.
-2. Set Minecraft time from `0` to `23999`, or enable realtime animation.
-3. Adjust sun azimuth, shadow coverage, bias, and preview shadow resolution around the subject.
-4. Tune sky ambient strength when materials should pick up the blue sky or warm horizon colors.
-
-### 4. Apply a material
-
-With **Shader Architect** enabled:
-
-1. Open **Material Studio**.
-2. Choose a built-in material such as **Lightflow**, **Cinematic Craft**, **Lightflow Principled PBR**, or **Vibrant Visuals PBR**.
-3. Apply it globally or to selected Cubes, Meshes, and Texture Meshes. Cubes also support per-face overrides.
-4. Use exposed controls to tune lighting, ambient contribution, shadows, bevels, outlines, rim light, AO, or reflections as appropriate. Lightflow's **Shadows** toggle switches cast shadows without changing presets.
-5. Create a **Material Instance** when different parts of the same model need different values without duplicating the shader code.
-
-### 5. Add atmosphere (optional)
-
-With **Lightflow Atmosphere** enabled:
-
-1. Choose **Edit → Add Volume Domain**.
-2. Select the domain in the Outliner and fit it around selected Cubes, Meshes, or Texture Meshes when useful.
-3. Choose **Soft Mist**, **God Rays**, **Cloud Volume**, or **Stage Haze** as a starting point.
-4. For visible shafts, use a directional or spot light with shadows and enable **Receive Volumetric Shadows** on the domain.
-5. Keep viewport quality on **Balanced** while composing; use **High** or **Ultra** only for Studio Render.
-
-### 6. Compose and render the image
-
-With **Studio Render** enabled:
-
-1. Open **Scene Composer** to enable realtime viewport Bloom and tune Bloom, exposure, contrast, saturation, temperature, tint, and vignette.
-2. Open **Studio Render** or use **Quick Studio Render**. The final image reuses the same Bloom parameters and emissive/occlusion semantics shown by Scene Composer.
-3. Choose **4K UHD** for a first high-quality export.
-4. Choose **Transparent** or **Solid Color** background.
-5. Use **Studio SSAA – 4x** for clean promotional output. Use lower samples while iterating.
-6. Select a full composition or the adjustable render frame.
-7. Click **Render** and choose whether to preview, save, copy, or load the image as a texture.
-
----
-
-## Plugin guide
-
-### Light Manager
-
-Light Manager is the foundation of the suite. It introduces real scene lights to the Blockbench outliner and connects those lights to Lightflow materials and Studio Render.
-
-**Main capabilities**
-
-- Point, spot, and directional light types.
-- Light color, intensity, color temperature, range, cone angle, and penumbra controls.
-- Viewport gizmos for positioning, aiming, range, cone, clipping, and shadow bounds.
-- Shadow controls for resolution, bias, normal bias, softness, near/far planes, and directional bounds.
-- Separate **Studio Shadow Resolution** for final renders without forcing the viewport to use the same cost.
-- Render-only 8K and 16K shadow maps for professional output, automatically capped to the GPU's supported texture size.
-- Resolution-, range-, cone-, clipping-, and bounds-aware automatic bias to reduce shadow acne without detaching shadows from surfaces.
-- Lighting profiles and shadow profiles for faster setup.
-- Fit selected lights to selected Cubes, Meshes, Texture Meshes, or groups.
-- Free movement from the current camera view.
-- Animation channels for position, rotation, color, and intensity.
-
-**Good starting setup**
-
-- Use one directional light as the key light.
-- Start with **Balanced** shadows before moving to higher resolutions.
-- Keep shadow bounds tight around the subject. Large directional bounds reduce useful shadow-map detail.
-- Use a low-to-medium preview shadow resolution while you work, then raise only the Studio Shadow Resolution for final output.
-
-### Lightflow Environment
-
-Lightflow Environment is a procedural preview-scene module. It drives a sky dome, Minecraft-style day cycle, square sun and moon, stars, clouds, directional lighting, and the ambient colors consumed by Lightflow materials and SSR.
-
-**Main capabilities**
-
-- Minecraft time from `0` to `23999`, realtime playback, configurable day length, and sun azimuth.
-- **Vanilla** and **Vibrant Visuals** presets with tailored day, sunset, night, cloud, sun, moon, and ambient palettes.
-- Procedural or generated Vanilla-style block clouds, with project-texture overrides for clouds, sun, and moon.
-- Complete custom sky palette controls for day/night zenith, horizon, sunrise, lower sky, sun, moon, and clouds.
-- Adjustable gradient shape, star density, cloud scale, direction, contrast, brightness, opacity, coverage, and speed.
-- Directional sun and moon lights with editable shadow area, near/far range, resolution, bias, normal bias, and pixelated shadow controls.
-- Sky, horizon, and ground ambient colors exposed to Shader Architect for material tinting and SSR miss-ray reflections.
-- Project persistence and a resizable Environment panel attached below the Outliner in **Lightflow Render** mode.
-
-The presets are independent procedural approximations tuned to reproduce the visual behavior of the named Minecraft render modes; they do not copy Minecraft source code or bundled textures.
-
-### Shader Architect
-
-Shader Architect is Lightflow's material and shader workspace. It can drive an entire scene with one material or assign individual material instances to Cubes, Meshes, and Texture Meshes. Cubes additionally support individual face assignments.
-
-**Main capabilities**
-
-- Global scene materials and per-element materials across Cubes, Meshes, and Texture Meshes, plus per-face Cube overrides.
-- Reusable Material Instances with independent exposed values.
-- Editable GLSL vertex and fragment shaders.
-- GLSL formatting plus compile/link validation inside Material Studio.
-- Import and export of custom `.samat` material files.
-- Exposed uniforms for artist-facing controls and advanced technical controls for shader authors.
-- Dynamic Light Manager uniforms for light positions, directions, colors, intensities, attenuation, cones, and shadow behavior.
-- Procedural environment ambient lighting and world-space SSR fallback reflections when a screen-space ray leaves the viewport or misses visible geometry.
-- Built-in surface systems including PBR-style controls, thickness-aware real-time subsurface scattering, stylized lighting, voxel-style AO, shadows, screen-space reflections, bevels, alpha-edge treatment, outlines, and promotional rim lighting.
-- Independently switchable PBR layers for clearcoat, anisotropy, sheen, transmission, and iridescence, plus specular and clearcoat tint controls.
-- UV-derived tangent frames for proper tangent-space normal maps and genuinely directional anisotropic GGX highlights, even when Blockbench geometry has no exported tangent attribute.
-- Native Blockbench `MER Subsurface` support: its alpha channel becomes a per-pixel SSS mask instead of being treated as glass transmission.
-- Native Blockbench texture semantics for `emissive`, `additive`, and `layered` render modes, including MER green-channel emission.
-- **Cinematic Craft**, the successor to Luma Forge, tuned as a Minecraft-trailer-oriented hero material with alpha-aware rim/outline masking, bevel shaping, tone mapping, and dynamic Lightflow shadows.
-- One-click Material Override presets: **Balanced**, **Trailer Hero**, **Soft Daylight**, **Night Drama**, and **Clean Product**.
-- Automatic zero-thickness Cube handling: coincident faces render as separate front-facing surfaces, and a fully transparent side inherits the visible side without z-fighting or incorrect shared lighting.
-- Alpha-profile-aware cutouts, per-material-slot shadow textures, and stochastic semitransparent shadow density in the raster shadow pipeline.
-- A **Vibrant Visuals PBR** preset and a **Pixelated Shadows** toggle with adjustable steps and pixel scale.
-
-**Material-instance workflow**
-
-1. Choose a base material.
-2. Select the render elements—or Cube faces—that should differ from the global material.
-3. Create a Material Instance, then optionally choose a quick Material Override preset.
-4. Change only the exposed values needed for that part: for example rim intensity, bevel width, metallic response, outline strength, or emissive behavior.
-5. Save as `.bbmodel` before closing the project.
-
-### Lightflow Atmosphere
-
-Lightflow Atmosphere adds bounded participating media to the Blockbench scene. Each **Volume Domain** is a normal Outliner element with position, rotation, size, visibility, save/undo support, and a wireframe editing gizmo.
-
-**Main capabilities**
-
-- Box and sphere/ellipsoid domains.
-- Uniform fog, exponential height fog, and animated procedural cloud density.
-- Beer–Lambert transmittance and Henyey–Greenstein anisotropic single scattering.
-- Separate **Physical Medium** and **Additive Light Shafts** rendering models, so a shadowed God Ray remains transparent instead of darkening the scene.
-- Artist-controlled multiple-scattering fill for softer fog and cloud shadows.
-- Direct contribution from up to four Light Manager lights.
-- Geometry-occluded volumetric shadows from up to two directional or spot lights.
-- Depth-aware stopping at Cubes, Meshes, and Texture Meshes, so light shafts and Bloom do not pass through foreground geometry.
-- Helper masking so light icons, locators, grids, selection helpers, and volume gizmos remain clear.
-- Separate viewport and Studio Render step counts and internal resolution.
-- Tile-stable spatial jitter and frozen cloud time during Studio Render to prevent seams.
-- DPI-correct viewport composition, alpha-tested foliage shadows, and camera-facing phase scattering for stable, visible God Rays.
-- SSAA-aware raymarch resolution, reusable AO depth, cached static raymarches, cached Atmosphere Bloom masks, and frustum culling for off-screen domains.
-- Lightweight alpha-aware depth-only captures when Shader Architect AO depth is unavailable.
-- Quick setups for Soft Mist, God Rays, Cloud Volume, Stage Haze, and Cinematic Dust.
-- Per-domain scattering, absorption, ambient fill, edge feather, shadow reception, and Bloom contribution.
-
-Live counters are available from the Blockbench developer console through `LightflowAtmosphere.performance()`; they report raymarches, cache hits, depth captures, and cache-hit rate.
-
-The implementation is physically grounded real-time **single scattering**. It is not path-traced multiple scattering, fluid simulation, or Blender Cycles; procedural clouds are shader density fields rather than simulated weather.
-
-### Studio Render
-
-Studio Render is the export layer. It is intended for portfolio images, social-media posts, thumbnails, transparent cutouts, and clean documentation renders.
-
-**Main capabilities**
-
-- Full-composition or adjustable-frame capture.
-- HD, 4K UHD, 4K DCI, square 4K, 8K, and custom output sizes.
-- Tiled rendering to avoid relying on one enormous render target.
-- Supersampling options from native output through 8× SSAA.
-- Tile-bleed handling to reduce visible seams in high-quality renders.
-- Transparent and solid-color backgrounds.
-- Preview, PNG save, clipboard, and load-as-texture destinations.
-- GPU diagnostics showing the detected renderer and relevant WebGL limits.
-- Temporary Studio Render sessions that coordinate with Light Manager so final shadow settings do not permanently disturb the viewport.
-- Optional final-image Bloom with a simple strength control and advanced threshold/radius controls.
-- Realtime viewport Bloom that uses the same emissive/atmosphere semantics, depth occlusion, threshold, radius, and strength as final output.
-- A fully GPU-resident three-level downsample pyramid: the viewport path has no synchronous `readPixels`, `getImageData`, CPU pixel loop, Canvas2D blur, or DOM overlay.
-- Physical-pixel viewport tracking through `getCurrentViewport()`, with render-target viewport state kept separate from logical CSS/DPR state.
-- Helper/gizmo exclusion plus Adaptive, Performance, Balanced, and High viewport quality profiles.
-- An attached **Scene Composer** panel in Lightflow Render, with the full dialog retained for grading and advanced controls.
-- GPU framebuffer color grading in the viewport and the export-safe Canvas2D grading path for final tiled renders.
-- Emissive-only Bloom masking: emissive render-mode alpha, MER maps, dedicated emissive maps, and additive materials glow without blooming ordinary bright surfaces.
-- Atmosphere-aware Bloom masking, including per-domain Bloom contribution for bright shafts and cloud highlights.
-- Selection highlight suppression during final capture so editing state cannot leak into exported pixels.
-- A two-column, sectioned render dialog that collapses responsively on narrow windows.
-- A compact default form; tile size, GPU diagnostics, resolution scaling, and technical effect controls stay under **Advanced Controls**.
-
----
-
-## Shader Architect presets
-
-The current built-in preset library includes:
-
-| Preset | Best use |
-| --- | --- |
-| **Classic Shader** | Familiar Blockbench-like rendering with simple controls. |
-| **Lightflow Principled PBR** | Layered physically based controls for metal/roughness, SSS, clearcoat, sheen, transmission, iridescence, and reflections. |
-| **Vibrant Visuals PBR** | A Vibrant Visuals-oriented PBR starting point with environment response, SSR, restrained roughness, and pixel-shadow defaults. |
-| **Lightflow** | General-purpose stylized lighting. Use its **Shadows** toggle for shadowed or shadow-free rendering without switching materials. |
-| **Pixelated Lightflow** | A deliberately stepped or pixel-oriented shaded response with independently switchable pixelated shadows. |
-| **Cinematic Craft** | Minecraft-trailer-oriented hero lighting, promotional edge treatment, bevel shaping, alpha-aware silhouettes, and a polished default grade. Existing `luma_forge` assignments migrate automatically. |
-| **Minecraft Promotional Bevel** | A specialized promotional bevel treatment for blocky, illustrated presentation renders. |
-
-Use the preset name as a starting point, not as a guarantee of a specific visual style. A good render comes from the interaction between the preset, texture content, cube scale, lighting, camera angle, and export settings.
-
-### Subsurface scattering workflow
-
-Use **Lightflow Principled PBR** for wax, skin-like stylization, leaves, thin fabric, candles, or translucent organic materials:
-
-1. Enable **Subsurface** and raise **SSS Weight** gradually from `0.15` to `0.5`.
-2. Set **SSS Color** to the color that should appear in backlit areas.
-3. Use **SSS Radius** to control how far light wraps around the form, and **SSS Thickness** to control how much backlight survives the material.
-4. Put a point, spot, or directional light behind or beside the subject to evaluate the transmitted-light lobe.
-5. For per-pixel control, use a Blockbench **MER Subsurface** texture. Lightflow reads its alpha channel automatically while **Native PBR SSS** is enabled.
-6. Open advanced material controls to tune **SSS Direction**, **SSS Focus**, **SSS Ambient**, and **SSS Shadows**.
-
-Lightflow's SSS is a stable real-time approximation designed for Blockbench's WebGL pipeline. It models light wrapping, forward/back scattering, thickness absorption, shadow response, and texture masks, but it is not Blender Cycles' path-traced random-walk SSS.
-
----
-
-## Recommended workflows
-
-### Clean Minecraft-style showcase
-
-1. Use **Cinematic Craft** with the **Trailer Hero** override preset, or start from **Lightflow** for a quieter result.
-2. Add one directional key light and one weak colored fill light.
-3. Enable a restrained bevel or alpha bevel only where it improves the silhouette.
-4. Add a subtle rim light to separate the model from a transparent or pale background.
-5. Render at 4K with 2×–4× SSAA.
-
-### Sharp pixel-art render
-
-1. Start with **Pixelated Lightflow**.
-2. Enable **Pixelated Shadows**, then tune shadow steps and pixel scale for the model scale and camera distance.
-3. Keep bevel, blur-like effects, and high softness values subtle.
-4. Test native samples first; increase SSAA only when it improves the outer contour without softening the intended pixel language.
-5. Use a transparent background for later compositing.
-
-### Vibrant Visuals scene
-
-1. Choose the **Vibrant Visuals** Environment preset and set the Minecraft time.
-2. Apply **Vibrant Visuals PBR** to the subject.
-3. Keep environment ambient and SSR enabled so the sky and horizon influence rough materials and reflections.
-4. Enable pixelated shadows where the stylized shadow edge is desired; disable it for a continuous PCF edge without changing material.
-5. Finish Bloom and grading in Scene Composer, then use the same settings in Studio Render.
-
-### Product-card or thumbnail render
-
-1. Use **Cinematic Craft** or **Lightflow Principled PBR**.
-2. Keep the background transparent or use a single neutral color.
-3. Frame the subject using Studio Render's adjustable capture frame.
-4. Use 4× SSAA for a final export after checking the composition with 1× or 2×.
-
-### Animated lighting preview
-
-1. Create lights in Light Manager.
-2. Open the Animate workspace.
-3. Animate position, rotation, color, and/or intensity.
-4. Use Shader Architect materials that react to Light Manager lights.
-5. Preview the animation before capture; final image capture is currently optimized around still render output.
-
-### God Rays
-
-1. Add a **God Rays** Volume Domain and place the camera inside or in front of it.
-2. Add a directional or spot light and enable its cast shadows.
-3. Place render geometry between the light and the visible part of the volume so its silhouette shapes the shafts.
-4. Raise **Anisotropy** toward `0.6–0.8` for stronger forward scattering when looking toward the light.
-5. Tune density before scattering strength; excessive density quickly hides the model.
-6. Enable Bloom in Studio Render and adjust the domain's **Bloom Contribution** only after the shaft exposure looks correct.
-
----
-
-## Saving and compatibility
-
-### Save format
-
-Save active Lightflow projects as **`.bbmodel`**. Shader Architect material assignments, material instances, Lightflow Environment settings, and Lightflow Atmosphere Volume Domains use custom project/outliner properties that may not survive every export format.
-
-### Compatibility expectations
-
-- Lightflow targets Blockbench `4.9.0+`.
-- Shader Architect, Atmosphere depth occlusion, selection fitting, and Studio Render highlight cleanup support `Cube`, `Mesh`, and `TextureMesh` elements.
-- The old `luma_forge` material ID remains readable and resolves to **Cinematic Craft**, so existing `.bbmodel` and `.samat` content does not need a manual migration.
-- The plugin metadata declares support for both Desktop and Web variants, but **Desktop is recommended** for high-resolution image export and the most predictable file behavior.
-- Browser security restrictions, GPU drivers, texture size limits, and WebGL capabilities can affect the web version.
-- A shader result in the Blockbench viewport is not guaranteed to transfer to a game engine or game exporter. Lightflow materials are designed for Blockbench rendering.
-
----
-
-## Performance and quality
-
-### Fast iteration preset
-
-- Resolution: 1920×1080
-- SSAA: 1× or 2×
-- Tile size: Auto
-- Preview shadow resolution: 512 or 1024
-- Studio shadow resolution: leave equal to preview until the final render
-- Atmosphere viewport quality: Balanced at 50–70% internal resolution
-
-### Final promotional preset
-
-- Resolution: 3840×2160 or 4096×4096
-- SSAA: 4×
-- Tile size: Auto or 2048 px
-- Transparent background when compositing is planned
-- Studio shadow resolution: 2048 or 4096 only when the model and camera need it
-- Atmosphere render quality: High at 100%; Ultra only for difficult close-up shafts or dense clouds. Atmosphere automatically compensates for Studio SSAA so 4×/8× does not multiply the raymarch resolution again.
-
-### Important tradeoffs
-
-- Higher supersampling improves edge quality but raises render time and memory use.
-- Larger shadow maps can improve detail but will not fix poor shadow bounds, unsuitable near/far planes, or a bad camera/light relationship.
-- Many lights, high-resolution shadows, screen-space effects, and 8K output can become expensive quickly.
-- Volumetric cost grows with ray steps, internal resolution, visible domains, active lights, and shadow-map samples. Up to four visible domains are rendered at once; off-screen domains are culled and unchanged frames reuse their previous raymarch by default.
-- Semitransparent textures use stochastic alpha coverage in ordinary WebGL shadow maps. This produces proportional shadow density without requiring ray tracing; colored transmissive shadows are outside the depth-only shadow-map model.
-- Keep the scene simple while tuning. Add expensive effects only after the core composition works.
-
----
-
-## Troubleshooting
-
-### Shader Architect says Light Manager is required
-
-Install and enable **Light Manager** first, then reload Shader Architect. Shader Architect intentionally waits for Light Manager so its materials can receive the expected lighting and shadow data.
-
-### The final render is too slow or fails at high resolution
-
-- Lower SSAA first.
-- Use **Auto** tile size or reduce tile size.
-- Reduce Studio Shadow Resolution.
-- Temporarily disable expensive material controls such as reflections, large rim radii, or complex bevel treatment.
-- Confirm Studio Render detects the dedicated GPU rather than an integrated or software renderer.
-
-### Shadows look jagged, detached, or acne-like
-
-- Start from a shadow profile instead of manually changing every value.
-- Tighten directional shadow bounds around the subject.
-- Check near/far planes.
-- Raise resolution only after bounds are correct.
-- Adjust normal bias carefully; too little may create acne, while too much can make shadows detach from objects.
-
-### Material overrides disappear after reopening a project
-
-Save the project as **`.bbmodel`**. Other formats may not preserve Lightflow's custom material-instance data.
-
-### A flat Cube flickers or lights incorrectly
-
-- Confirm the render element is using a Lightflow material after updating Shader Architect to `2.5.1` or newer.
-- Keep the intended textured face and fully transparent opposite face; Lightflow detects the collapsed axis and resolves the two-sided surface automatically.
-- If both coincident faces contain visible pixels, each remains independent and is lit from its own direction.
-
-### A transparent material casts the wrong shadow
-
-- Cutout alpha is respected by the custom depth and distance shadow materials.
-- Semitransparent alpha casts a proportional dithered shadow. Increase Studio Render samples for a cleaner final integration.
-- WebGL shadow maps store depth, not transmitted RGB color, so colored glass shadows require a future transmittance-buffer backend; see `docs/RENDER_BACKENDS.md`.
-
-### FPS drops in scenes with many Cubes
-
-- Shader Architect `2.6.0+` automatically collapses equivalent Cube face slots and pools identical materials across elements. Different face textures, transparency modes, or Material Overrides remain independent.
-- Reload Shader Architect after updating so existing scene materials are rebuilt through the optimized path.
-- In Blockbench Developer Tools, run `LightflowPerformance()` to inspect `collapsedCubes`, `savedMaterialBatches`, `estimatedSceneDrawsPerFrame`, and the renderer's latest draw-call count.
-- Compare the same camera and effect settings. AO intentionally adds scene passes, but its receiver depth now uses a lightweight cached shader rather than evaluating the complete surface lighting again.
-
-### Gizmos appear where they should not
-
-Studio Render hides gizmos by default. Verify that **Show Gizmos** is disabled in Studio Render settings, then render again.
-
-### Bloom differs between viewport and final render
-
-- Open **Scene Composer** and ensure **Realtime Viewport Bloom** is enabled.
-- Use the same Bloom threshold, strength, and radius that Studio Render will use; both paths share mask and occlusion semantics while using output-appropriate GPU/Canvas compositors.
-- Use **Adaptive** for automatic internal-resolution control. Set **Bloom FPS Limit** to `0` to follow every viewport render, or choose a cap up to 144 FPS.
-- Realtime composition only runs in **Lightflow Render** mode. Gizmos are excluded from the Bloom mask and Shader Architect AO is preserved in the base frame.
-- On Windows display scaling, update to Studio Render `1.6.0+`; older versions could apply renderer DPR twice to offscreen targets and appear enlarged or shifted.
-- Transparent final output can composite differently over an external background; compare against the intended destination background when judging edge glow.
-
-### The environment does not affect a material or reflection
-
-- Confirm Lightflow Environment and Shader Architect `2.7.0+` are both enabled.
-- Use **Lightflow Principled PBR**, **Vibrant Visuals PBR**, or another environment-aware Lightflow preset.
-- Raise environment ambient strength for diffuse tinting and enable SSR for reflections.
-- SSR reflects visible screen geometry first and uses the procedural environment only for miss rays; fully off-screen objects are not reconstructed.
-
-### Volumetric shafts are missing
-
-- Confirm the Volume Domain is enabled and surrounds the visible ray path.
-- Use a directional or spot light; point-light volumetric illumination works, but point-light volumetric shadow maps are not part of this first release.
-- Enable cast shadows on the light and **Receive Volumetric Shadows** on the domain.
-- Increase density gradually and verify anisotropy is not aimed away from the camera.
-- For leaf cards or other cutout textures, keep transparent pixels at alpha 0 so the light shadow map can filter the shafts through the silhouette.
-
-### Fog is noisy, banded, or too slow
-
-- Increase viewport steps before increasing viewport resolution.
-- Use **High** at 100% for normal final renders and reserve **Ultra** for difficult scenes.
-- Disable temporal jitter for a stable viewport pattern; Studio Render freezes time across all tiles automatically.
-- Reduce the number of overlapping domains and active shadowed lights.
-
-### A plugin error appears
-
-Open Blockbench Developer Tools and include the Console error, Blockbench version, operating system, GPU/renderer information, plugin versions, a minimal `.bbmodel`, and a screenshot when reporting the issue.
-
----
-
-## Project structure
-
-A release-candidate checkout keeps each independently loadable plugin at the repository root, with validation and renderer notes beside it:
-
-```text
-lightflow-blockbench/
-├─ light_manager.js
-├─ lightflow_environment.js
-├─ shader_architect.js
-├─ lightflow_atmosphere.js
-├─ studio_render.js
-├─ docs/
-│  └─ RENDER_BACKENDS.md
-├─ tests/
-│  └─ release_candidate.test.js
-├─ package.json
-├─ README.md
-└─ CHANGELOG.md
-```
-
-Keep plugin IDs, JavaScript file names, and release package names consistent:
-
-- `light_manager`
-- `lightflow_environment`
-- `shader_architect`
-- `lightflow_atmosphere`
-- `studio_render`
-
----
-
-## Contributing and feedback
-
-Lightflow is being developed in the open to learn what Blockbench artists actually need.
-
-Useful feedback includes:
-
-- A minimal project that reproduces the issue.
-- Expected result versus actual result.
-- Blockbench version and Lightflow module versions.
-- Operating system and GPU renderer shown by Studio Render.
-- Console error text or a screenshot of it.
-- Screenshots at both viewport size and final Studio Render size for visual bugs.
-
-For feature requests, explain the artistic result you are trying to achieve rather than only the setting you want added. A clear before/after image is especially useful.
-
----
+Please separate reproducible bugs from visual suggestions. Both are useful, but they require different investigation.
 
 ## Roadmap
 
-This roadmap is directional, not a release promise.
+Before the first public Marketplace release, my priorities are:
 
-- More artist-friendly preset packs and reusable lighting rigs.
-- Better first-run guidance and sample `.bbmodel` scenes.
-- More robust quality presets for low-, mid-, and high-end GPUs.
-- Refinement of AO, screen-space reflection history, bevel behavior, and rim consistency between viewport and final render.
-- Optional temporal stabilization for Scene Composer on capable hardware.
-- A transmittance-buffer experiment for colored raster shadows, gated by GPU capabilities.
-- Evaluation of a future native/WebGPU renderer only when Blockbench and the browser graphics stack expose a stable ray-tracing path; the current WebGL backend does not advertise hardware RTX.
-- Higher-order multiple scattering, point-light volumetric shadows, artist-authored 3D density textures, and improved temporal accumulation for Atmosphere.
-- Expanded documentation, visual examples, and troubleshooting coverage.
-- Packaging and validation for a Blockbench Plugin Store submission.
+- final UI and UX consistency across all modules;
+- broader real-project compatibility testing;
+- safer migrations between development builds;
+- clearer presets and beginner onboarding;
+- more examples and visual documentation;
+- additional performance work for large scenes and integrated viewport effects;
+- packaging, metadata, and review preparation for the Blockbench Plugin Marketplace.
+
+Longer-term experiments may include deeper animation workflows, expanded atmosphere tools, optional alternate rendering backends, and new material systems — only when they can be implemented honestly and reliably.
+
+## License and trademarks
+
+The project does not currently include a repository license file. Until a license is added, normal copyright restrictions apply; public source visibility alone does not grant permission to redistribute or reuse the code.
+
+Blockbench is a separate project and trademark. Minecraft is a trademark of Microsoft. Lightflow is an independent project and is not affiliated with, endorsed by, or sponsored by Blockbench, Mojang Studios, or Microsoft.
 
 ---
 
-## License
-
-A public release should include a clear license before accepting external contributions or redistribution. The recommended default for a broadly reusable Blockbench plugin suite is the **MIT License**. Add the final license text as `LICENSE` at the repository root and, if needed, inside each Plugin Store package.
-
----
-
-## Credits and trademarks
-
-Lightflow is an independent community project and is not affiliated with Blockbench, Mojang Studios, or Microsoft. Blockbench, Minecraft, and related marks belong to their respective owners.
-
-Built for Blockbench artists by **MidFord327**.
+<p align="center"><strong>Built by MidFord for artists who want their Blockbench work to feel finished.</strong></p>

--- a/docs/DEVELOPMENT_STATUS.md
+++ b/docs/DEVELOPMENT_STATUS.md
@@ -1,0 +1,51 @@
+# Development Status
+
+## What “stable development preview” means
+
+This is the first Lightflow build intended for sustained artist testing rather than isolated technical experiments.
+
+“Stable” currently means:
+
+- the five-module pipeline can be loaded and used together;
+- projects can persist the major Lightflow systems in `.bbmodel`;
+- current builds include lifecycle recovery for plugins that finish loading after a project is already open;
+- common interactions avoid many of the global rebuilds and stale cross-project tasks found in earlier release candidates;
+- automated syntax and regression validation exists for core behavior.
+
+It does **not** mean:
+
+- final API or project-format stability;
+- complete compatibility with every Blockbench format and plugin combination;
+- finished UI and onboarding;
+- Marketplace availability;
+- zero rendering bugs;
+- guaranteed performance on every GPU;
+- a final semantic-versioned public release.
+
+## Current module versions in the supplied development build
+
+| Module | Version |
+| --- | ---: |
+| Light Manager | 1.7.0 |
+| Lightflow Environment | 1.5.1 |
+| Shader Architect | 2.9.1 |
+| Lightflow Atmosphere | 1.2.0 |
+| Studio Render | 1.9.0 |
+
+These versions should be treated as one matched development build.
+
+## Current priorities
+
+- finish the shared Lightflow Render workspace and panel behavior;
+- reduce interaction latency and avoid unnecessary shader/shadow rebuilds;
+- improve large-scene behavior;
+- validate project switching, closing, late plugin loading, and migration;
+- make installation and first use understandable without prior project knowledge;
+- publish visual examples and reproducible starter scenes;
+- prepare package metadata and review requirements for the Blockbench Plugin Marketplace.
+
+## Renderer boundary
+
+The supported renderer is Blockbench's current Three.js/WebGL path. Lightflow provides raster lights and shadows, screen-space effects, procedural environment response, volumetric composition, and tiled supersampled still rendering.
+
+Hardware ray tracing/path tracing is not exposed through the current host plugin surface and is not advertised as implemented. Colored transmissive shadows remain future renderer work.

--- a/docs/FIRST_RENDER.md
+++ b/docs/FIRST_RENDER.md
@@ -1,0 +1,120 @@
+# Your First Lightflow Render
+
+This tutorial creates a clean showcase image without requiring custom shaders or advanced volumetrics.
+
+## 1. Prepare the model
+
+Open a model with correct textures, UVs, transparency, hierarchy, and pose. Save a copy as `.bbmodel` before adding Lightflow-specific data.
+
+Switch to **Lightflow Render** mode.
+
+## 2. Create the key light
+
+Use Light Manager to add a **Directional Light**.
+
+Start with:
+
+- one neutral or slightly warm key light;
+- medium intensity;
+- Balanced preview shadows;
+- tight directional shadow bounds around the model;
+- a separate higher Studio Shadow Resolution for the final render.
+
+Aim the light from above and to one side so the model has a readable light side and shadow side.
+
+## 3. Add a simple fill
+
+Add a low-intensity Point or Spot light from the opposite side only when the shadows are too dark. The fill should recover information, not remove the lighting direction.
+
+Two useful rules:
+
+- keep the fill dimmer than the key;
+- avoid giving every side the same brightness.
+
+## 4. Choose an environment
+
+Open Environment Composer.
+
+- Use **Vanilla** for a familiar Minecraft-inspired presentation.
+- Use **Vibrant Visuals** for stronger sky color and a more modern response.
+- Change Minecraft time to move quickly between daylight, sunset, and night.
+- Adjust ambient strength only after the key light already reads clearly.
+
+The environment can provide sky color, horizon color, ground response, reflections, sun/moon light, stars, clouds, and directional shadows.
+
+## 5. Apply a material
+
+Open Material Studio and apply a built-in material globally.
+
+Good starting choices:
+
+- **Lightflow** for a flexible stylized result;
+- **Cinematic Craft** for a stronger hero/trailer presentation;
+- **Lightflow Principled PBR** for more physically inspired controls;
+- **Vibrant Visuals PBR** for environment-aware Minecraft PBR presentation.
+
+Use a Material Instance only when a specific part needs different values. Use per-face overrides sparingly; global consistency is easier to art-direct.
+
+## 6. Refine the shape
+
+Adjust only the controls that solve a visible problem:
+
+- roughness/specular for highlight size;
+- bevel or normal shaping for edge readability;
+- ambient occlusion for contact depth;
+- rim light for silhouette separation;
+- outline for graphic definition;
+- subsurface scattering for skin, wax, leaves, or other thin materials;
+- pixelated shadows when the visual language should remain voxel-like.
+
+Do not enable every effect by default.
+
+## 7. Add atmosphere only when it helps
+
+Create a Volume Domain and fit it around the relevant part of the scene.
+
+- **Soft Mist** adds depth separation.
+- **God Rays** creates additive shafts from a shadowed Spot or Directional light.
+- **Cloud Volume** creates local procedural cloud forms.
+- **Stage Haze** adds a restrained studio atmosphere.
+- **Cinematic Dust** creates textured shafts and floating density variation.
+
+Keep preview quality at Balanced while editing. Raise render quality only for the final image.
+
+## 8. Compose the image
+
+Open Scene Composer.
+
+1. Frame the model with a clear silhouette.
+2. Enable Bloom only when emissive or bright areas should glow.
+3. Adjust exposure before contrast.
+4. Use saturation, temperature, and tint in small amounts.
+5. Add vignette only when it directs attention rather than hiding the frame.
+6. Save a camera preset when the composition matters.
+
+## 9. Export with Studio Render
+
+For a first polished still:
+
+- Resolution: 3840 × 2160 or a suitable square preset.
+- Samples: 4x while learning; increase only when the improvement is visible.
+- Background: Transparent for compositing, or Solid Color for a finished plate.
+- Frame: use the adjustable render frame when the viewport composition and output ratio differ.
+- Destination: Preview first, then Save.
+
+Studio Render uses tiled output for high resolutions and can reuse the same Bloom and grading language shown in Scene Composer.
+
+## A reliable order of decisions
+
+When a render is not working, fix it in this order:
+
+1. camera and silhouette;
+2. key light direction;
+3. shadow shape;
+4. environment and fill;
+5. material response;
+6. atmosphere;
+7. Bloom and color grading;
+8. final sample count and resolution.
+
+More effects cannot rescue a weak camera or unreadable light direction.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,79 @@
+# Installing Lightflow
+
+Lightflow is currently a **manual development preview**. It has not yet been published in the official Blockbench Plugin Marketplace.
+
+## Before you install
+
+- Use Blockbench 4.9.0 or newer.
+- Prefer Blockbench Desktop.
+- Download every Lightflow module from the same commit or release package.
+- Back up important `.bbmodel` projects before moving between development builds.
+
+## Install from the repository
+
+1. Download the repository as a ZIP or clone it with Git.
+2. Extract it to a permanent folder. Do not load plugins directly from a temporary ZIP preview.
+3. Open Blockbench.
+4. Open **File → Plugins**.
+5. Use **Load Plugin from File** for each JavaScript file.
+6. Load them in this order:
+
+```text
+1. light_manager.js
+2. lightflow_environment.js
+3. shader_architect.js
+4. lightflow_atmosphere.js
+5. studio_render.js
+```
+
+Light Manager must load first because it provides the shared lighting foundation and lifecycle used by other modules.
+
+## Verify the installation
+
+Open or create a project, then confirm that:
+
+- **Lightflow Render** is available as a view mode;
+- Light Manager actions can add a Point, Spot, or Directional light;
+- the Environment, Material, Atmosphere, and Scene Composer panels appear in Lightflow Render mode;
+- Studio Render is available from the relevant menu/actions;
+- the developer console contains no red plugin-load errors.
+
+## Updating
+
+1. Save and close important projects.
+2. Replace all five plugin files with files from the same newer build.
+3. Reload the plugins or restart Blockbench.
+4. Reopen a copy of a project first and verify lights, materials, environment settings, atmosphere domains, and camera presets.
+
+Do not update only one dependency-sensitive module unless the changelog explicitly says the versions are compatible.
+
+## Removing Lightflow
+
+Disable or uninstall each local plugin from Blockbench's Plugin dialog. Removing the plugin does not automatically remove Lightflow data already stored inside a `.bbmodel` file.
+
+Keep an untouched project backup when testing removal or migration behavior.
+
+## Development validation
+
+For contributors or local builds:
+
+```bash
+npm install
+npm run validate
+```
+
+This runs JavaScript syntax checks and the repository regression tests. Node.js 18 or newer is required.
+
+## Common installation problems
+
+### Shader Architect or Atmosphere says Light Manager is required
+
+Light Manager did not load first, failed to initialize, or came from an incompatible build. Reload Light Manager, inspect the console, then reload the dependent module.
+
+### Saved lights or materials do not appear
+
+Use `.bbmodel`, verify that every module loaded successfully, and avoid mixing files from different commits. Recent builds include late project hydration, but a failed dependency can still prevent a module from restoring its own data.
+
+### The plugin loads but the panels are missing
+
+Switch to **Lightflow Render** mode and select an applicable object when the panel depends on selection. Then check the developer console for initialization errors.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,0 +1,103 @@
+# Lightflow Module Guide
+
+Lightflow is distributed as five independently loadable Blockbench plugins. They are designed to behave as one suite, but each module owns a clear part of the rendering pipeline.
+
+## Light Manager
+
+The foundation module for real scene lights.
+
+Use it for:
+
+- Point, Spot, and Directional lights;
+- viewport handles for position, direction, range, cone, and bounds;
+- color, temperature, intensity, attenuation, and penumbra;
+- adaptive raster shadows with preview/final quality separation;
+- light and shadow profiles;
+- fitting lights or directional bounds to selected content;
+- animation channels for position, rotation, color, and intensity.
+
+Install this module first.
+
+## Lightflow Environment
+
+A Minecraft-inspired procedural world and ambient-light system.
+
+Use it for:
+
+- Minecraft time from 0 to 23999;
+- realtime day-cycle playback;
+- Vanilla and Vibrant Visuals presets;
+- custom sky gradients and palettes;
+- deterministic stars;
+- square sun and moon textures with moon phases;
+- voxel-style clouds and cloud motion;
+- project texture overrides;
+- sky, horizon, and ground ambient colors;
+- environment reflections and sun/moon shadows.
+
+The environment is not only a background. Compatible materials consume its ambient and reflection response.
+
+## Shader Architect
+
+The material workspace and programmable surface system.
+
+Use it for:
+
+- global materials;
+- per-element materials for Cubes, Meshes, and Texture Meshes;
+- per-face Cube overrides;
+- Material Instances and reusable override presets;
+- Lightflow, Cinematic Craft, Principled PBR, Vibrant Visuals PBR, and pixelated workflows;
+- AO, SSR, SSS, bevels, rim light, outlines, transmission, clearcoat, sheen, anisotropy, and iridescence;
+- editable GLSL with formatting and validation;
+- `.samat` import/export;
+- native Blockbench emissive, additive, layered, and MER texture semantics.
+
+Shader Architect requires Light Manager.
+
+## Lightflow Atmosphere
+
+A local volumetric system based on editable Volume Domains.
+
+Use it for:
+
+- uniform fog;
+- height fog;
+- local mist;
+- additive God Rays;
+- procedural clouds;
+- cinematic dust;
+- physically composited or shaft-style volumes;
+- depth occlusion and volumetric shadow reception;
+- separate preview and render quality.
+
+Atmosphere is one of the most expensive modules. Use the smallest domain and lowest preview quality that still communicates the intended result.
+
+## Studio Render
+
+The final composition and still-output module.
+
+Use it for:
+
+- Scene Composer inside Lightflow Render mode;
+- realtime GPU Bloom;
+- exposure, contrast, saturation, temperature, tint, and vignette;
+- saved camera presets;
+- adjustable render frame;
+- transparent or solid backgrounds;
+- tiled high-resolution output;
+- supersampling;
+- preview, save, clipboard, or texture destinations;
+- 4K, DCI 4K, square 4K, 8K, and custom resolutions.
+
+Studio Render can operate independently, but it becomes most useful when it receives lighting, material, environment, and atmosphere data from the rest of the suite.
+
+## Recommended module combinations
+
+| Goal | Modules |
+| --- | --- |
+| Better viewport lighting | Light Manager |
+| Stylized material preview | Light Manager + Shader Architect |
+| Minecraft environment scene | Light Manager + Environment + Shader Architect |
+| Cinematic volumetric image | Light Manager + Environment + Shader Architect + Atmosphere + Studio Render |
+| Clean transparent product render | Light Manager + Shader Architect + Studio Render |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,85 @@
+# Performance and Troubleshooting
+
+## Start with these safe settings
+
+- Preview shadows: Balanced.
+- Studio shadows: High only for the lights that need it.
+- Atmosphere preview: Balanced or Draft.
+- Atmosphere render: High.
+- Viewport Bloom: Adaptive.
+- Studio Render: 4K, 4x samples.
+
+## The viewport stutters
+
+Check the most expensive systems first:
+
+1. realtime Atmosphere;
+2. high-resolution shadow maps;
+3. multiple shadow-casting lights;
+4. high-quality realtime Bloom;
+5. AO and SSR on large or highly segmented scenes;
+6. very large viewport dimensions or display scaling.
+
+Reduce preview quality rather than final-render quality. Keep directional shadow bounds and atmosphere domains close to the subject.
+
+## Shadows look detached or acne-covered
+
+- Tighten light range, near/far clipping, cone, or directional bounds.
+- Return bias and normal bias to an automatic or known preset value.
+- Do not use an unnecessarily large shadow area.
+- Raise shadow resolution only after correcting the projection area.
+
+## Bloom appears through foreground objects
+
+Use matching module versions and confirm Bloom occlusion is enabled. Foreground geometry must remain in the emissive mask depth path even when it does not glow.
+
+## Bloom or Atmosphere is offset at Windows scaling above 100%
+
+Use a recent matched build. Lightflow contains DPI-safe render-target viewport handling, but older mixed module versions can reintroduce scale or alignment errors.
+
+## Transparent output becomes black
+
+- Set Studio Render background to Transparent.
+- Verify the destination supports alpha.
+- Use current Studio Render Bloom composition.
+- Inspect whether an atmosphere or material intentionally writes opacity.
+
+## Lights or materials disappear after opening a project
+
+- Confirm Light Manager loaded first.
+- Confirm all modules come from the same build.
+- Use `.bbmodel`.
+- Check the developer console for parsing or hydration errors.
+- Test with a backup copy after updating.
+
+## A Volume Domain casts a box shadow
+
+That is not intended. Use a current Atmosphere and Light Manager pair; the editing proxy should be excluded from scene shadow casting and receiving.
+
+## A shader does not compile
+
+Open Material Studio validation and inspect the complete GLSL error. Custom shaders that use Three.js chunks must remain compatible with the Three.js revision bundled by the target Blockbench version.
+
+## Studio Render fails at a very large resolution
+
+GPU texture size, renderbuffer size, memory, total pixel count, and browser/desktop process limits still apply. Try:
+
+- 4K before 8K;
+- lower samples;
+- a smaller tile size;
+- fewer high-resolution shadow maps;
+- lower Atmosphere render quality;
+- closing other GPU-heavy applications.
+
+## Information to include in a bug report
+
+- Blockbench version;
+- operating system;
+- GPU;
+- display scaling;
+- Lightflow module versions;
+- model type and approximate scene size;
+- active effects;
+- exact reproduction steps;
+- console error;
+- minimal project or recording.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,57 @@
+# Lightflow Workflows
+
+## Clean transparent product render
+
+Use this for a model sheet, store image, portfolio thumbnail, or compositing asset.
+
+1. Disable or simplify the environment background.
+2. Use a directional key and soft point/spot fill.
+3. Apply a restrained material with readable bevels and AO.
+4. Avoid Atmosphere unless the image specifically needs it.
+5. Use a transparent Studio Render background.
+6. Keep Bloom off or very subtle.
+7. Export 4K with 4x samples before attempting larger output.
+
+## Minecraft-style outdoor scene
+
+1. Enable Lightflow Environment.
+2. Choose Vanilla or Vibrant Visuals.
+3. Set time first; it controls the broad color story.
+4. Fit environment shadow coverage around the subject.
+5. Use environment ambient response in the material.
+6. Add a local light only when the sun/moon cannot provide the needed focal emphasis.
+7. Use pixelated shadows when the final style should retain block-scale visual rhythm.
+
+## Cinematic hero render
+
+1. Start with a low or dramatic camera angle.
+2. Build a clear key/fill/rim hierarchy.
+3. Try Cinematic Craft or a controlled PBR material.
+4. Use material instances for focal details, not every object.
+5. Add a restrained atmosphere domain behind or around the subject.
+6. Use emissive details to support Bloom.
+7. Grade the image in Scene Composer, then export with the same settings in Studio Render.
+
+## God Rays
+
+1. Add a Spot or Directional light.
+2. Enable shadows and place an occluder between the light and volume.
+3. Add a Volume Domain and choose God Rays or Cinematic Dust.
+4. Enable volumetric shadow reception.
+5. Align the domain with the visible beam area instead of filling the entire scene.
+6. Tune density before scattering strength.
+7. Keep the shadowed parts transparent; black boxes usually indicate incorrect placement, excessive absorption, or an incompatible build.
+
+## Performance-first iteration
+
+While composing:
+
+- use Balanced or lower shadow resolution;
+- keep Atmosphere preview quality at Balanced or Draft;
+- use Adaptive or Performance Bloom quality;
+- edit one active viewport;
+- keep directional bounds and volume domains tight;
+- disable effects that are not contributing to the current decision;
+- render small previews before 4K/8K output.
+
+For the final image, raise one quality setting at a time and compare the visible improvement.


### PR DESCRIPTION
## What changed

- Rewrote the README around Lightflow's artistic value, creator voice, complete five-module workflow, manual installation, first-render path, honest renderer boundaries, and pre-Marketplace status.
- Reframed the current milestone as the first stable development preview for real artist testing without presenting it as feature-complete or publicly released.
- Rebuilt the changelog around the supplied matched development build and preserved the important RC performance, hydration, DPI, Bloom, Environment, material, and Atmosphere milestones.
- Restored `docs/` with dedicated guides for installation, a first render, module responsibilities, practical workflows, performance/troubleshooting, and development status.
- Corrected version references to the supplied files:
  - Light Manager 1.7.0
  - Lightflow Environment 1.5.1
  - Shader Architect 2.9.1
  - Lightflow Atmosphere 1.2.0
  - Studio Render 1.9.0
- Removed the misleading MIT/repository-license presentation because the repository currently has no license file.

## Why

The previous README was technically extensive but read like internal release-candidate documentation. This revision gives artists a clear first impression, a fast path to installation and their first render, and separate technical guides for deeper details.

## Validation

- Compared branch against `main`: 8 documentation files changed, branch is 8 commits ahead and 0 behind.
- Verified all README documentation links target files added by this branch.
- No JavaScript source was changed.

## Visual documentation note

The supplied screenshot archive was reviewed to understand the current UI and available scenes. Binary screenshot assets are not included in this connector-created branch yet; the written documentation is structured so curated hero images and step crops can be added without another rewrite.